### PR TITLE
Curator search allows better control and fixes broken items

### DIFF
--- a/stash/stash_engine/app/controllers/stash_engine/resources_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/resources_controller.rb
@@ -6,6 +6,7 @@ module StashEngine
     before_action :require_modify_permission, except: %i[index new data_paper]
     before_action :require_in_progress, only: %i[upload review upload_manifest]
     before_action :lockout_incompatible_uploads, only: %i[upload upload_manifest]
+    before_action :update_internal_search, only: %i[upload review upload_manifest]
 
     attr_writer :resource
 
@@ -125,6 +126,11 @@ module StashEngine
         redirect_to upload_resource_path(resource)
         false
       end
+    end
+
+    # this is to be sure that our internal search index gets updated occasionally before full submission so search is better
+    def update_internal_search
+      @resource&.identifier&.update_search_words!
     end
 
   end

--- a/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
+++ b/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
@@ -96,8 +96,8 @@ module StashEngine
             #{SELECT_CLAUSE}
             #{relevance}
             #{FROM_CLAUSE}
-            #{build_where_clause(params.fetch(:q, ''), params.fetch(:all_advanced, false), params.fetch(:tenant, ''), params.fetch(:curation_status, ''),
-                                 params.fetch(:publication_name, ''))}
+            #{build_where_clause(params.fetch(:q, ''), params.fetch(:all_advanced, false), params.fetch(:tenant, ''),
+                                 params.fetch(:curation_status, ''), params.fetch(:publication_name, ''))}
             #{build_order_clause(column, params.fetch(:direction, ''), params.fetch(:q, ''))}
           "
           results = ActiveRecord::Base.connection.execute(query).map { |result| new(result) }
@@ -133,15 +133,16 @@ module StashEngine
         # modifiers, and if so just pass it through because they are likely a special person who knows what they're doing,
         # otherwise add plusses to all their words to make them required internally
         def advanced_search(terms)
-          if terms.match(/[~+<>*]/)
+          if /[~+<>*]/.match?(terms)
             terms
           else
-            terms&.split&.map{|i| "+\"#{i}\""}&.join(' ')
+            terms&.split&.map { |i| "+\"#{i}\"" }&.join(' ')
           end
         end
 
         # Create the ORDER BY portion of the query. If the user included a search term order by relevance first!
         # We cannot sort by author_names here, so ignore if that is the :sort_column
+        # rubocop:disable Metrics/CyclomaticComplexity
         def build_order_clause(column, direction, q)
           return 'ORDER BY title' if column == 'relevance' && q.blank?
 
@@ -151,6 +152,7 @@ module StashEngine
             (column.present? && column != 'author_names' ? "ORDER BY #{column} #{direction || 'ASC'}" : '')
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def sort_by_author_names(results, direction)
           multiply_by = (direction.casecmp('desc').zero? ? -1 : 1)

--- a/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
+++ b/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
@@ -96,7 +96,7 @@ module StashEngine
             #{SELECT_CLAUSE}
             #{relevance}
             #{FROM_CLAUSE}
-            #{build_where_clause(params.fetch(:q, ''), params.fetch(:all_advanced, false), params.fetch(:tenant_id, ''), params.fetch(:curation_status, ''),
+            #{build_where_clause(params.fetch(:q, ''), params.fetch(:all_advanced, false), params.fetch(:tenant, ''), params.fetch(:curation_status, ''),
                                  params.fetch(:publication_name, ''))}
             #{build_order_clause(column, params.fetch(:direction, ''), params.fetch(:q, ''))}
           "

--- a/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
+++ b/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
@@ -42,7 +42,8 @@ module StashEngine
           LEFT OUTER JOIN stash_engine_curation_activities seca ON seca.id = j3.latest_curation_activity_id
       SQL
 
-      SEARCH_CLAUSE = 'MATCH(sei.search_words) AGAINST(%{term}) > 05'
+      SEARCH_CLAUSE = 'MATCH(sei.search_words) AGAINST(%{term})'
+      BOOLEAN_SEARCH_CLAUSE = 'MATCH(sei.search_words) AGAINST(%{term} IN BOOLEAN MODE)'
       SCAN_CLAUSE = 'sei.search_words LIKE %{term}'
       TENANT_CLAUSE = 'ser.tenant_id = %{term}'
       STATUS_CLAUSE = 'seca.status = %{term}'
