### PR TITLE
 Shopping cart report

### DIFF
--- a/spec/factories/stash_engine/curation_activities.rb
+++ b/spec/factories/stash_engine/curation_activities.rb
@@ -45,7 +45,7 @@ FactoryBot.define do
         # https://stackoverflow.com/questions/8751175/skip-callbacks-on-factory-girl-and-rspec
         ca.define_singleton_method(:submit_to_datacite) {}
         ca.define_singleton_method(:update_solr) {}
-        ca.define_singleton_method(:submit_to_stripe) {}
+        ca.define_singleton_method(:process_payment) {}
         ca.define_singleton_method(:email_status_change_notices) {}
         ca.define_singleton_method(:email_orcid_invitations) {}
       end

--- a/spec/mocks/curation_activity.rb
+++ b/spec/mocks/curation_activity.rb
@@ -7,7 +7,7 @@ module Mocks
       # callback explicitly.
       allow_any_instance_of(StashEngine::CurationActivity).to receive(:submit_to_datacite).and_return(true)
       allow_any_instance_of(StashEngine::CurationActivity).to receive(:update_solr).and_return(true)
-      allow_any_instance_of(StashEngine::CurationActivity).to receive(:submit_to_stripe).and_return(true)
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:process_payment).and_return(true)
       allow_any_instance_of(StashEngine::CurationActivity).to receive(:email_status_change_notices).and_return(true)
       allow_any_instance_of(StashEngine::CurationActivity).to receive(:email_orcid_invitations).and_return(true)
     end

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -182,7 +182,7 @@ module StashApi
       # all this bogus return false stuff is to prevent double render errors in some circumstances
       return if check_superuser_restricted_params == false
       return if check_may_set_user_id == false
-      return if check_may_set_invoice_id == false
+      return if check_may_set_payment_id == false
     end
 
     def check_superuser_restricted_params
@@ -211,10 +211,10 @@ module StashApi
       false
     end
 
-    def check_may_set_invoice_id
-      return if params['invoiceId'].nil?
+    def check_may_set_payment_id
+      return if params['paymentId'].nil?
       unless @user.role == 'superuser'
-        render json: { error: 'Unauthorized: only superuser roles may set an invoiceId' }.to_json, status: 401
+        render json: { error: 'Unauthorized: only superuser roles may set a paymentId' }.to_json, status: 401
         return false
       end
       false

--- a/stash/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser.rb
@@ -37,7 +37,8 @@ module StashApi
       @hash[:authors]&.each { |author| add_author(json_author: author) }
       StashDatacite::Description.create(description: @hash[:abstract], description_type: 'abstract', resource_id: @resource.id)
       TO_PARSE.each { |item| dynamic_parse(my_class: item) }
-      @resource.identifier.invoice_id = @hash['invoiceId']
+      @resource.identifier.payment_type = @hash['paymentType']
+      @resource.identifier.payment_id = @hash['paymentId']
       @resource.identifier.save
       @resource.identifier
     end

--- a/stash/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
+++ b/stash/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
@@ -46,7 +46,8 @@ module StashApi
         'abstract' =>
               'Cyberneticists agree that concurrent models are an interesting new topic in the field of machine learning.',
         'userId' => @user2.id,
