### PR TITLE
Changes to pre-populate usage by script and only use from the database

### DIFF
--- a/stash/stash_engine/app/models/stash_engine/counter_citation.rb
+++ b/stash/stash_engine/app/models/stash_engine/counter_citation.rb
@@ -1,6 +1,6 @@
 module StashEngine
   class CounterCitation < ActiveRecord::Base
-    # belongs_to :identifier, class_name: 'StashEngine::Identifier'
+    belongs_to :identifier, class_name: 'StashEngine::Identifier'
 
     # this class caches the counter_citations so it doesn't take so long to get them all
 

--- a/stash/stash_engine/app/models/stash_engine/counter_citation.rb
+++ b/stash/stash_engine/app/models/stash_engine/counter_citation.rb
@@ -6,21 +6,21 @@ module StashEngine
 
     def self.citations(stash_identifier:)
       cite_events = Stash::EventData::Citations.new(doi: stash_identifier.identifier)
-      logger.debug('before getting citation events')
+      # logger.debug('before getting citation events')
       dois = cite_events.results
-      logger.debug('after getting citation events')
+      # logger.debug('after getting citation events')
       dois.map do |citation_event|
-        citation_metadata(doi: citation_event)
+        citation_metadata(doi: citation_event, stash_identifier: stash_identifier)
       end
     end
 
-    def self.citation_metadata(doi:)
+    def self.citation_metadata(doi:, stash_identifier:)
       # check for cached citation
       cites = where(doi: doi)
       return cites.first unless cites.blank?
 
       datacite_metadata = Stash::DataciteMetadata.new(doi: doi)
-      create(citation: datacite_metadata.html_citation, doi: doi)
+      create(citation: datacite_metadata.html_citation, doi: doi, identifier_id: stash_identifier.id)
     end
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/counter_stat.rb
+++ b/stash/stash_engine/app/models/stash_engine/counter_stat.rb
@@ -5,18 +5,20 @@ module StashEngine
     # this class wraps around some database accessors to cache them so we don't query the same stats more than once
     # per day because that is the max time that we update stats
 
+    # all these "check" methods may be obsolete if we do scripts for population of everything ahead.  See note
+    # above update_if_necessary for details of our fun with datacite.
     def check_unique_investigation_count
-      update_if_necessary
+      # update_if_necessary
       unique_investigation_count
     end
 
     def check_unique_request_count
-      update_if_necessary
+      # update_if_necessary
       unique_request_count
     end
 
     def check_citation_count
-      update_if_necessary
+      # update_if_necessary
       citation_count
     end
 
@@ -25,6 +27,10 @@ module StashEngine
     # or this one has machine hits, I think.  doi:10.6086/D1H59V
     #
     # but unfortunately, we can really only display stats against production
+    #
+    # We are no longer using this until we have everything working with DataCite correctly.
+    # Also we are probably moving to a script to populate citations and data ahead since they want them as part of instant reporting.
+    # Will leave in for now, but can probably be removed if that is the permanent way we do things.
     def update_if_necessary
       # we should have a counter stat already if it got to this class
       # only update stats if it's a later calendar week than this record was updated
@@ -32,7 +38,7 @@ module StashEngine
 
       # do no update the usage data until we can successfully get all of our reports in to DataCite in order to pull them back
       # update_usage!
-      update_citation_count!
+      # update_citation_count!
       self.updated_at = Time.new.utc # seem to need this for some reason, since not always updating automatically
       save!
     end

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -10,6 +10,7 @@ module StashEngine
     has_many :external_references, class_name: 'StashEngine::ExternalReference', dependent: :destroy
     # there are places we may have more than one from our old versions
     has_many :shares, class_name: 'StashEngine::Share', dependent: :destroy
+    has_many :cached_citations, class_name: 'StashEngine::CounterCitation', dependent: :destroy
     has_one :latest_resource,
             class_name: 'StashEngine::Resource',
             primary_key: 'latest_resource_id',

--- a/stash/stash_engine/app/views/stash_engine/landing/_citations.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/landing/_citations.html.erb
@@ -1,6 +1,6 @@
 <%# takes a local identifier AR object #%>
 <h3>Works Referencing This Dataset</h3>
-<% identifier.citations.each do |cite| %>
+<% identifier.cached_citations.each do |cite| %>
   <p>
     <% if cite.citation.blank? %>
       <%= "Citation metadata for #{cite.doi} was not available from DataCite." %>

--- a/stash/stash_engine/app/views/stash_engine/landing/_metrics.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/landing/_metrics.html.erb
@@ -21,11 +21,11 @@
     <!-- <span class="o-metrics__label">citations</span> -->
   </div>
   <div class="o-metrics__number" id="metrics_citation_count">
-    <% if identifier.counter_stat.check_citation_count > 0 %>
-      <%= link_to "#{identifier.counter_stat.check_citation_count} citations", stash_url_helpers.show_citations_path(identifier_id: identifier.id),
+    <% if identifier.counter_stat.citation_count > 0 %>
+      <%= link_to "#{identifier.counter_stat.citation_count} citations", stash_url_helpers.show_citations_path(identifier_id: identifier.id),
                   id: 'citation_link', remote: true %>
     <% else %>
-      <%= identifier.counter_stat.check_citation_count %> citations
+      <%= identifier.counter_stat.citation_count %> citations
     <% end %>
   </div>
   <div class="o-metrics__number" id="metrics_citation_spinner" style="display: none;">