@@ -95,7 +96,7 @@ module StashEngine
             #{SELECT_CLAUSE}
             #{relevance}
             #{FROM_CLAUSE}
-            #{build_where_clause(params.fetch(:q, ''), params.fetch(:exact, false), params.fetch(:tenant_id, ''), params.fetch(:curation_status, ''),
+            #{build_where_clause(params.fetch(:q, ''), params.fetch(:all_advanced, false), params.fetch(:tenant_id, ''), params.fetch(:curation_status, ''),
                                  params.fetch(:publication_name, ''))}
             #{build_order_clause(column, params.fetch(:direction, ''), params.fetch(:q, ''))}
           "
@@ -107,9 +108,9 @@ module StashEngine
         private
 
         # Create the WHERE portion of the query based on the filters set by the user (if any)
-        def build_where_clause(search_term, exact, tenant_filter, status_filter, publication_filter)
+        def build_where_clause(search_term, all_advanced, tenant_filter, status_filter, publication_filter)
           where_clause = [
-            (search_term.present? ? build_search_clause(search_term, exact) : nil),
+            (search_term.present? ? build_search_clause(search_term, all_advanced) : nil),
             add_term_to_clause(TENANT_CLAUSE, tenant_filter),
             add_term_to_clause(STATUS_CLAUSE, status_filter),
             add_term_to_clause(PUBLICATION_CLAUSE, publication_filter)
@@ -118,9 +119,25 @@ module StashEngine
         end
 
         # Build the WHERE portion of the query for the specified search term (if any)
-        def build_search_clause(term, exact)
+        def build_search_clause(term, all_advanced)
           return '' unless term.present?
-          ( exact == '1' ? "(#{add_term_to_clause(SCAN_CLAUSE, "%#{term}%")})" : "(#{add_term_to_clause(SEARCH_CLAUSE, term)})" )
+
+          if all_advanced == '1'
+            "(#{add_term_to_clause(BOOLEAN_SEARCH_CLAUSE, advanced_search(term))})"
+          else
+            "(#{add_term_to_clause(SEARCH_CLAUSE, term)})"
+          end
+        end
+
+        # If someone is choosing 'all words' then default to boolean search and determine if they're using common
+        # modifiers, and if so just pass it through because they are likely a special person who knows what they're doing,
+        # otherwise add plusses to all their words to make them required internally
+        def advanced_search(terms)
+          if terms.match(/[~+<>*]/)
+            terms
+          else
+            terms&.split&.map{|i| "+\"#{i}\""}&.join(' ')
+          end
         end
 
         # Create the ORDER BY portion of the query. If the user included a search term order by relevance first!

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_edit_dataset_button.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_edit_dataset_button.html.erb
@@ -1,4 +1,4 @@
 <%= form_tag(metadata_entry_pages_new_version_path, method: :post) do -%>
   <button class="c-admin-edit-icon" title="Edit Dataset"><i class="fa fa-pencil" aria-hidden="true"></i></button>
-  <%= hidden_field_tag :resource_id, resource_id %>
+  <%= hidden_field_tag :resource_id, resource_id, id: "resource_id_#{resource_id}" %>
 <% end %>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_filter.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_filter.html.erb
@@ -7,17 +7,18 @@
   <label for="curation_status">Status:</label>
   <%= select_tag(:curation_status, options_for_select( [['Status', '']] + status_select, params[:curation_status]),
                  class: 'c-horizontal-form__input--status', onchange: "this.form.submit();" ) %>
+
   <% if @publications.any? %>
-  <p>
-    <label for="journal-name">Journal Name:</label>
-    <%= text_field_tag(:publication_name, @pub_name, class: 'c-horizontal-form__input--search', id: 'journal-name') %>
-  </p>
+    <p>
+      <label for="publication_name">Journal Name:</label>
+      <%= text_field_tag(:publication_name, params[:publication_name], class: 'c-horizontal-form__input--search', id: 'publication_name') %>
+    </p>
   <% end %>
   &nbsp;
   <a href="#" class="c-horizontal-form__input" id="filter_resetter">Reset all filters</a>
 
-  <% params.except(:controller, :action, :tenant, :curation_status, :commit, :page, :page_size, :show_all).each_pair do |k,v| %>
-    <%= hidden_field_tag k, v %>
+  <% params.except(:controller, :action, :tenant, :curation_status, :commit, :page, :page_size, :show_all, :publication_name).each_pair do |k,v| %>
+    <%= hidden_field_tag k, v, id: "filter_#{k}" %>
   <% end %>
 <% end -%>
 
@@ -28,7 +29,6 @@
     $("#tenant option[value='']").prop('selected',true);
     $("#curation_status option[value='']").prop('selected',true);
     $('#publication_name[type="text"]').val('');
-    $('#publication_name[type="hidden"]').val('');
     $("#filter_form").submit();
   });
 

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_filter.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_filter.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'index' }, method: 'get', id: 'filter_form' ) do -%>
-  <label for="tenant">Filter by:</div>
+  <label for="tenant" class="c-horizontal-form__input--filter-by">Filter by:</label>
   <% if current_user.superuser? %>
     <%= select_tag(:tenant, options_for_select( [['Institution', '']] + institution_select, params[:tenant]),
                    class: 'c-horizontal-form__input', onchange: "this.form.submit();" ) %>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_search.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_search.html.erb
