### PR TITLE
Dash datacite targets

### DIFF
--- a/stash/stash_engine/lib/tasks/datacite_target.rake
+++ b/stash/stash_engine/lib/tasks/datacite_target.rake
@@ -7,7 +7,7 @@ namespace :datacite_target do
   task update_dash: :environment do
     stash_ids = DashUpdater.dash_items_to_update
     stash_ids.each_with_index do |stash_id, idx|
-      puts "#{idx}: updating #{stash_id.identifier}"
+      puts "#{idx+1}/#{stash_ids.length}: updating #{stash_id.identifier}"
       DashUpdater.submit_id_metadata(stash_identifier: stash_id)
       sleep 1
     end

--- a/stash/stash_engine/lib/tasks/datacite_target.rake
+++ b/stash/stash_engine/lib/tasks/datacite_target.rake
@@ -1,11 +1,16 @@
-# require_relative 'datacite_target/somefile'
+require_relative 'datacite_target/dash_updater'
 
 # rubocop:disable Metrics/BlockLength
-namespace :counter do
+namespace :datacite_target do
 
-  desc 'test task'
-  task test_task: :environment do
-    puts 'a test task running in the rails environment'
+  desc 'update_dash DOI targets to reflect new environment'
+  task update_dash: :environment do
+    stash_ids = DashUpdater.dash_items_to_update
+    stash_ids.each_with_index do |stash_id, idx|
+      puts "#{idx}: updating #{stash_id.identifier}"
+      DashUpdater.submit_id_metadata(stash_identifier: stash_id)
+      sleep 1
+    end
   end
 
 end

--- a/stash/stash_engine/lib/tasks/datacite_target.rake
+++ b/stash/stash_engine/lib/tasks/datacite_target.rake
@@ -1,13 +1,11 @@
 require_relative 'datacite_target/dash_updater'
-
-# rubocop:disable Metrics/BlockLength
 namespace :datacite_target do
 
   desc 'update_dash DOI targets to reflect new environment'
   task update_dash: :environment do
     stash_ids = DashUpdater.dash_items_to_update
     stash_ids.each_with_index do |stash_id, idx|
-      puts "#{idx+1}/#{stash_ids.length}: updating #{stash_id.identifier}"
+      puts "#{idx + 1}/#{stash_ids.length}: updating #{stash_id.identifier}"
       DashUpdater.submit_id_metadata(stash_identifier: stash_id)
       sleep 1
     end

--- a/stash/stash_engine/lib/tasks/datacite_target.rake
+++ b/stash/stash_engine/lib/tasks/datacite_target.rake
@@ -1,0 +1,11 @@
+# require_relative 'datacite_target/somefile'
+
+# rubocop:disable Metrics/BlockLength
+namespace :counter do
+
+  desc 'test task'
+  task test_task: :environment do
+    puts 'a test task running in the rails environment'
+  end
+
+end

--- a/stash/stash_engine/lib/tasks/datacite_target/dash_updater.rb
+++ b/stash/stash_engine/lib/tasks/datacite_target/dash_updater.rb
@@ -1,0 +1,28 @@
+module DashUpdater
+
+  def self.dash_items_to_update
+    # I was going to limit this to items created before transition to the new system, but we may want to update others
+    # in order to get thier ROR information updated
+    StashEngine::Identifier.joins(:resources).where(pub_state: %w{embargoed published})
+        .where("stash_engine_resources.tenant_id <> 'dryad'").distinct
+  end
+
+  def self.submit_id_metadata(stash_identifier:, retry_pause: 10)
+    resource = stash_identifier.resources.where(meta_view: true).order('id DESC').first
+    return if resource.nil?
+
+    idg = Stash::Doi::IdGen.make_instance(resource: resource)
+    tries = 0
+
+    begin
+      idg.update_identifier_metadata!
+    rescue Stash::Doi::IdGenError => ige
+      tries += 1
+      puts "Try: #{tries} \tStash::Doi::IdGen - Unable to submit metadata changes for : '#{resource&.identifier&.to_s}'"
+      puts ige.message
+      puts ''
+      sleep retry_pause # pause for a while to let ezid/datacite stop having problems in case temporary
+      retry unless tries > 9
+    end
+  end
+end

--- a/stash/stash_engine/lib/tasks/datacite_target/dash_updater.rb
+++ b/stash/stash_engine/lib/tasks/datacite_target/dash_updater.rb
@@ -3,8 +3,8 @@ module DashUpdater
   def self.dash_items_to_update
     # I was going to limit this to items created before transition to the new system, but we may want to update others
     # in order to get thier ROR information updated
-    StashEngine::Identifier.joins(:resources).where(pub_state: %w{embargoed published})
-        .where("stash_engine_resources.tenant_id <> 'dryad'").distinct
+    StashEngine::Identifier.joins(:resources).where(pub_state: %w[embargoed published])
+      .where("stash_engine_resources.tenant_id <> 'dryad'").distinct
   end
 
   def self.submit_id_metadata(stash_identifier:, retry_pause: 10)
@@ -23,6 +23,7 @@ module DashUpdater
       puts ''
       sleep retry_pause # pause for a while to let ezid/datacite stop having problems in case temporary
       retry unless tries > 9
+      raise ige # re-raise the exception
     end
   end
 end

--- a/stash/stash_engine/spec/unit/tasks/datacite_target/dash_updater_spec.rb
+++ b/stash/stash_engine/spec/unit/tasks/datacite_target/dash_updater_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'db_spec_helper'
+require 'ostruct'
+require_relative '../../../../lib/tasks/datacite_target/dash_updater.rb'
+require_relative '../../../../../spec_helpers/factory_helper'
+require 'byebug'
+
+module DashUpdater
+  describe 'Updating Function' do
+
+    before(:each) do
+      @identifier = create(:identifier)
+      @resource = create(:resource, identifier_id: @identifier.id, meta_view: true)
+      @curation_activity = create(:curation_activity, resource: @resource)
+    end
+
+    it 'retries failing requests and fails after too many retries' do
+      @mock_idgen = double('idgen')
+      allow(@mock_idgen).to receive('update_identifier_metadata!'.intern).and_raise(Stash::Doi::IdGenError, 'test exception')
+      allow(Stash::Doi::IdGen).to receive(:make_instance).and_return(@mock_idgen)
+
+      expect { DashUpdater.submit_id_metadata(stash_identifier: @identifier, retry_pause: 0) }
+        .to raise_error(Stash::Doi::IdGenError, 'test exception')
+    end
+
+    it "returns early if this resource doesn't have a public version" do
+      @resource.update(meta_view: false)
+      @resource.reload
+      expect(DashUpdater.submit_id_metadata(stash_identifier: @identifier, retry_pause: 0)).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
See ticket 600.  This queries to get items embargoed or published and from non-Dryad collections (ie Dash) and then updates the metadata for them with DataCite/EZID.  It will update the target URLs and also the ROR ids that Ryan added.

It retries up to 10 times and doesn't update unless there is an embargoed/published item that shows metadata.