### PR TITLE
Clean incorrect travis info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ services:
   - mysql
 
 before_install:
+  - sudo apt-get clean
+  - sudo rm -rf /var/lib/apt/lists/*
   - sudo apt-get update
   - if [ "$TO_TEST" = "MAIN" ]; then sudo apt-get install mutt; fi
   - gem update --system


### PR DESCRIPTION
Based on various web comments, including https://unix.stackexchange.com/questions/116641/how-do-you-fix-apt-get-update-hash-sum-mismatch, this may fix the current Travis issues.