@@ -12,7 +12,7 @@
     <a href="#" id="clear_search" class="c-horizontal-form__input">Clear Search</a>
 
     <% params.except(:controller, :action, :q, :commit, :page, :page_size, :show_all, :sort, :direction, :all_advanced).each_pair do |k,v| %>
-        <%= hidden_field_tag k, v %>
+        <%= hidden_field_tag k, v, id: "search_#{k}" %>
     <% end %>
   <% end %>
 </div>
@@ -22,7 +22,7 @@
   $("#clear_search").click(function(e) {
     e.preventDefault();
     $('#search-terms').val("");
-    $('#exact').prop("checked", false);
+    $('#all_advanced').prop("checked", false);
     $("#search_form").submit();
   });
 </script>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_search.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_search.html.erb
@@ -2,10 +2,16 @@
   <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'index' }, method: 'get', id: 'search_form' ) do %>
     <label for="search-terms">Search Terms:</label>
     <%= search_field_tag(:q, params[:q], class: 'c-horizontal-form__input--search', id: 'search-terms' ) %>
+    <%= hidden_field_tag(:sort, 'relevance') %>
+    <span class="c-horizontal-form__input">
+      &nbsp;
+      <%= check_box_tag(:exact, value = "1", checked = (params[:exact] == '1')) %>
+      <%= label_tag(:exact, 'Exact phrase') %>
+    </span>
     <%= submit_tag('Search', class: 'c-horizontal-form__input' ) %>
     <a href="#" id="clear_search" class="c-horizontal-form__input">Clear Search</a>
 
-    <% params.except(:controller, :action, :q, :commit, :page, :page_size, :show_all).each_pair do |k,v| %>
+    <% params.except(:controller, :action, :q, :commit, :page, :page_size, :show_all, :sort, :direction, :exact).each_pair do |k,v| %>
         <%= hidden_field_tag k, v %>
     <% end %>
   <% end %>
@@ -15,7 +21,8 @@
   // put this in here because it goes along with this form only
   $("#clear_search").click(function(e) {
     e.preventDefault();
-    $('#q').val("");
+    $('#search-terms').val("");
+    $('#exact').prop("checked", false);
     $("#search_form").submit();
   });
 </script>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_search.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_search.html.erb
@@ -5,13 +5,13 @@
     <%= hidden_field_tag(:sort, 'relevance') %>
     <span class="c-horizontal-form__input">
       &nbsp;
