### PR TITLE
Hacky blacklist

### DIFF
--- a/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
@@ -20,14 +20,14 @@ module StashEngine
       # a holiday when we don't have other good ways to block yet without assistance from others.
 
       block_path = Rails.root.join('uploads', 'blacklist.txt').to_s
-      if File.exist?(block_path)
-        File.read(block_path).split("\n").each do |exc|
-          next if exc.blank? || exc.start_with?('#')
+      return unless File.exist?(block_path)
 
-          if request&.remote_ip&.start_with?(exc)
-            head(429)
-            break
-          end
+      File.read(block_path).split("\n").each do |exc|
+        next if exc.blank? || exc.start_with?('#')
+
+        if request&.remote_ip&.start_with?(exc)
+          head(429)
+          break
         end
       end
     end


### PR DESCRIPTION
Hey Ryan,

This is a hack into our before-filter for setting up downloads.  We had an IP address from India overloading the server today with huge download requests and hitting the same items many times (in excess of 64 times for the full version download of 400+ GB).  I needed to add another IP address to blacklist.  We really need some way to block people when they become a problem without changing code (or puppet or AWS) when we can't control those settings well or quickly right now.

If there is the file `uploads/blacklist.txt` then it reads it and splits the lines.  It ignores any blank lines or ones that start with `#`.  If the remote_ip starts with something on a line in the file then it blocks that IP address and returns a head response of 429 instead of doing a download.

I tested and downloads still work for me and it seems to have blocked the Indian IP Address that some other people besides us also reported as problematic or malicious, also, that I added to the blacklist file.