### PR TITLE
Prevent error when autocompletes called with no parameter

### DIFF
--- a/stash/stash_datacite/app/controllers/stash_datacite/affiliations_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/affiliations_controller.rb
@@ -8,12 +8,15 @@ module StashDatacite
     # GET /affiliations/autocomplete
     def autocomplete
       partial_term = params['term']
-      return if partial_term.blank?
-      # clean the partial_term of unwanted characters so it doesn't cause errors when calling the ROR API
-      partial_term.gsub!(%r{[\/\-\\\(\)~!@%&"\[\]\^\:]}, ' ')
-      @affiliations = Stash::Organization::Ror.find_by_ror_name(partial_term)
-      list = map_affiliation_for_autocomplete(bubble_up_exact_matches(affil_list: @affiliations, term: partial_term))
-      render json: list
+      if partial_term.blank?
+        render json: nil
+      else
+        # clean the partial_term of unwanted characters so it doesn't cause errors when calling the ROR API
+        partial_term.gsub!(%r{[\/\-\\\(\)~!@%&"\[\]\^\:]}, ' ')
+        @affiliations = Stash::Organization::Ror.find_by_ror_name(partial_term)
+        list = map_affiliation_for_autocomplete(bubble_up_exact_matches(affil_list: @affiliations, term: partial_term))
+        render json: list
+      end
     end
 
     private

--- a/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -33,14 +33,16 @@ module StashDatacite
     # GET /publications/autocomplete?term={query_term}
     def autocomplete
       partial_term = params['term']
-      return if partial_term.blank?
-      # clean the partial_term of unwanted characters so it doesn't cause errors when calling the Journal API
-      partial_term.gsub!(%r{[\/\-\\\(\)~!@%&"\[\]\^\:]}, ' ')
-
-      response = HTTParty.get("#{APP_CONFIG.old_dryad_url}/api/v1/journals/search",
-                              query: { 'query': partial_term, 'count': 20 },
-                              headers: { 'Content-Type' => 'application/json' })
-      render json: response.body
+      if partial_term.blank?
+        render json: nil
+      else
+        # clean the partial_term of unwanted characters so it doesn't cause errors when calling the Journal API
+        partial_term.gsub!(%r{[\/\-\\\(\)~!@%&"\[\]\^\:]}, ' ')
+        response = HTTParty.get("#{APP_CONFIG.old_dryad_url}/api/v1/journals/search",
+                                query: { 'query': partial_term, 'count': 20 },
+                                headers: { 'Content-Type' => 'application/json' })
+        render json: response.body
+      end
     end
 
     # GET /publications/issn/{id}

--- a/stash/stash_datacite/app/controllers/stash_datacite/subjects_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/subjects_controller.rb
@@ -32,8 +32,12 @@ module StashDatacite
 
     # GET /subjects
     def autocomplete
-      @subjects = Subject.order(:subject).where('subject LIKE ?', "%#{params[:term]}%") unless params[:term].blank?
-      render json: @subjects.map(&:subject)
+      if params[:term].blank?
+        render json: nil
+      else
+        @subjects = Subject.order(:subject).where('subject LIKE ?', "%#{params[:term]}%")
+        render json: @subjects.map(&:subject)
+      end
     end
 
     # get subjects/landing(?params), for display of "keywords" on landing page


### PR DESCRIPTION
Web bots sometimes notices our endpoints for autocomplete and follow them. When they don't provide a `term` parameter, these endpoints were attempting to render an `autocomplete` view, and producing a 500 error, which would trigger an annoying email to devs.

This PR explicitly renders null for such requests, preventing any errors.

To test, note that the normal call is something like:
`http://datadryad.org/stash_datacite/publications/autocomplete?term=molecu`
while the bot call is usually something like:
`http://datadryad.org/stash_datacite/publications/autocomplete`