-      <%= check_box_tag(:exact, value = "1", checked = (params[:exact] == '1')) %>
-      <%= label_tag(:exact, 'Exact phrase') %>
+      <%= check_box_tag(:all_advanced, value = "1", checked = (params[:all_advanced] == '1')) %>
+      <%= label_tag(:all_advanced, 'All terms') %> <sup>&dagger;</sup>
     </span>
     <%= submit_tag('Search', class: 'c-horizontal-form__input' ) %>
     <a href="#" id="clear_search" class="c-horizontal-form__input">Clear Search</a>
 
-    <% params.except(:controller, :action, :q, :commit, :page, :page_size, :show_all, :sort, :direction, :exact).each_pair do |k,v| %>
+    <% params.except(:controller, :action, :q, :commit, :page, :page_size, :show_all, :sort, :direction, :all_advanced).each_pair do |k,v| %>
         <%= hidden_field_tag k, v %>
     <% end %>
   <% end %>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
@@ -20,9 +20,11 @@
 
   <p>
     &dagger; By default the search uses relevance ranking and not all terms are required.  Choosing the <em>All terms</em>
-    option requires all the terms in your query to be present.  If you prefer to do an advanced query, select <em>All terms</em>
-    and add any one of the following characters &quot;~ + < > *&quot; while following the syntax such as
-    <a href="https://dev.mysql.com/doc/refman/5.5/en/fulltext-boolean.html">described here</a>.
+    option requires all the terms in your query to be present in the results.  If you prefer to do an advanced query
+    with more fine-grained options, select <em>All terms</em>
+    and add any of (<em>~ + < > *</em>) that are commonly part of
+    <a href="https://dev.mysql.com/doc/refman/5.5/en/fulltext-boolean.html">the boolean query syntax</a> to use that
+    syntax.
   </p>
 </div>
 

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
@@ -17,6 +17,13 @@
   <div>
     <%= link_to 'Get Comma Separated Values (CSV) for import into Excel', params.merge(format: :csv) %>
   </div>
+
+  <p>
+    &dagger; By default the search uses relevance ranking and not all terms are required.  Choosing the <em>All terms</em>
+    option requires all the terms in your query to be present.  If you prefer to do an advanced query, select <em>All terms</em>
+    and add any one of the following characters &quot;~ + < > *&quot; while following the syntax such as
+    <a href="https://dev.mysql.com/doc/refman/5.5/en/fulltext-boolean.html">described here</a>.
+  </p>
 </div>
 
 <div id="popup_dialog" style="display:none;">

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -232,5 +232,25 @@ namespace :identifiers do
     p "Finished: #{Time.now.utc}"
   end
 
+  desc 'update search words for items that are obviously missing them'
+  task update_missing_search_words: :environment do
+    identifiers = StashEngine::Identifier.where('LENGTH(search_words) < 60 OR search_words IS NULL')
+    puts "Updating search words for #{identifiers.length} items"
+    identifiers.each_with_index do |id, idx|
+      id&.update_search_words!
+      puts "Updated #{idx + 1}/#{identifiers.length} items" if (idx + 1) % 100 == 0
+    end
+  end
+
+  desc 'update search words for all items (in case we need to refresh them all)'
+  task update_all_search_words: :environment do
+    identifiers = StashEngine::Identifier.all
+    puts "Updating search words for #{identifiers.length} items"
+    identifiers.each_with_index do |id, idx|
+      id&.update_search_words!
+      puts "Updated #{idx + 1}/#{identifiers.length} items" if (idx + 1) % 100 == 0
+    end
+  end
+
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
These are the changes here and how to test. (I'm adding a cron in the other repository, also.)

- When searching for keywords it orders by relevance ( tf/idf ) after a search is done until another sort order is chosen.
- Added *All terms* checkbox which makes every word typed in the box required (AND query).  It also makes matches exactly so useful for things like DOI search so it doesn't tokenize at the slash, dot or other weird places and match a lot of items.
- *All terms* also allows MySQL specialized search syntax and reverts to that if people use some special characters like the plus sign. (See note at bottom of the page)
- Clear search and reset filters fixed.
- Filter by for tenant fixed and works.
- Journal name autocomplete/filter fixed.  It allows limiting to a subset of journals within the current results as Brian implemented it.