### PR TITLE
Improve ROR autocomplete

### DIFF
--- a/spec/responses/stash_datacite/affiliations_controller_spec.rb
+++ b/spec/responses/stash_datacite/affiliations_controller_spec.rb
@@ -1,32 +1,41 @@
 require 'rails_helper'
 require 'uri'
-# require_relative 'helpers'
+require_relative '../stash_api/helpers'
 require 'fixtures/stash_api/metadata'
 require 'fixtures/stash_api/curation_metadata'
 require 'cgi'
 require 'digest'
+
 # see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
 module StashDatacite
   RSpec.describe AffiliationsController, type: :request do
 
     include Mocks::Ror
-    include Mocks::RSolr
-    include Mocks::Stripe
     include Mocks::CurationActivity
-    include Mocks::Repository
-    include Mocks::UrlUpload
 
     before(:each) do
       neuter_curation_callbacks!
-      mock_ror!
     end
 
     describe 'get affiliations' do
-      it 'will retrive an affiliation' do
-        response_code = get "/stash_datacite/affiliations/autocomplete?term=ucla"
+      it 'will retrive an affiliation through autocomplete' do
+        stub_ror_name_lookup(name: 'BOGUS_ROR_NAME')
+        response_code = get '/stash_datacite/affiliations/autocomplete?term=BOGUS_ROR_NAME'
         expect(response_code).to eq(200)
+
+        ror_result = JSON.parse(response.body)
+        expect(ror_result.size).to eq(2)
+      end
+
+      it 'will force an exact-match affiliation to be before other matches, regardless of alphabetical order' do
+        stub_ror_name_lookup(name: 'ZZZZ Name')
+        response_code = get '/stash_datacite/affiliations/autocomplete?term=ZZZZ'
+        expect(response_code).to eq(200)
+
+        autocomplete_result = JSON.parse(response.body)
+        expect(autocomplete_result[0]['long_name']).to eq('ZZZZ Name')
       end
     end
-    
+
   end
 end

--- a/spec/responses/stash_datacite/affiliations_controller_spec.rb
+++ b/spec/responses/stash_datacite/affiliations_controller_spec.rb
@@ -23,14 +23,10 @@ module StashDatacite
 
     describe 'get affiliations' do
       it 'will retrive an affiliation' do
-        # response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", FILE_HASH.to_json, default_authenticated_headers
-        # expect(response_code).to eq(201)
-        # hsh = response_body_hash
-        # FILE_HASH.keys.reject { |k| k == 'skipValidation' }.each do |key|
-        #   expect(hsh[key]).to eq(FILE_HASH[key])
-        # end
+        response_code = get "/stash_datacite/affiliations/autocomplete?term=ucla"
+        expect(response_code).to eq(200)
       end
-
     end
+    
   end
 end

--- a/spec/responses/stash_datacite/affiliations_controller_spec.rb
+++ b/spec/responses/stash_datacite/affiliations_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 require 'uri'
-#require_relative 'helpers'
+# require_relative 'helpers'
 require 'fixtures/stash_api/metadata'
 require 'fixtures/stash_api/curation_metadata'
 require 'cgi'
@@ -23,12 +23,12 @@ module StashDatacite
 
     describe 'get affiliations' do
       it 'will retrive an affiliation' do
-       # response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", FILE_HASH.to_json, default_authenticated_headers
-       # expect(response_code).to eq(201)
-       # hsh = response_body_hash
-       # FILE_HASH.keys.reject { |k| k == 'skipValidation' }.each do |key|
-       #   expect(hsh[key]).to eq(FILE_HASH[key])
-       # end
+        # response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", FILE_HASH.to_json, default_authenticated_headers
+        # expect(response_code).to eq(201)
+        # hsh = response_body_hash
+        # FILE_HASH.keys.reject { |k| k == 'skipValidation' }.each do |key|
+        #   expect(hsh[key]).to eq(FILE_HASH[key])
+        # end
       end
 
     end

