### PR TITLE
Autocomplete: non-controlled affiliations

### DIFF
--- a/spec/features/stash_datacite/affiliation_autofill_spec.rb
+++ b/spec/features/stash_datacite/affiliation_autofill_spec.rb
@@ -25,6 +25,7 @@ RSpec.feature 'AffiliationAutofill', type: :feature do
     end
 
     it 'sets the ROR id when user selects an option', js: true do
+      stub_ror_id_lookup(university: 'University of Testing v2')
       fill_in 'author[affiliation][long_name]', with: 'Testing'
       first('.ui-menu-item-wrapper', wait: 5).click
       expect(find('#author_affiliation_ror_id', visible: false).value).to eql('https://ror.org/TEST2')

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -42,7 +42,7 @@ module StashApi
         expect(hsh[:abstract]).to eq(output[:abstract])
         in_author = hsh[:authors].first
         out_author = output[:authors].first
-        expect(in_author.email).to eq(out_author.email)
+        expect(in_author[:email]).to eq(out_author[:email])
       end
 
       it 'creates a new basic dataset with a placename' do

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -42,7 +42,7 @@ module StashApi
         expect(hsh[:abstract]).to eq(output[:abstract])
         in_author = hsh[:authors].first
         out_author = output[:authors].first
-        expect(in_author).to eq(out_author)
+        expect(in_author.email).to eq(out_author.email)
       end
 
       it 'creates a new basic dataset with a placename' do

--- a/stash/stash_datacite/app/controllers/stash_datacite/authors_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/authors_controller.rb
@@ -71,10 +71,12 @@ module StashDatacite
     end
 
     def process_affiliation
+      logger.info("-----------process_affil")
       return nil unless @author.present?
 
       args = author_params
       affil = StashDatacite::Affiliation.from_long_name(args['affiliation']['long_name'])
+      logger.info("------------ affil = #{affil.to_json}")
       args['affiliation']['id'] = affil.id unless affil.blank?
 
       # This would not be necessary if the relationship between author and affiliations

--- a/stash/stash_datacite/app/controllers/stash_datacite/authors_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/authors_controller.rb
@@ -74,7 +74,11 @@ module StashDatacite
       return nil unless @author.present?
 
       args = author_params
-      affil = StashDatacite::Affiliation.from_long_name(args['affiliation']['long_name'])
+      affil = if args['affiliation']['ror_id'].present?
+                StashDatacite::Affiliation.from_ror_id(args['affiliation']['ror_id'])
+              else
+                StashDatacite::Affiliation.from_long_name(args['affiliation']['long_name'])
+              end
       args['affiliation']['id'] = affil.id unless affil.blank?
 
       # This would not be necessary if the relationship between author and affiliations

--- a/stash/stash_datacite/app/controllers/stash_datacite/authors_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/authors_controller.rb
@@ -71,12 +71,10 @@ module StashDatacite
     end
 
     def process_affiliation
-      logger.info("-----------process_affil")
       return nil unless @author.present?
 
       args = author_params
       affil = StashDatacite::Affiliation.from_long_name(args['affiliation']['long_name'])
-      logger.info("------------ affil = #{affil.to_json}")
       args['affiliation']['id'] = affil.id unless affil.blank?
 
       # This would not be necessary if the relationship between author and affiliations

--- a/stash/stash_datacite/app/models/stash_datacite/affiliation.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/affiliation.rb
@@ -43,12 +43,12 @@ module StashDatacite
     # asterisk on the name, so we know it is not associated with ROR.
     def self.from_long_name(long_name)
       return nil if long_name.blank?
-      
+
       affil = find_or_initialize_by_long_name(long_name)
       return affil if affil.ror_id.present?
 
       # The record didn't exist in ROR so return it with the asterisk
-      affil.long_name = affil.long_name + "*"
+      affil.long_name = affil.long_name + '*'
       affil
     end
 

