### PR TITLE
A11y upload alert

### DIFF
--- a/stash/stash_engine/app/views/stash_engine/file_uploads/_files_upload.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/file_uploads/_files_upload.html.erb
@@ -47,7 +47,7 @@
     <%= image_tag 'stash_engine/spinner.gif', size: '80x60', alt: 'Loading spinner' %>
 </div>
 
-<div class="c-upload__upload-complete-text" id="upload_complete" style="display: none;" role="region" aria-live="polite">
+<div class="c-upload__upload-complete-text" id="upload_complete" style="display: none;" role="status" aria-live="polite">
   <p>Upload complete.</p>
 </div>
 

--- a/stash/stash_engine/app/views/stash_engine/file_uploads/_files_upload.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/file_uploads/_files_upload.html.erb
@@ -47,7 +47,7 @@
     <%= image_tag 'stash_engine/spinner.gif', size: '80x60', alt: 'Loading spinner' %>
 </div>
 
-<div class="c-upload__upload-complete-text" id="upload_complete" style="display: none;">
+<div class="c-upload__upload-complete-text" id="upload_complete" style="display: none;" role="region" aria-live="polite">
   <p>Upload complete.</p>
 </div>
 


### PR DESCRIPTION
So far, this alerts a user using a screen reader "Upload complete", shortly after it appears in the UI. Not able to alert a user that a file has been removed yet because this functionality doesn't exist ...

There needs to be a new <div> created for these status notes when a user uploads or removes files, including logic that renders text that says, "File successfully removed", or something similar. This would require a refactor.