### PR TITLE
Change error text

### DIFF
--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_curation_activity_form.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_curation_activity_form.html.erb
@@ -3,7 +3,7 @@
 
   <%= form_for :resource, url: curation_activity_change_path(resource.id), method: :post, remote: true do |f| %>
 
-    <p class="c-alert--error">Unable to save your changes at this time. This is typically due to a Datacite/Ezid error.</p>
+    <p class="c-alert--error">Unable to save your changes at this time due to an internal error. Please contact a developer.</p>
 
     <%# Users cannot change the status or publication date once the files are published %>
     <% if resource.curatable? %>


### PR DESCRIPTION
This error is typically *not* due to a Datacite problem, it's typically some strange issue with processing the item's metadata, which must be tracked down and guarded against.