### PR TITLE
Allow non-secure logins for docker

### DIFF
--- a/stash/stash_engine/config/initializers/omniauth.rb
+++ b/stash/stash_engine/config/initializers/omniauth.rb
@@ -32,7 +32,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   OmniAuth.config.full_host = ->(env) do
     # "omniauth.strategy"=>#<OmniAuth::Strategies::ORCID> might be helpful if we need to know if strategy is ORCID
     u = URI.parse("http://#{env['HTTP_X_FORWARDED_HOST'] || env['HTTP_HOST']}")
-    u.scheme = 'https' if env['omniauth.strategy'].to_s.include?('ORCID') && !u.host[/(localhost)|(.+dash\.datadryad\.org)/]
+    u.scheme = 'https' if env['omniauth.strategy'].to_s.include?('ORCID') && !u.host[/(localhost)|(.+dash\.datadryad\.org)|(docker)/]
     "#{u.scheme}://#{u.host}#{(u.port == 80 ? '' : ":#{u.port}")}" # only add port if it's not 80
   end
 


### PR DESCRIPTION
This is to allow Terry's docker container to login insecurely.  Modifying the hack we had to put in to get https working correctly because of issues with the Apache reverse proxy in normal operation with login/omniauth .