### PR TITLE
Fix misc internal errors

### DIFF
--- a/stash/stash_datacite/app/controllers/stash_datacite/affiliations_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/affiliations_controller.rb
@@ -10,7 +10,7 @@ module StashDatacite
       partial_term = params['term']
       return if partial_term.blank?
       # clean the partial_term of unwanted characters so it doesn't cause errors when calling the ROR API
-      partial_term.gsub!(%r{[\/\-\\\(\)~!@%&"]}, ' ')
+      partial_term.gsub!(%r{[\/\-\\\(\)~!@%&"\[\]\^\:]}, ' ')
       @affiliations = Stash::Organization::Ror.find_by_ror_name(partial_term)
       list = map_affiliation_for_autocomplete(@affiliations)
       render json: list

--- a/stash/stash_datacite/app/controllers/stash_datacite/affiliations_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/affiliations_controller.rb
@@ -7,7 +7,11 @@ module StashDatacite
 
     # GET /affiliations/autocomplete
     def autocomplete
-      @affiliations = Stash::Organization::Ror.find_by_ror_name(params['term']) unless params['term'].blank?
+      partial_term = params['term']
+      return if partial_term.blank?
+      # clean the partial_term of unwanted characters so it doesn't cause errors when calling the ROR API
+      partial_term.tr!('/-', '  ')
+      @affiliations = Stash::Organization::Ror.find_by_ror_name(partial_term)
       list = map_affiliation_for_autocomplete(@affiliations)
       render json: list
     end

--- a/stash/stash_datacite/app/controllers/stash_datacite/affiliations_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/affiliations_controller.rb
@@ -10,7 +10,7 @@ module StashDatacite
       partial_term = params['term']
       return if partial_term.blank?
       # clean the partial_term of unwanted characters so it doesn't cause errors when calling the ROR API
-      partial_term.tr!('/-', '  ')
+      partial_term.gsub!(%r{[\/\-\\\(\)~!@%&"]}, ' ')
       @affiliations = Stash::Organization::Ror.find_by_ror_name(partial_term)
       list = map_affiliation_for_autocomplete(@affiliations)
       render json: list

--- a/stash/stash_datacite/app/controllers/stash_datacite/geolocation_boxes_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/geolocation_boxes_controller.rb
@@ -10,7 +10,6 @@ module StashDatacite
       @geolocation_boxes = GeolocationBox.select(:resource_id, :sw_latitude, :sw_longitude, :ne_latitude, :ne_longitude)
         .only_geo_bbox(params[:resource_id])
       respond_to do |format|
-        format.html
         format.json { render json: @geolocation_boxes }
       end
     end

--- a/stash/stash_datacite/app/controllers/stash_datacite/geolocation_places_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/geolocation_places_controller.rb
@@ -9,7 +9,6 @@ module StashDatacite
     def places_coordinates
       @geolocation_places = GeolocationPlace.geo_places(params[:resource_id])
       respond_to do |format|
-        format.html
         format.json { render json: @geolocation_places }
       end
     end

--- a/stash/stash_datacite/app/controllers/stash_datacite/geolocation_points_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/geolocation_points_controller.rb
@@ -18,7 +18,6 @@ module StashDatacite
       respond_to do |format|
         @geolocation_points = GeolocationPoint.select(:resource_id, :id, :latitude, :longitude)
           .only_geo_points(params[:resource_id])
-        format.html
         format.json { render json: @geolocation_points }
       end
     end

--- a/stash/stash_engine/app/controllers/stash_engine/landing_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/landing_controller.rb
@@ -51,6 +51,9 @@ module StashEngine
       CounterLogger.general_hit(request: request, resource: resource) if resource.metadata_published?
       ensure_has_geolocation!
       @invitations = (params[:invitation] ? OrcidInvitation.where(secret: params[:invitation]).where(identifier_id: id.id) : nil)
+      respond_to do |format|
+        format.html
+      end
     end
 
     def data_paper


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/558

These internal errors are typically caused by crawlers making poorly-formed requests. Nevertheless, they result in emails to the developers, which are undesirable.

Some sample calls that are fixed with this PR:

`curl -i -X GET https://datadryad.org/stash/dataset/doi:10.6071/M3GT0P -H "Accept: application/json"`

`curl -i -X GET https://datadryad.org/stash_datacite/geolocation_boxes/boxes_coordinates?resource_id=31849 -H "Accept: text/html"`

`curl -i -X GET https://datadryad.org/stash_datacite/affiliations/autocomplete?term=Qatar+- -H "Accept: application/json"`