--- a/stash/stash_engine/db/migrate/20200121221800_add_citation_updated_to_stash_engine_counter_stats.rb
+++ b/stash/stash_engine/db/migrate/20200121221800_add_citation_updated_to_stash_engine_counter_stats.rb
@@ -1,0 +1,6 @@
+class AddCitationUpdatedToStashEngineCounterStats < ActiveRecord::Migration
+  def change
+    # give an old default so it will out of date and be rechecked
+    add_column :stash_engine_counter_stats, :citation_updated, :datetime, default: '2018-01-01'
+  end
+end

--- a/stash/stash_engine/db/migrate/20200121235923_add_identifier_id_to_counter_citation.rb
+++ b/stash/stash_engine/db/migrate/20200121235923_add_identifier_id_to_counter_citation.rb
@@ -1,0 +1,6 @@
+class AddIdentifierIdToCounterCitation < ActiveRecord::Migration
+  def change
+    add_column :stash_engine_counter_citations, :identifier_id, :integer
+    add_index :stash_engine_counter_citations, :identifier_id
+  end
+end

--- a/stash/stash_engine/lib/stash/datacite_metadata.rb
+++ b/stash/stash_engine/lib/stash/datacite_metadata.rb
@@ -25,7 +25,7 @@ module Stash
       return nil if @metadata == false
       response = RestClient.get "#{DATACITE_BASE}#{CGI.escape(@doi)}", accept: 'application/citeproc+json'
       @metadata = JSON.parse(response.body)
-    rescue RestClient::Exception => ex
+    rescue RestClient::Exception, Errno::ECONNREFUSED => ex
       logger.error("#{Time.new.utc} Could not get response from DataCite for metadata lookcup #{@doi}")
       logger.error("#{Time.new.utc} #{ex}")
       @metadata = false

--- a/stash/stash_engine/lib/tasks/counter.rake
+++ b/stash/stash_engine/lib/tasks/counter.rake
@@ -54,10 +54,10 @@ namespace :counter do
     StashEngine::CounterStat.delete_all
   end
 
-  desc 'task to populate in citation information'
+  desc 'task to populate in citation information that has not been cached'
   task populate_citations: :environment do
     puts "Run to update citations at #{Time.new}"
-    identifiers = StashEngine::Identifier.where(pub_state: [:published, :embargoed])
+    identifiers = StashEngine::Identifier.where(pub_state: %i[published embargoed])
 
     identifiers.each_with_index do |identifier, idx|
       puts "Updated #{idx + 1}/#{identifiers.length}" if (idx + 1) % 100 == 0

--- a/stash/stash_engine/lib/tasks/counter.rake
+++ b/stash/stash_engine/lib/tasks/counter.rake
@@ -54,6 +54,11 @@ namespace :counter do
     StashEngine::CounterStat.delete_all
   end
 
+  desc 'task to populate in citation information'
+  task populate_citations: :environment do
+    # TODO: fill in
+  end
+
   desc 'test that environment is passed in'
   task :test_env do
     puts "LOG_DIRECTORY is set as #{ENV['LOG_DIRECTORY']}" if ENV['LOG_DIRECTORY']

--- a/stash/stash_engine/lib/tasks/counter.rake
+++ b/stash/stash_engine/lib/tasks/counter.rake
@@ -56,7 +56,22 @@ namespace :counter do
 
   desc 'task to populate in citation information'
   task populate_citations: :environment do
-    # TODO: fill in
+    puts "Run to update citations at #{Time.new}"
+    identifiers = StashEngine::Identifier.where(pub_state: [:published, :embargoed])
+
+    identifiers.each_with_index do |identifier, idx|
+      puts "Updated #{idx + 1}/#{identifiers.length}" if (idx + 1) % 100 == 0
+
+      counter_stat = identifier.counter_stat
+      next if counter_stat.citation_updated > 30.days.ago # only do this expensive operation once a month, so skip if it's been checked lately
+
+      # identifier.citations automatically checks and caches new ones as needed
+      citations = identifier.citations
+
+      counter_stat.citation_count = citations.length
+      counter_stat.citation_updated = Time.new
+      counter_stat.save!
+    end
   end
 
   desc 'test that environment is passed in'

--- a/stash/stash_engine/spec/db/stash_engine/counter_stat_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/counter_stat_spec.rb
@@ -44,12 +44,12 @@ module StashEngine
     end
 
     describe :check_citation_count do
-      it 'updates counts if from before this week' do
+      xit 'updates counts if from before this week' do
         cs = @identifier.counter_stat
         expect(cs.check_citation_count).to eq(2)
       end
 
-      it "doesn't update counts if from this week" do
+      xit "doesn't update counts if from this week" do
         cs = @identifier.counter_stat
         cs.update(updated_at: Time.new)
         expect(cs.check_citation_count).to eq(5)


### PR DESCRIPTION
This is part of https://github.com/CDL-Dryad/dryad-product-roadmap/issues/617 .

I'm currently pre-populating stats for development and this script will populate the stats into our database.

It adds some fields to the database such as a timestamp for the last time citations were updated.  Also adds in a foreign key for citations and the identifier table so they are easier to link together.

Script will run through and pre-populate all the citation stuff from external APIs which are already embedded in some of our method calls that formerly did it live and cached.

Before we do it on production, will need to deploy code (or at least update the database migration there) because of database additions.