-        'invoiceId' => 'invoice-123'
+        'paymentId' => 'invoice-123',
+        'paymentType' => 'stripe'
       }.with_indifferent_access
 
       @update_metadata = {
@@ -135,8 +136,9 @@ module StashApi
         expect(resource.current_editor_id).to eq(@user2.id)
       end
 
-      it 'puts the invoiceId on the identifier' do
-        expect(@stash_identifier.invoice_id). to eq('invoice-123')
+      it 'puts the paymentId on the identifier' do
+        expect(@stash_identifier.payment_id). to eq('invoice-123')
+        expect(@stash_identifier.payment_type). to eq('stripe')
       end
     end
 

--- a/stash/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -242,7 +242,7 @@ module StashEngine
     def ready_for_payment?
       resource&.identifier&.reload
       StashEngine.app&.payments&.service == 'stripe' &&
-        resource&.identifier&.invoice_id.nil? &&
+        resource&.identifier&.payment_id.nil? &&
         (status == 'published' || status == 'embargoed')
     end
 

--- a/stash/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -51,7 +51,7 @@ module StashEngine
     # ------------------------------------------
 
     # When the status is published/embargoed send to Stripe and DataCite
-    after_create :submit_to_datacite, :update_solr, :submit_to_stripe, :remove_peer_review,
+    after_create :submit_to_datacite, :update_solr, :process_payment, :remove_peer_review,
                  if: proc { |ca|
                        !ca.resource.skip_datacite_update && (ca.published? || ca.embargoed?) &&
                                  latest_curation_status_changed?
@@ -118,10 +118,18 @@ module StashEngine
 
     # Callbacks
     # ------------------------------------------
-    def submit_to_stripe
-      return unless ready_for_payment? &&
-                    resource.identifier&.user_must_pay?
+    def process_payment
+      return unless ready_for_payment?
 
+      if resource.identifier&.user_must_pay?
+        submit_to_stripe
+      else
+        resource.identifier&.record_payment
+      end
+    end
+
+    def submit_to_stripe
+      return unless ready_for_payment?
       inv = Stash::Payments::Invoicer.new(resource: resource, curator: user)
       inv.charge_user_via_invoice
     end

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -318,6 +318,22 @@ module StashEngine
       found_article_appears
     end
 
+    # returns the date on which this identifier was approved for publication
+    # (i.e., the date on which it entered the status 'published' or 'embargoed'
+    def approval_date
+      return nil unless %w[published embargoed].include?(pub_state)
+
+      found_approval_date = nil
+      resources.each do |res|
+        res.curation_activities.each do |ca|
+          next unless %w[published embargoed].include?(ca.status)
+          found_approval_date = ca.created_at
+          break
+        end
+      end
+      found_approval_date
+    end
+    
     # returns the publication state based on history
     # finds the latest applicable state from terminal states for each resource/version.
     # We only really care about whether it's some form of published, embargoed or withdrawn

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -236,6 +236,7 @@ module StashEngine
       else
         self.payment_type = 'unknown'
       end
+      self.save
     end
 
     def publication_data(field_name)

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -222,6 +222,22 @@ module StashEngine
         (!submitter_affiliation.present? || !submitter_affiliation.fee_waivered?)
     end
 
+    def record_payment
+      return if payment_type.present?
+      if submitter_affiliation&.fee_waivered?
+        self.payment_type = 'waiver'
+        self.payment_id = submitter_affiliation.country_name
+      elsif institution_will_pay?
+        self.payment_type = 'institution'
+        self.payment_id = latest_resource&.tenant&.tenant_id
+      elsif journal_will_pay?
+        self.payment_type = 'journal-' + publication_data('paymentPlanType')
+        self.payment_id = publication_issn
+      else
+        self.payment_type = 'unknown'
+      end
+    end
+
     def publication_data(field_name)
       return nil if publication_issn.nil?
       url = APP_CONFIG.old_dryad_url + '/api/v1/journals/' + publication_issn

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -236,7 +236,7 @@ module StashEngine
       else
         self.payment_type = 'unknown'
       end
-      self.save
+      save
     end
 
     def publication_data(field_name)

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -281,6 +281,10 @@ module StashEngine
       publication_data('stripeCustomerID')
     end
 
+    def journal_sponsor_name
+      publication_data('sponsorName')
+    end
+
     def journal_notify_contacts
       publication_data('notifyContacts')
     end

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -333,7 +333,7 @@ module StashEngine
       end
       found_approval_date
     end
-    
+
     # returns the publication state based on history
     # finds the latest applicable state from terminal states for each resource/version.
     # We only really care about whether it's some form of published, embargoed or withdrawn

--- a/stash/stash_engine/db/migrate/20200111013011_add_payment_type.rb
+++ b/stash/stash_engine/db/migrate/20200111013011_add_payment_type.rb
@@ -7,7 +7,7 @@ class AddPaymentType < ActiveRecord::Migration
       if i.payment_id
         if i.payment_id.start_with?('in_')
           i.update_column(:payment_type, 'stripe')
-        else          
+        else
           # else, separate on the colon, set payment_type to part before colon, and payment_id to rest
           found_type, found_id = i.payment_id.match(/(.+):(.+)/).captures
           next unless found_type && found_id
@@ -20,11 +20,10 @@ class AddPaymentType < ActiveRecord::Migration
 
   def down
     StashEngine::Identifier.all.each do |i|
-      if i.payment_id
-        if i.payment_type != 'stripe'
-          new_id = "#{i.payment_type}:#{i.payment_id}"
-          i.update_column(:payment_id, new_id)
-        end
+      next unless i.payment_id
+      if i.payment_type != 'stripe'
+        new_id = "#{i.payment_type}:#{i.payment_id}"
+        i.update_column(:payment_id, new_id)
       end
     end
     rename_column :stash_engine_identifiers, :payment_id, :invoice_id

--- a/stash/stash_engine/db/migrate/20200111013011_add_payment_type.rb
+++ b/stash/stash_engine/db/migrate/20200111013011_add_payment_type.rb
@@ -1,0 +1,33 @@
+class AddPaymentType < ActiveRecord::Migration
+  def up
+    rename_column :stash_engine_identifiers, :invoice_id, :payment_id
+    add_column :stash_engine_identifiers, :payment_type, :string, after: :search_words
+    StashEngine::Identifier.reset_column_information
+    StashEngine::Identifier.all.each do |i|
+      if i.payment_id
+        if i.payment_id.start_with?('in_')
+          i.update_column(:payment_type, 'stripe')
+        else          
+          # else, separate on the colon, set payment_type to part before colon, and payment_id to rest
+          found_type, found_id = i.payment_id.match(/(.+):(.+)/).captures
+          next unless found_type && found_id
+          i.update_column(:payment_id, found_id)
+          i.update_column(:payment_type, found_type)
+        end
+      end
+    end
+  end
+
+  def down
+    StashEngine::Identifier.all.each do |i|
+      if i.payment_id
+        if i.payment_type != 'stripe'
+          new_id = "#{i.payment_type}:#{i.payment_id}"
+          i.update_column(:payment_id, new_id)
+        end
+      end
+    end
+    rename_column :stash_engine_identifiers, :payment_id, :invoice_id
+    remove_column :stash_engine_identifiers, :payment_type
+  end
+end

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -182,13 +182,11 @@ namespace :identifiers do
       year_month = ENV['YEAR_MONTH']
     end
     p "Writing Shopping Cart Report for #{year_month} to file..."
-    CSV.open("shopping_cart_report_#{year_month}.csv", "w") do |csv|
-      csv << ["DOI", "Approval Date", "Payment Type", "Payment ID", "Journal Name", "Sponsor Name"]
+    CSV.open("shopping_cart_report_#{year_month}.csv", 'w') do |csv|
+      csv << ['DOI', 'Approval Date', 'Payment Type', 'Payment ID', 'Journal Name', 'Sponsor Name']
       StashEngine::Identifier.publicly_viewable.each do |i|
         approval_date_str = i.approval_date&.strftime('%Y-%m-%d')
-        if approval_date_str&.start_with?(year_month)
-          csv << [ i.identifier, approval_date_str, i.payment_type, i.payment_id, i.publication_name ]
-        end
+        csv << [i.identifier, approval_date_str, i.payment_type, i.payment_id, i.publication_name] if approval_date_str&.start_with?(year_month)
       end
     end
     # Exit cleanly (don't let rake assume that an extra argument is another task to process)

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -171,6 +171,18 @@ namespace :identifiers do
     end
   end
 
+  desc 'Generate a report of items that have been published in a given month'
+  task shopping_cart_report: :environment , [:year_month] do |task, args|
+    p "processing #{args}"
+    p "Shopping Cart Report for  #{year_month}"
+    # find the right list of items
+    ## take argument for the year-month
+    ## if none, default to the previously completed month
+    # for each item
+    ## get the variables associated with publication status
+    ## output a CSV of the metadata
+  end
+
   desc 'populate publicationName'
   task load_publication_names: :environment do
     p "Searching CrossRef and the Journal API for publication names: #{Time.now.utc}"

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -177,7 +177,7 @@ namespace :identifiers do
     # If none, default to the previously completed month.
     if ENV['YEAR_MONTH'].blank?
       puts 'No month specified, assuming last month.'
-      year_month = 1.month.ago.strftime("%Y-%m")
+      year_month = 1.month.ago.strftime('%Y-%m')
     else
       year_month = ENV['YEAR_MONTH']
     end

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -182,10 +182,10 @@ namespace :identifiers do
       year_month = ENV['YEAR_MONTH']
     end
     p "Shopping Cart Report for #{year_month}"
-    # - any identifier that became published or embargoed during the target month
-    # for each item
-    ## get the variables associated with publication status
-    ## output a CSV of the metadata
+    StashEngine::Identifier.publicly_viewable.each do |i|
+      ## get the variables associated with publication status
+      ## output a CSV of the metadata
+    end
     # Exit cleanly (don't let rake assume that an extra argument is another task to process)
     exit
   end

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -176,15 +176,20 @@ namespace :identifiers do
     # Get the year-month specified in YEAR_MONTH environment variable.
     # If none, default to the previously completed month.
     if ENV['YEAR_MONTH'].blank?
-      puts 'No month specified, assuming last month.'
+      p 'No month specified, assuming last month.'
       year_month = 1.month.ago.strftime('%Y-%m')
     else
       year_month = ENV['YEAR_MONTH']
     end
-    p "Shopping Cart Report for #{year_month}"
-    StashEngine::Identifier.publicly_viewable.each do |i|
-      ## get the variables associated with publication status
-      ## output a CSV of the metadata
+    p "Writing Shopping Cart Report for #{year_month} to file..."
+    CSV.open("shopping_cart_report_#{year_month}.csv", "w") do |csv|
+      csv << ["DOI", "Approval Date", "Payment Type", "Payment ID", "Journal Name", "Sponsor Name"]
+      StashEngine::Identifier.publicly_viewable.each do |i|
+        approval_date_str = i.approval_date&.strftime('%Y-%m-%d')
+        if approval_date_str&.start_with?(year_month)
+          csv << [ i.identifier, approval_date_str, i.payment_type, i.payment_id, i.publication_name ]
+        end
+      end
     end
     # Exit cleanly (don't let rake assume that an extra argument is another task to process)
     exit

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -172,15 +172,22 @@ namespace :identifiers do
   end
 
   desc 'Generate a report of items that have been published in a given month'
-  task shopping_cart_report: :environment , [:year_month] do |task, args|
-    p "processing #{args}"
-    p "Shopping Cart Report for  #{year_month}"
-    # find the right list of items
-    ## take argument for the year-month
-    ## if none, default to the previously completed month
+  task shopping_cart_report: :environment do
+    # Get the year-month specified in YEAR_MONTH environment variable.
+    # If none, default to the previously completed month.
+    if ENV['YEAR_MONTH'].blank?
+      puts 'No month specified, assuming last month.'
+      year_month = 1.month.ago.strftime("%Y-%m")
+    else
+      year_month = ENV['YEAR_MONTH']
+    end
+    p "Shopping Cart Report for #{year_month}"
+    # - any identifier that became published or embargoed during the target month
     # for each item
     ## get the variables associated with publication status
     ## output a CSV of the metadata
+    # Exit cleanly (don't let rake assume that an extra argument is another task to process)
+    exit
   end
 
   desc 'populate publicationName'

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -186,7 +186,9 @@ namespace :identifiers do
       csv << ['DOI', 'Approval Date', 'Payment Type', 'Payment ID', 'Journal Name', 'Sponsor Name']
       StashEngine::Identifier.publicly_viewable.each do |i|
         approval_date_str = i.approval_date&.strftime('%Y-%m-%d')
-        csv << [i.identifier, approval_date_str, i.payment_type, i.payment_id, i.publication_name] if approval_date_str&.start_with?(year_month)
+        if approval_date_str&.start_with?(year_month)
+          csv << [i.identifier, approval_date_str, i.payment_type, i.payment_id, i.publication_name, i.journal_sponsor_name]
+        end
       end
     end
     # Exit cleanly (don't let rake assume that an extra argument is another task to process)

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -190,6 +190,15 @@ namespace :identifiers do
     exit
   end
 
+  desc 'populate payment info'
+  task load_payment_info: :environment do
+    p 'Populating payment information for published/embargoed items'
+    StashEngine::Identifier.publicly_viewable.where(payment_type: nil).each do |i|
+      i.record_payment
+      p "#{i.id} #{i.identifier} #{i.payment_type} #{i.payment_id}"
+    end
+  end
+
   desc 'populate publicationName'
   task load_publication_names: :environment do
     p "Searching CrossRef and the Journal API for publication names: #{Time.now.utc}"

--- a/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -440,6 +440,22 @@ module StashEngine
       end
     end
 
+    describe '#journal_sponsor_name' do
+      it 'retrieves the journal sponsorName' do
+        @fake_journal_name = 'Fake Journal'
+        @fake_sponsor_name = 'sponsor_abc123'
+        stub_request(:any, %r{/journals/#{@fake_issn}})
+          .to_return(body: '{"fullName":"' + @fake_journal_name + '",
+                             "issn":"' + @fake_issn + '",
+                             "website":"http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-294X",
+                             "description":"Molecular Ecology publishes papers that utilize molecular genetic techniques...",
+                             "sponsorName":"' + @fake_sponsor_name + '"}',
+                     status: 200,
+                     headers: { 'Content-Type' => 'application/json' })
+        expect(identifier.journal_sponsor_name).to eq(@fake_sponsor_name)
+      end
+    end
+
     describe '#journal_allows' do
       it 'allows review when there is no journal' do
         allow(@identifier).to receive('publication_name').and_return(nil)

--- a/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -162,7 +162,7 @@ module StashEngine
       describe 'curation activity setup' do
         before(:each) do
           allow_any_instance_of(CurationActivity).to receive(:update_solr).and_return(true)
-          allow_any_instance_of(CurationActivity).to receive(:submit_to_stripe).and_return(true)
+          allow_any_instance_of(CurationActivity).to receive(:process_payment).and_return(true)
           allow_any_instance_of(CurationActivity).to receive(:submit_to_datacite).and_return(true)
         end
 
@@ -493,7 +493,7 @@ module StashEngine
       before(:each) do
         # a way to neuter all the callback activity
         allow_any_instance_of(CurationActivity).to receive(:update_solr).and_return(true)
-        allow_any_instance_of(CurationActivity).to receive(:submit_to_stripe).and_return(true)
+        allow_any_instance_of(CurationActivity).to receive(:process_payment).and_return(true)
         allow_any_instance_of(CurationActivity).to receive(:submit_to_datacite).and_return(true)
       end
 
@@ -539,7 +539,7 @@ module StashEngine
       before(:each) do
         # a way to neuter all the callback activity
         allow_any_instance_of(CurationActivity).to receive(:update_solr).and_return(true)
-        allow_any_instance_of(CurationActivity).to receive(:submit_to_stripe).and_return(true)
+        allow_any_instance_of(CurationActivity).to receive(:process_payment).and_return(true)
         allow_any_instance_of(CurationActivity).to receive(:submit_to_datacite).and_return(true)
       end
 
@@ -570,7 +570,7 @@ module StashEngine
       before(:each) do
         # a way to neuter all the callback activity
         allow_any_instance_of(CurationActivity).to receive(:update_solr).and_return(true)
-        allow_any_instance_of(CurationActivity).to receive(:submit_to_stripe).and_return(true)
+        allow_any_instance_of(CurationActivity).to receive(:process_payment).and_return(true)
         allow_any_instance_of(CurationActivity).to receive(:submit_to_datacite).and_return(true)
       end
 
@@ -663,7 +663,7 @@ module StashEngine
       before(:each) do
         # a way to neuter all the callback activity
         allow_any_instance_of(CurationActivity).to receive(:update_solr).and_return(true)
-        allow_any_instance_of(CurationActivity).to receive(:submit_to_stripe).and_return(true)
+        allow_any_instance_of(CurationActivity).to receive(:process_payment).and_return(true)
         allow_any_instance_of(CurationActivity).to receive(:submit_to_datacite).and_return(true)
       end
 

--- a/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
@@ -23,7 +23,7 @@ module StashEngine
         tenant_id: 'ucop'
       )
       allow_any_instance_of(CurationActivity).to receive(:update_solr).and_return(true)
-      allow_any_instance_of(CurationActivity).to receive(:submit_to_stripe).and_return(true)
+      allow_any_instance_of(CurationActivity).to receive(:process_payment).and_return(true)
       allow_any_instance_of(CurationActivity).to receive(:submit_to_datacite).and_return(true)
 
       # Mock all the mailers fired by callbacks because these tests don't load everything we need

--- a/stash/stash_engine/spec/factories.rb
+++ b/stash/stash_engine/spec/factories.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
         # https://stackoverflow.com/questions/8751175/skip-callbacks-on-factory-girl-and-rspec
         ca.define_singleton_method(:submit_to_datacite) {}
         ca.define_singleton_method(:update_solr) {}
-        ca.define_singleton_method(:submit_to_stripe) {}
+        ca.define_singleton_method(:process_payment) {}
         ca.define_singleton_method(:email_status_change_notices) {}
         ca.define_singleton_method(:email_orcid_invitations) {}
       end

--- a/stash/stash_engine/spec/unit/models/curation_activity_spec.rb
+++ b/stash/stash_engine/spec/unit/models/curation_activity_spec.rb
@@ -53,7 +53,7 @@ module StashEngine
         # get rid of callbacks for adding one and testing
         CurationActivity.skip_callback(:create, :after, :submit_to_datacite)
         CurationActivity.skip_callback(:create, :after, :update_solr)
-        CurationActivity.skip_callback(:save, :after, :submit_to_stripe)
+        CurationActivity.skip_callback(:save, :after, :process_payment)
         @curation_activity1 = create(:curation_activity, resource: @resource)
         CurationActivity.set_callback(:create, :after, :submit_to_datacite)
         # these two never need to fire to test this example
@@ -67,7 +67,7 @@ module StashEngine
       end
 
       it "doesn't submit when status isn't changed" do
-        CurationActivity.skip_callback(:create, :after, :submit_to_datacite, :submit_to_stripe)
+        CurationActivity.skip_callback(:create, :after, :submit_to_datacite, :process_payment)
         @curation_activity2 = create(:curation_activity, resource: @resource, status: 'published')
         CurationActivity.set_callback(:create, :after, :submit_to_datacite)
 
@@ -105,7 +105,7 @@ module StashEngine
         @resource = create(:resource, identifier_id: @identifier.id, user: @user)
 
         CurationActivity.skip_callback(:create, :after, :update_solr)
-        CurationActivity.skip_callback(:save, :after, :submit_to_stripe)
+        CurationActivity.skip_callback(:save, :after, :process_payment)
         allow_any_instance_of(CurationActivity).to receive(:should_update_doi?).and_return(true)
 
         logger = double(ActiveSupport::Logger)

--- a/stash/stash_engine/spec/unit/models/curation_activity_spec.rb
+++ b/stash/stash_engine/spec/unit/models/curation_activity_spec.rb
@@ -43,10 +43,7 @@ module StashEngine
         @resource.update(current_resource_state_id: @resource_state.id)
         @version = create(:version, resource_id: @resource.id)
 
-        # @curation_activity = create(:curation_activity)
-        # @curation_activity.update(identifier_id: @identifier.id)
         @mock_idgen = spy('idgen')
-        # allow(@mock_idgen).to receive('update_identifier_metadata!'.intern).and_raise('submitted DOI')
         allow(@mock_idgen).to receive('update_identifier_metadata!'.intern) # .and_return('called make metadata')
         allow(Stash::Doi::IdGen).to receive(:make_instance).and_return(@mock_idgen)
 
@@ -56,9 +53,6 @@ module StashEngine
         CurationActivity.skip_callback(:save, :after, :process_payment)
         @curation_activity1 = create(:curation_activity, resource: @resource)
         CurationActivity.set_callback(:create, :after, :submit_to_datacite)
-        # these two never need to fire to test this example
-        # CurationActivity.set_callback(:create, :after, :update_solr)
-        # CurationActivity.set_callback(:save, :after, :submit_to_stripe)
       end
 
       it "doesn't submit when a status besides Embargoed or Published is set" do

--- a/stash/stash_engine/spec/unit/stash/payments/invoicer_spec.rb
+++ b/stash/stash_engine/spec/unit/stash/payments/invoicer_spec.rb
@@ -10,7 +10,8 @@ module Stash
       before(:each) do
         @identifier = double(StashEngine::Identifier)
         allow(@identifier).to receive(:to_s).and_return('doi:10.123/a1b.c2d3')
-        allow(@identifier).to receive(:invoice_id=)
+        allow(@identifier).to receive(:payment_id=)
+        allow(@identifier).to receive(:payment_type=)
         allow(@identifier).to receive(:save).and_return(true)
         allow(@identifier).to receive(:storage_size).and_return(5.01e+10.to_i)
 


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/573

Adds capability for storing and reporting on the type of payment that was associated with each published/embargoed item. 

Changes include:
- In `stash_engine_identifiers`, the `invoice_id` has been replaced by a `payment_type` and `payment_id`, to record the specific type of payment that was in effect when a dataset was approved by curators
- In `identifier.rb`, a new method `approval_date` calculates the date on which a dataset was first approved by curators (this is also the date on which payment was applied)
- A new rake task `identifiers:load_payment_info` will fill in payment information for previously-published datasets 
- A new rake task `identifiers:shopping_cart_report` will generate a report of published items and their payment status. This report defaults to reporting on the most recent complete month, but a report can be generated for any month using the YEAR_MONTH environment variable.

To test: 
1) Run the database migration
2) Deploy the code
3) Populate the payment fields in the database: `RAILS_ENV=local bundle exec rake identifiers:load_payment_info`
4) Run the report: `RAILS_ENV=local bundle exec rake identifiers:shopping_cart_report YEAR_MONTH=2019-11`