### PR TITLE
Correct peer-review links

### DIFF
--- a/stash/stash_api/app/models/stash_api/dataset.rb
+++ b/stash/stash_api/app/models/stash_api/dataset.rb
@@ -97,7 +97,7 @@ module StashApi
       res = @se_identifier.latest_resource
       curation_activity = StashEngine::CurationActivity.latest(res&.id)
       hsh[:curationStatus] = curation_activity&.readable_status
-      hsh[:sharingLink] = res&.share&.sharing_link if curation_activity&.peer_review?
+      hsh[:sharingLink] = res&.identifier&.shares&.first&.sharing_link if curation_activity&.peer_review?
     end
 
   end

--- a/stash/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser.rb
@@ -109,7 +109,8 @@ module StashApi
     def ensure_publisher
       return unless @resource.publisher.blank?
       publisher = StashDatacite::Publisher.where(resource_id: @resource.id).first
-      StashDatacite::Publisher.create(publisher: @resource.tenant.short_name, resource_id: @resource.id) unless publisher
+      return if publisher
+      StashDatacite::Publisher.create(publisher: @resource.tenant.short_name, resource_id: @resource.id) if @resource.tenant
     end
 
     def ensure_resource_type

--- a/stash/stash_api/spec/unit/models/stash_api/dataset_spec.rb
+++ b/stash/stash_api/spec/unit/models/stash_api/dataset_spec.rb
@@ -1,10 +1,6 @@
 require 'db_spec_helper'
 require_relative '../../../../../spec_helpers/factory_helper'
 require 'byebug'
-# require 'test_helper'
-
-# something wacky about our setup requires this here.  It seems to be either a) never requiring them or b) requiring them 1000 times otherwise
-# FactoryBot.find_definitions
 
 module StashApi
   RSpec.describe Dataset do
@@ -108,6 +104,22 @@ module StashApi
         @dataset = Dataset.new(identifier: @identifier.to_s, user: @user)
         @metadata = @dataset.metadata
         expect(@metadata[:loosenValidation]).to eq(true)
+      end
+
+      it 'has a curation status' do
+        @dataset = Dataset.new(identifier: @identifier.to_s, user: @user)
+        @metadata = @dataset.metadata
+        expect(@metadata[:curationStatus]).to eq('In Progress')
+      end
+
+      it 'has a sharing link when it is in peer_review status' do
+        bogus_link = 'http://some.sharing.com/linkvalue'
+        allow_any_instance_of(StashEngine::Share).to receive(:sharing_link).and_return(bogus_link)
+        r = @identifier.resources.last
+        StashEngine::CurationActivity.create(resource: r, status: 'peer_review')
+        @dataset = Dataset.new(identifier: @identifier.to_s, user: @user)
+        @metadata = @dataset.metadata
+        expect(@metadata[:sharingLink]).to be(bogus_link)
       end
 
     end


### PR DESCRIPTION
Fixes peer-review links that use the old format (e.g., https://datadryad.org/review?doi=doi:10.5061/dryad.abc123). These links were broken by rearrangements of the links in https://github.com/CDL-Dryad/stash/pull/287, but we didn't have enough tests in stash_api to detect the problem.

Also adjusts the logic for setting the publisher to items added through the API that may not have a tenant set.