--- a/stash/stash_datacite/app/models/stash_datacite/affiliation.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/affiliation.rb
@@ -60,7 +60,7 @@ module StashDatacite
       return db_affils.first if db_affils.any?
 
       ror_org = Stash::Organization::Ror.find_by_ror_id(ror_id)
-      Affiliation.new(long_name: ror_org.name, ror_id: ror_id)
+      Affiliation.new(long_name: ror_org&.name, ror_id: ror_id)
     rescue Stash::Organization::RorError
       nil
     end

--- a/stash/stash_datacite/app/models/stash_datacite/affiliation.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/affiliation.rb
@@ -45,10 +45,10 @@ module StashDatacite
       return nil if long_name.blank?
 
       db_affils = Affiliation.where('LOWER(long_name) = LOWER(?)', long_name) +
-                  Affiliation.where('LOWER(long_name) = LOWER(?)', long_name + '*')
+                  Affiliation.where('LOWER(long_name) = LOWER(?)', "#{long_name}*")
       return db_affils.first if db_affils.any?
 
-      Affiliation.new(long_name: long_name + '*')
+      Affiliation.new(long_name: "#{long_name}*")
     end
 
     # Get an affiliation by ror_id. We prefer to reuse an existing affiliation

--- a/stash/stash_datacite/app/models/stash_datacite/affiliation.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/affiliation.rb
@@ -53,7 +53,6 @@ module StashDatacite
     end
 
     def self.find_or_initialize_by_long_name(long_name)
-      logger.info("-----fOIBLn #{long_name}")
       affil = Affiliation.where('LOWER(long_name) = LOWER(?)', long_name)
       (affil.any? ? affil.first : Affiliation.new(long_name: long_name))
     end

