### PR TITLE
Shopping-cart-report: change ordering based on curator feedback

### DIFF
--- a/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -362,6 +362,8 @@ module StashEngine
       end
 
       it 'records an institution payment' do
+        allow(@identifier).to receive(:journal_will_pay?).and_return(false)
+        allow(@identifier).to receive(:publication_data).and_return('bogus_journal_data')
         allow(@identifier).to receive(:institution_will_pay?).and_return(true)
         @identifier.record_payment
         expect(@identifier.payment_type).to eq('institution')


### PR DESCRIPTION
Changing the ordering of some items that go into the shopping cart report:
- precedence of institutions vs journals when calculating who "pays" for a given submission
- approval_date should be the first resource that was published, not the most recent