### PR TITLE
In-progress items: email reminders

### DIFF
--- a/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
+++ b/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
@@ -62,7 +62,7 @@ module StashEngine
     end
 
     def in_progress_reminder(resource)
-      warn("Unable to send in_progress_reminder; nil resource") unless resource.present?
+      warn('Unable to send in_progress_reminder; nil resource') unless resource.present?
       return unless resource.present?
       user = resource.authors.first || resource.user
       return unless user.present? && user_email(user).present?

--- a/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
+++ b/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
@@ -53,7 +53,7 @@ module StashEngine
 
     # Called from the StashEngine::Repository
     def error_report(resource, error)
-      warn("Unable to report update error #{error}; nil resource") unless resource.present?
+      logger.warn("Unable to report update error #{error}; nil resource") unless resource.present?
       return unless resource.present?
       assign_variables(resource)
       @backtrace = to_backtrace(error)
@@ -62,7 +62,7 @@ module StashEngine
     end
 
     def in_progress_reminder(resource)
-      warn('Unable to send in_progress_reminder; nil resource') unless resource.present?
+      logger.warn('Unable to send in_progress_reminder; nil resource') unless resource.present?
       return unless resource.present?
       user = resource.authors.first || resource.user
       return unless user.present? && user_email(user).present?
@@ -82,7 +82,7 @@ module StashEngine
     end
 
     def helpdesk_notice(resource, message)
-      warn('Unable to send helpdesk notice; nil resource') unless resource.present?
+      logger.warn('Unable to send helpdesk notice; nil resource') unless resource.present?
       return unless resource.present?
       assign_variables(resource)
       @message = message

--- a/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
+++ b/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
@@ -61,6 +61,17 @@ module StashEngine
            subject: "#{rails_env} Submitting dataset \"#{@resource.title}\" (doi:#{@resource.identifier_value}) failed")
     end
 
+    def in_progress_reminder(resource)
+      warn("Unable to send in_progress_reminder; nil resource") unless resource.present?
+      return unless resource.present?
+      user = resource.authors.first || resource.user
+      return unless user.present? && user_email(user).present?
+      @user_name = user_name(user)
+      assign_variables(resource)
+      mail(to: user_email(user),
+           subject: "#{rails_env} REMINDER: Dryad Submission \"#{@resource.title}\"")
+    end
+
     def dependency_offline(dependency)
       return unless dependency.present?
       @dependency = dependency

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_activity_log_row.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_activity_log_row.html.erb
@@ -2,7 +2,7 @@
 <tr class="c-lined-table__row">
   <td><%= formatted_datetime(curation_activity.created_at) %></td>
   <td><%= curation_activity.readable_status %></td>
-  <td><%= curation_activity.user&.name %></td>
+  <td><%= curation_activity.user&.name || "System" %></td>
   <td><%= curation_activity.note %></td>
   <td><%= curation_activity.keywords %></td>
 </tr>

--- a/stash/stash_engine/app/views/stash_engine/curation_activity/index.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/curation_activity/index.html.erb
@@ -18,7 +18,7 @@
     <tr>
       <td><%= curation_activity.created_at %></td>
       <td><%= curation_activity.readable_status %></td>
-      <td><%= curation_activity.user.name %></td>
+      <td><%= curation_activity.user&.name || "System" %></td>
       <td><%= curation_activity.note %></td>
       <td><%= curation_activity.keywords %></td>
     </tr>

--- a/stash/stash_engine/app/views/stash_engine/user_mailer/in_progress_reminder.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/user_mailer/in_progress_reminder.html.erb
@@ -12,7 +12,3 @@
 
 <p>If you do not intend to submit this dataset, you may “delete” this dataset. Please get in touch with any questions at <a href="mailto:<%= @helpdesk_email %>"><%= @helpdesk_email %></a>.</p>
 
-<p>The Dryad Team<br/>
-www.datadryad.org</p>
-
-

--- a/stash/stash_engine/app/views/stash_engine/user_mailer/in_progress_reminder.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/user_mailer/in_progress_reminder.html.erb
@@ -1,0 +1,18 @@
+<p>Dear <%= @user_name %>,</p>
+
+<p>We noticed that you have begun a submission to Dryad, “<%= @resource.title %>”, but have not completed the process.</p>
+
+<p>If you are ready for this dataset to enter the submission process, please follow these steps:</p>
+<ol>
+<li>Login</li>
+<li>Click on “my datasets”</li>
+<li>Click “resume” your dataset submission,</li>
+<li>On page 3 of the submission form, click “submit”</li>
+</ol>
+
+<p>If you do not intend to submit this dataset, you may “delete” this dataset. Please get in touch with any questions at <a href="mailto:<%= @helpdesk_email %>"><%= @helpdesk_email %></a>.</p>
+
+<p>The Dryad Team<br/>
+www.datadryad.org</p>
+
+


### PR DESCRIPTION
For step 2 of https://github.com/CDL-Dryad/dryad-product-roadmap/issues/568

(Note this subsumes PR #38)

1. Adds a rake task that will email users a reminder about items that have been left in_progress. The email will only be sent once for each resource, regardless of how many times the task is run, using the text of the associated Curation Activity to determine whether the email has been previously sent.
2. The Curation Activity for this task, along with the other Curation Activities that are created by cron tasks, have been set to user_id = 0, which now displays in the UI as "System", to indicate that the activity was not performed by a human user.