--- a/spec/responses/stash_datacite/affiliations_controller_spec.rb
+++ b/spec/responses/stash_datacite/affiliations_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+require 'uri'
+#require_relative 'helpers'
+require 'fixtures/stash_api/metadata'
+require 'fixtures/stash_api/curation_metadata'
+require 'cgi'
+require 'digest'
+# see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
+module StashDatacite
+  RSpec.describe AffiliationsController, type: :request do
+
+    include Mocks::Ror
+    include Mocks::RSolr
+    include Mocks::Stripe
+    include Mocks::CurationActivity
+    include Mocks::Repository
+    include Mocks::UrlUpload
+
+    before(:each) do
+      neuter_curation_callbacks!
+      mock_ror!
+    end
+
+    describe 'get affiliations' do
+      it 'will retrive an affiliation' do
+       # response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", FILE_HASH.to_json, default_authenticated_headers
+       # expect(response_code).to eq(201)
+       # hsh = response_body_hash
+       # FILE_HASH.keys.reject { |k| k == 'skipValidation' }.each do |key|
+       #   expect(hsh[key]).to eq(FILE_HASH[key])
+       # end
+      end
+
+    end
+  end
+end

--- a/stash/stash_datacite/app/controllers/stash_datacite/affiliations_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/affiliations_controller.rb
@@ -11,7 +11,6 @@ module StashDatacite
       return if partial_term.blank?
       # clean the partial_term of unwanted characters so it doesn't cause errors when calling the ROR API
       partial_term.gsub!(%r{[\/\-\\\(\)~!@%&"\[\]\^\:]}, ' ')
-      logger.debug("searching affiliations for #{partial_term}")
       @affiliations = Stash::Organization::Ror.find_by_ror_name(partial_term)
       list = map_affiliation_for_autocomplete(bubble_up_exact_matches(affil_list: @affiliations, term: partial_term))
       render json: list
@@ -34,7 +33,6 @@ module StashDatacite
       other_items = []
       match_term = term.downcase
       affil_list.each do |affil_item|
-        logger.debug("affil_item #{affil_item}")
         name = affil_item[:name].downcase
         if name.start_with?(match_term)
           matches_at_beginning << affil_item

--- a/stash/stash_datacite/app/controllers/stash_datacite/affiliations_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/affiliations_controller.rb
@@ -11,8 +11,9 @@ module StashDatacite
       return if partial_term.blank?
       # clean the partial_term of unwanted characters so it doesn't cause errors when calling the ROR API
       partial_term.gsub!(%r{[\/\-\\\(\)~!@%&"\[\]\^\:]}, ' ')
+      logger.debug("searching affiliations for #{partial_term}")
       @affiliations = Stash::Organization::Ror.find_by_ror_name(partial_term)
-      list = map_affiliation_for_autocomplete(@affiliations)
+      list = map_affiliation_for_autocomplete(bubble_up_exact_matches(affil_list: @affiliations, term: partial_term))
       render json: list
     end
 
@@ -23,6 +24,27 @@ module StashDatacite
       # however new user-entered items go into long name.
       return [] unless affiliations.is_a?(Array)
       affiliations.map { |u| { id: u[:id], long_name: u[:name] } }
+    end
+
+    # Re-order the affiliations list to prioritize exact matches at the beginning of the string, then
+    # exact matches within the string, otherwise leaving the order unchanged
+    def bubble_up_exact_matches(affil_list:, term:)
+      matches_at_beginning = []
+      matches_within = []
+      other_items = []
+      match_term = term.downcase
+      affil_list.each do |affil_item|
+        logger.debug("affil_item #{affil_item}")
+        name = affil_item[:name].downcase
+        if name.start_with?(match_term)
+          matches_at_beginning << affil_item
+        elsif name.include?(match_term)
+          matches_within << affil_item
+        else
+          other_items << affil_item
+        end
+      end
+      matches_at_beginning + matches_within + other_items
     end
 
   end

--- a/stash/stash_engine/lib/stash/organization/ror.rb
+++ b/stash/stash_engine/lib/stash/organization/ror.rb
@@ -38,7 +38,7 @@ module Stash
       def self.find_by_ror_name(query)
         resp = query_ror(URI, { 'query': query }, HEADERS)
         results = process_pages(resp, query) if resp.parsed_response.present? && resp.parsed_response['items'].present?
-        results.present? ? results.flatten.uniq.sort_by { |a| a[:name] } : []
+        results.present? ? results.flatten.uniq : []
       rescue HTTParty::Error, SocketError => e
         raise RorError, "Unable to connect to the ROR API for `find_by_ror_name`: #{e.message}"
       end


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/599

ROR is returning reasonable results on its own. The biggest problem with the autocomplete was that we were forcing the results to alphabetize, which forced random items to the top of the list. This removes the alphabetization, and adds a tiering system to the results, so exact matches are pushed to the top.