### PR TITLE
Autocomplete: non-controlled journal names

### DIFF
--- a/stash/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
+++ b/stash/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
@@ -37,6 +37,10 @@ function loadPublications() {
 		    });
 		},
                 source: function (request, response) {
+		    // save the user's typed request in the database with an asterisk, in case they don't click on an autocomplete result
+		    document.getElementById("internal_datum_publication_name").value = request.term + "*";
+		    var form = $(this.form);
+                    $(form).trigger('submit.rails');
 		    $.ajax({
 			url: "/stash_datacite/publications/autocomplete",
                         dataType: "json",
@@ -70,16 +74,10 @@ function loadPublications() {
                     previous_label = new_label;
                 },
                 change: function( event, ui ) {
-                    // clear out the publication info if the user removes the value
-                    if(!ui.item) {
-                        document.getElementById("internal_datum_publication_name").value = '';
-                        document.getElementById("internal_datum_publication_issn").value = '';
-                        var form = $(this.form);
-                        $(form).trigger('submit.rails');
-                    }
-                },
+		    // do nothing
+		},
                 focus: function() {
-                    // prevent value inserted on focus
+                    // prevent value inserted on focus		    
                     return false;
                 },
             });

--- a/stash/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
+++ b/stash/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
@@ -23,24 +23,24 @@ function loadPublications() {
 		// or internal_datum_publication_name will have a text value, so use one of 
 		// these values to fill in the journal title
 		create: function(a) {
-		    if(document.getElementById("internal_datum_publication_issn").value){
+		    if($("#internal_datum_publication_issn").val()){
 			$.ajax({
-                            url: "/stash_datacite/publications/issn/"+ document.getElementById("internal_datum_publication_issn").value,
+                            url: "/stash_datacite/publications/issn/"+ $("#internal_datum_publication_issn").val(),
                             dataType: "json",
                             success: function( data ) {
-				document.getElementById("internal_datum_publication").value = ""
+				$("#internal_datum_publication").val("")
 				if (data.fullName != null) {
-				    document.getElementById("internal_datum_publication").value = data.fullName;
+				    $("#internal_datum_publication").val(data.fullName);
 				}
 			    }
 			});
-		    } else if(document.getElementById("internal_datum_publication_name").value){
-			document.getElementById("internal_datum_publication").value = document.getElementById("internal_datum_publication_name").value
+		    } else if($("#internal_datum_publication_name").val()){
+			$("#internal_datum_publication").val($("#internal_datum_publication_name").val())
 		    }
 		},
                 source: function (request, response) {
 		    // save the user's typed request in the database with an asterisk, in case they don't click on an autocomplete result
-		    document.getElementById("internal_datum_publication_name").value = request.term + "*";
+		    $("#internal_datum_publication_name").val(request.term + "*");
 		    var form = $(this.form);
                     $(form).trigger('submit.rails');
 		    $.ajax({
@@ -67,8 +67,8 @@ function loadPublications() {
                 select: function( event, ui ) {
                     new_value = ui.item.value;
                     new_label = ui.item.label;
-                    document.getElementById("internal_datum_publication_issn").value = new_value;
-                    document.getElementById("internal_datum_publication_name").value = new_label;
+                    $("#internal_datum_publication_issn").val(new_value);
+                    $("#internal_datum_publication_name").val(new_label);
                     ui.item.value = ui.item.label;
                     var form = $(this.form);
                     $(form).trigger('submit.rails');

--- a/stash/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
+++ b/stash/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
@@ -19,22 +19,24 @@ function loadPublications() {
             })
             .autocomplete({
 		// when page is loaded, IF the dataset has been filled in already,
-		// internal_datum_publication will have an ISSN, so use this ISSN
-		// to look up the journal title
+		// internal_datum_publication will have an ISSN (for a controlled value),
+		// or internal_datum_publication_name will have a text value, so use one of 
+		// these values to fill in the journal title
 		create: function(a) {
-		    if(!document.getElementById("internal_datum_publication").value){
-			return;
-		    }
-                    $.ajax({
-                        url: "/stash_datacite/publications/issn/"+ document.getElementById("internal_datum_publication").value,
-                        dataType: "json",
-                        success: function( data ) {
-                            document.getElementById("internal_datum_publication").value = ""
-                            if (data.fullName != null) {
-				document.getElementById("internal_datum_publication").value = data.fullName;
+		    if(document.getElementById("internal_datum_publication_issn").value){
+			$.ajax({
+                            url: "/stash_datacite/publications/issn/"+ document.getElementById("internal_datum_publication_issn").value,
+                            dataType: "json",
+                            success: function( data ) {
+				document.getElementById("internal_datum_publication").value = ""
+				if (data.fullName != null) {
+				    document.getElementById("internal_datum_publication").value = data.fullName;
+				}
 			    }
-			}
-		    });
+			});
+		    } else if(document.getElementById("internal_datum_publication_name").value){
+			document.getElementById("internal_datum_publication").value = document.getElementById("internal_datum_publication_name").value
+		    }
 		},
                 source: function (request, response) {
 		    // save the user's typed request in the database with an asterisk, in case they don't click on an autocomplete result
@@ -111,26 +113,26 @@ function loadPublications() {
 // show and hide things for clicking by user for pretty form making
 function setPublicationChoiceDisplay(chosen){
     switch(chosen) {
-        case 'manuscript':
-            $(".js-doi-section").hide();
-            $(".js-ms-section").show();
-            $(".c-import__form-section").show();
-            $(".js-other-info").hide();
-            $(".js-populate-submit").val("Import Manuscript Metadata");
-            $("#choose_manuscript").prop("checked", true);
-            break;
-        case 'published':
-            $(".js-ms-section").hide();
-            $(".js-doi-section").show()
-            $(".c-import__form-section").show();
-            $(".js-other-info").hide();
-            $(".js-populate-submit").val("Import Article Metadata");
-            $("#choose_published").prop("checked", true);
-            break;
-        default:
-            $(".c-import__form-section").hide();
-            $(".js-other-info").show();
-            $("#choose_other").prop("checked", true);
+    case 'published':
+        $(".js-ms-section").hide();
+        $(".js-doi-section").show()
+        $(".c-import__form-section").show();
+        $(".js-other-info").hide();
+        $(".js-populate-submit").val("Import Article Metadata");
+        $("#choose_published").prop("checked", true);
+        break;
+    case 'manuscript':
+        $(".js-doi-section").hide();
+        $(".js-ms-section").show();
+        $(".c-import__form-section").show();
+        $(".js-other-info").hide();
+        $(".js-populate-submit").val("Import Manuscript Metadata");
+        $("#choose_manuscript").prop("checked", true);
+        break;
+    default:
+        $(".c-import__form-section").hide();
+        $(".js-other-info").show();
+        $("#choose_other").prop("checked", true);
     }
 }
 

--- a/stash/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
@@ -8,7 +8,8 @@ module StashDatacite
       @metadata_entry = Resource::MetadataEntry.new(@resource, current_tenant)
       @metadata_entry.resource_type
       se_id = StashEngine::Identifier.find(@resource.identifier_id)
-      @publication = StashEngine::InternalDatum.find_or_initialize_by(stash_identifier: se_id, data_type: 'publicationISSN')
+      @publication_issn = StashEngine::InternalDatum.find_or_initialize_by(stash_identifier: se_id, data_type: 'publicationISSN')
+      @publication_name = StashEngine::InternalDatum.find_or_initialize_by(stash_identifier: se_id, data_type: 'publicationName')
       @msid = StashEngine::InternalDatum.find_or_initialize_by(stash_identifier: se_id, data_type: 'manuscriptNumber')
       @doi = StashDatacite::RelatedIdentifier.find_or_initialize_by(resource_id: @resource.id, related_identifier_type: 'doi',
                                                                     relation_type: 'issupplementto')

--- a/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
@@ -1,5 +1,5 @@
 <p id="import-choices-label">My data is related to:</p>
-<%= form_for(@publication, url: publications_update_path, method: :patch, remote: true, authenticity_token: true) do |f| %>
+<%= form_for(@publication_issn, url: publications_update_path, method: :patch, remote: true, authenticity_token: true) do |f| %>
 	<div class="c-import__choicesbox js-import-choice" role="group" aria-labelledby="import-choices-label">
 		<div class="c-import__choicebox">
 			<div class="c-import__icon"><i class="fa fa-pencil-square-o fa-3x"></i></div>
@@ -33,16 +33,16 @@
 		<div class="c-input__inline">
 			<div class="c-input">
 				<%= f.label "publication", 'Journal Name', class: 'c-input__label' %>
-				<%= f.text_field :publication, value: @publication.value, class: "js-publications c-input__text" %>
+			        <%= f.text_field :publication, value: @publication_name.value, class: "js-publications c-input__text" %>
 				<%= f.hidden_field :identifier_id, value: @resource.identifier_id %>
 				<%= f.hidden_field :resource_id, value: @resource.id %>
-				<%= f.hidden_field :publication_issn, value: @publication.value %>
-				<%= f.hidden_field :publication_name, value: @publication.value %>
+				<%= f.hidden_field :publication_issn, value: @publication_issn.value %>
+				<%= f.hidden_field :publication_name, value: @publication_name.value %>
 				<%= f.hidden_field :do_import, value: 'false' %>
 			</div>
 			<div class="c-input js-ms-section">
 				<%= f.label "msid", 'Manuscript Number', class: 'c-input__label' %>
-				<%= f.text_field :msid, value: @msid.value, class: "js-msid c-input__text", placeholder: 'APPS-D-17-00113' %>
+			        <%= f.text_field :msid, value: @msid.value, class: "js-msid c-input__text", placeholder: 'APPS-D-17-00113' %>
 			</div>
 			<div class="c-input js-doi-section">
 				<%= f.label "doi", 'DOI', class: 'c-input__label' %>

--- a/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
@@ -64,10 +64,8 @@
 <script>
 	<% if !@doi&.related_identifier.blank? %>
   	setPublicationChoiceDisplay('published');
-	<% elsif !@msid&.value.blank? %>
-  	setPublicationChoiceDisplay('manuscript');
 	<% else %>
-  	setPublicationChoiceDisplay('other');
+  	setPublicationChoiceDisplay('manuscript');
 	<% end %>
 </script>
 


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/627 and the first (journal) part of https://github.com/CDL-Dryad/dryad-product-roadmap/issues/622.

This improves the behavior when a user types a value in the submission system's journal autocomplete box and *doesn't* select a value from the dropdown list. Previously, the typed name would be lost. Now, the name is saved to the database, with an asterisk appended. When the page is later viewed, that same name is displayed. However, if the user had previously selected a controlled value from the list, which was internally stored with the ISSN, the name of that journal takes precedence.