### PR TITLE
In-progress items: status display in Admin Dashboard

### DIFF
--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -45,7 +45,13 @@
         <% end %>
       </td>
       <td class="c-admin-hide-border-right" id="js-curation-state-<%= dataset.identifier_id %>">
-        <%= StashEngine::CurationActivity.readable_status(dataset.status) %>
+	  <% if (dataset.resource_state == 'error') %>
+	      Merritt Error
+	  <% elsif (dataset.resource_state == 'processing') %>
+	      Processing
+	  <% else %>
+              <%= StashEngine::CurationActivity.readable_status(dataset.status) %>
+	  <% end %>
       </td>
       <td class="c-admin-hide-border-left">
         <% if %w[admin superuser].include?(current_user.role) && dataset.resource_state == 'submitted' %>


### PR DESCRIPTION
For step 1 of https://github.com/CDL-Dryad/dryad-product-roadmap/issues/568

On the Admin Dashboard, when an item is being processed by Merritt, or has errored in Merritt, show a human-readable version of the resource_state instead of the curation status.