--- a/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
@@ -19,9 +19,9 @@
 	 .autocomplete({
              source: function (request, response) {
 		 // save the user's typed request, in case they don't click on an autocomplete result
-		 $('<%= "##{form_id}" %> #author_affiliation_typed_name').val(request.term);
-		 var form = $(this).parents('form');
-		 $(form).trigger('submit.rails');
+		 // $('<%= "##{form_id}" %> #author_affiliation_typed_name').val(request.term);
+		 //var form = $(this).parents('form');
+		 //$(form).trigger('submit.rails');
 		 $.ajax({
 		     url: "<%= stash_datacite.affiliations_autocomplete_path %>",
 		     dataType: "json",
@@ -46,6 +46,9 @@
              select: function (event, ui) {
 		 $('<%= "##{form_id}" %> #author_affiliation_ror_id').val(ui.item.id); // set hidden field ror_id
 		 $('<%= "##{form_id}" %> #author_affiliation_id').val(''); // clear the hidden field id for the affiliation object
+		 var form = $(this).parents('form');
+		 $(form).trigger('submit.rails');
+		 var savedval = $('<%= "##{form_id}" %> #author_affiliation_ror_id').val();
              },
              open: function (event, ui) {
              },

--- a/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
@@ -18,10 +18,8 @@
 	 })
 	 .autocomplete({
              source: function (request, response) {
-		 console.log("source")
 		 // save the user's typed request, in case they don't click on an autocomplete result
 		 $('<%= "##{form_id}" %> #author_affiliation_typed_name').val(request.term);
-		 console.log("form_id", form_id)
 		 var form = $(this).parents('form');
 		 $(form).trigger('submit.rails');
 		 $.ajax({
@@ -46,24 +44,17 @@
 		 return false;
              },
              select: function (event, ui) {
-		 console.log("select")
 		 $('<%= "##{form_id}" %> #author_affiliation_ror_id').val(ui.item.id); // set hidden field ror_id
-		 $('<%= "##{form_id}" %> #author_affiliation_id').val(''); // clear the hidden field id
-		 console.log(ui.item.id)
+		 $('<%= "##{form_id}" %> #author_affiliation_id').val(''); // clear the hidden field id for the affiliation object
              },
              open: function (event, ui) {
-		 console.log("open")
              },
              close: function (event, ui) {
-		 console.log("close")
 		 $(this).focus();
              },
 	     change: function( event, ui ) {
-		 // do nothing
 	     }
 	 }).blur(function (event) {
-	     console.log("blur")
-	     console.log("blursave")
 	     var form = $(this).parents('form');
 	     $(form).trigger('submit.rails');
 	 });

--- a/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
@@ -18,10 +18,6 @@
 	 })
 	 .autocomplete({
              source: function (request, response) {
-		 // save the user's typed request, in case they don't click on an autocomplete result
-		 // $('<%= "##{form_id}" %> #author_affiliation_typed_name').val(request.term);
-		 //var form = $(this).parents('form');
-		 //$(form).trigger('submit.rails');
 		 $.ajax({
 		     url: "<%= stash_datacite.affiliations_autocomplete_path %>",
 		     dataType: "json",

--- a/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
@@ -1,63 +1,71 @@
 <%= form.fields_for :affiliation, author.affiliation do |affil_fields| %>
-  <%= affil_fields.label :long_name, "Institutional Affiliation", class: 'c-input__label required' %>
-  <%= affil_fields.text_field(:long_name, class: 'c-input__text js-affiliation') %>
-
-  <%= affil_fields.hidden_field :id %>
-  <%= affil_fields.hidden_field :ror_id, class: 'js-affiliation_id' %>
+    <%= affil_fields.label :long_name, "Institutional Affiliation", class: 'c-input__label required' %>
+    <%= affil_fields.text_field(:long_name, class: 'c-input__text js-affiliation') %>
+    <%= affil_fields.hidden_field :id %>
+    <%= affil_fields.hidden_field :ror_id, class: 'js-affiliation_id' %>
 <% end %>
 
 <script type="text/javascript">
-  var disable;
-  $(function () {
-    $('<%= "##{form_id}" %> .js-affiliation')
-      // don't navigate away from the field on tab when selecting an item
-      .bind( "keydown", function( event ) {
-        if ( event.keyCode === $.ui.keyCode.TAB &&
-            $( this ).autocomplete( "instance" ).menu.active ) {
-          event.preventDefault();
-        }
-      })
-      .autocomplete({
-        source: function (request, response) {
-          // Clear the existing ROR id
-          $('<%= "##{form_id}" %> #author_affiliation_ror_id').val('');
-          $.ajax({
-            url: "<%= stash_datacite.affiliations_autocomplete_path %>",
-            dataType: "json",
-            data: {
-              term: request.term
-            },
-            success: function (data) {
-              response($.map(data, function (item) {
-                return {
-                  value: item.long_name,
-                  id: item.id
-                }
-              }));
-            }
-          });
-        },
-        minLength: 1,
-        focus: function () {
-          // prevent value inserted on focus
-          return false;
-        },
-        select: function (event, ui) {
-          $('<%= "##{form_id}" %> #author_affiliation_ror_id').val(ui.item.id); // set hidden field ror_id
-          $('<%= "##{form_id}" %> #author_affiliation_id').val(''); // clear the hidden field id
-        },
-        open: function (event, ui) {
-          disable = true
-        },
-        close: function (event, ui) {
-          disable = false;
-          $(this).focus();
-        }
-      }).blur(function (event) {
-        if (!disable) {
-          var form = $(this).parents('form');
-          $(form).trigger('submit.rails');
-        }
-      });
-  });
+
+ $(function () {
+     $('<%= "##{form_id}" %> .js-affiliation')
+     // don't navigate away from the field on tab when selecting an item
+	 .bind( "keydown", function( event ) {
+             if ( event.keyCode === $.ui.keyCode.TAB &&
+		  $( this ).autocomplete( "instance" ).menu.active ) {
+		 event.preventDefault();
+             }
+	 })
+	 .autocomplete({
+             source: function (request, response) {
+		 console.log("source")
+		 // save the user's typed request, in case they don't click on an autocomplete result
+		 $('<%= "##{form_id}" %> #author_affiliation_typed_name').val(request.term);
+		 console.log("form_id", form_id)
+		 var form = $(this).parents('form');
+		 $(form).trigger('submit.rails');
+		 $.ajax({
+		     url: "<%= stash_datacite.affiliations_autocomplete_path %>",
+		     dataType: "json",
+		     data: {
+			 term: request.term
+		     },
+		     success: function (data) {
+			 response($.map(data, function (item) {
+			     return {
+				 value: item.long_name,
+				 id: item.id
+			     }
+			 }));
+		     }
+		 });
+             },
+             minLength: 1,
+             focus: function () {
+		 // prevent value inserted on focus
+		 return false;
+             },
+             select: function (event, ui) {
+		 console.log("select")
+		 $('<%= "##{form_id}" %> #author_affiliation_ror_id').val(ui.item.id); // set hidden field ror_id
+		 $('<%= "##{form_id}" %> #author_affiliation_id').val(''); // clear the hidden field id
+		 console.log(ui.item.id)
+             },
+             open: function (event, ui) {
+		 console.log("open")
+             },
+             close: function (event, ui) {
+		 console.log("close")
+		 $(this).focus();
+             },
+	     change: function( event, ui ) {
+		 // do nothing
+	     }
+	 }).blur(function (event) {
+	     console.log("blur")
+	     console.log("blursave")
+	     var form = $(this).parents('form');
+	     $(form).trigger('submit.rails');
+	 });
+ });
 </script>

--- a/stash/stash_datacite/spec/db/stash_datacite/affiliation_spec.rb
+++ b/stash/stash_datacite/spec/db/stash_datacite/affiliation_spec.rb
@@ -93,17 +93,6 @@ module StashDatacite
         expect(StashDatacite::Affiliation.from_long_name('test affiliation')).to eql(affil)
       end
 
-      it 'does do a ROR lookup if the record does NOT already have a ROR id' do
-        affil = StashDatacite::Affiliation.create(long_name: 'Test Affiliation')
-        expect(StashDatacite::Affiliation).to receive(:find_by_ror_long_name).with('test affiliation')
-        expect(StashDatacite::Affiliation.from_long_name('test affiliation')).to eql(affil)
-      end
-
-      it 'uses the long_name returned by ROR' do
-        allow(StashDatacite::Affiliation).to receive(:find_by_ror_long_name).and_return(id: '999', name: 'Foo')
-        StashDatacite::Affiliation.create(long_name: 'Test Affiliation')
-        expect(StashDatacite::Affiliation.from_long_name('test affiliation').long_name).to eql('Foo')
-      end
     end
 
     describe 'self.find_by_ror_long_name(long_name)' do

--- a/stash/stash_datacite/spec/unit/stash/import/crossref_spec.rb
+++ b/stash/stash_datacite/spec/unit/stash/import/crossref_spec.rb
@@ -199,7 +199,7 @@ module Stash
 
         it 'populates affiliations' do
           @cr.send(:populate_authors)
-          expect(@resource.authors.first.affiliation.long_name).to eql('Hotel California')
+          expect(@resource.authors.first.affiliation.long_name).to eql('Hotel California*')
         end
 
         it 'handles minimal data because lots of stuff is missing metadata' do

--- a/stash/stash_engine/lib/stash/organization/ror.rb
+++ b/stash/stash_engine/lib/stash/organization/ror.rb
@@ -58,8 +58,6 @@ module Stash
       # Search the ROR API for a specific organization.
       # @return a Stash::Organization::Ror::Organization object or nil
       def self.find_by_ror_id(ror_id)
-        return { id: nil, name: query } unless ping
-
         resp = HTTParty.get("#{URI}/#{ror_id}", headers: HEADERS)
         return nil if resp.parsed_response.blank? ||
                       resp.parsed_response['id'].blank? ||


### PR DESCRIPTION
For the second (affiliation) part of CDL-Dryad/dryad-product-roadmap#622.

When a user types in an affiliation name, but does not select a name from the autocomplete, save the typed name with an asterisk appended. This allows curators to identify the non-controlled values and act accordingly.