### PR TITLE
Allow some datasets to avoid payment for funders

### DIFF
--- a/dryad-config-example/app_config.yml
+++ b/dryad-config-example/app_config.yml
@@ -117,6 +117,8 @@ defaults: &DEFAULTS
     - 'Zambia'
     - 'India'
     - 'Pakistan'
+  funder_exemptions:
+    - 'Happy Clown School'
   link_out:
     # LinkOut FTP information for Europe PubMed Central
     labslink:

--- a/spec/features/stash_datacite/new_dataset_spec.rb
+++ b/spec/features/stash_datacite/new_dataset_spec.rb
@@ -114,6 +114,24 @@ RSpec.feature 'NewDataset', type: :feature do
       expect(page).to have_text('Payment is not required', wait: 5)
     end
 
+    it 'waives the fee when funder has agreed to pay', js: true do
+      # APP_CONFIG.funder_exemptions has the exceptions. Right now, just 'Happy Clown School' in test environment
+      only_fill_required_fields
+      fill_in_funder(name: 'Happy Clown School', value: '12XU')
+
+      navigate_to_review
+      expect(page).to have_text('This submisison does not require a payment', wait: 5)
+    end
+
+    it "doesn't waive the fee when funder isn't paying", js: true do
+      # APP_CONFIG.funder_exemptions has the exceptions. Right now, just 'Happy Clown School' in test environment
+      only_fill_required_fields
+      fill_in_funder(name: 'Wiring Harness Solutions', value: '12XU')
+
+      navigate_to_review
+      expect(page).not_to have_text('This submisison does not require a payment', wait: 5)
+    end
+
     it 'charges user when institution is not in a fee-waiver country', js: true do
       non_waiver_country = Faker::Address.country
       non_waiver_university = Faker::Educator.university

--- a/spec/features/stash_datacite/new_dataset_spec.rb
+++ b/spec/features/stash_datacite/new_dataset_spec.rb
@@ -120,7 +120,7 @@ RSpec.feature 'NewDataset', type: :feature do
       fill_in_funder(name: 'Happy Clown School', value: '12XU')
 
       navigate_to_review
-      expect(page).to have_text('This submisison does not require a payment', wait: 5)
+      expect(page).to have_text('Payment for this deposit is sponsored by Happy Clown School', wait: 5)
     end
 
     it "doesn't waive the fee when funder isn't paying", js: true do
@@ -129,7 +129,7 @@ RSpec.feature 'NewDataset', type: :feature do
       fill_in_funder(name: 'Wiring Harness Solutions', value: '12XU')
 
       navigate_to_review
-      expect(page).not_to have_text('This submisison does not require a payment', wait: 5)
+      expect(page).not_to have_text('Payment for this deposit is sponsored by', wait: 5)
     end
 
     it 'charges user when institution is not in a fee-waiver country', js: true do

--- a/spec/support/helpers/dataset_helper.rb
+++ b/spec/support/helpers/dataset_helper.rb
@@ -28,6 +28,14 @@ module DatasetHelper
   end
 
   def fill_required_fields
+    only_fill_required_fields
+
+    # ##############################
+    # LICENSE/PAYMENT AGREEMENTS
+    agree_to_everything
+  end
+
+  def only_fill_required_fields
     # make sure we're on the right page
     navigate_to_metadata
 
@@ -45,10 +53,6 @@ module DatasetHelper
     # Abstract
     abstract = find_blank_ckeditor_id('description_abstract')
     fill_in_ckeditor abstract, with: Faker::Lorem.paragraph
-
-    # ##############################
-    # LICENSE/PAYMENT AGREEMENTS
-    agree_to_everything
   end
 
   def submit_form
@@ -76,6 +80,13 @@ module DatasetHelper
     fill_in 'author[author_last_name]', with: Faker::Name.unique.last_name
     fill_in 'author[author_email]', with: Faker::Internet.safe_email
     fill_in 'author[affiliation][long_name]', with: Faker::Educator.university
+  end
+
+  def fill_in_funder(name:, value:)
+    funder_el = page.find('input.js-funders', match: :first)
+    award_el = page.find('input.js-award_number', match: :first)
+    funder_el.fill_in(with: name)
+    award_el.fill_in(with: value)
   end
 
   def agree_to_everything

--- a/stash/stash_datacite/app/models/stash_datacite/contributor.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/contributor.rb
@@ -67,6 +67,14 @@ module StashDatacite
       affiliations.try(:first)
     end
 
+    def payment_exempted?
+      return false if contributor_name.blank? || contributor_type != 'funder' || APP_CONFIG.funder_exemptions.blank?
+
+      return true if APP_CONFIG.funder_exemptions.include?(contributor_name) # these should be consistent because of fundref lookup
+
+      false
+    end
+
     private
 
     def strip_whitespace

--- a/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
@@ -40,6 +40,8 @@
 	<p>Payment for this deposit is sponsored by <b><%= @resource.tenant.long_name %></b>.</p>
     <% elsif submitter_affiliation.present? && submitter_affiliation.fee_waivered? %>
 	<p>Payment is not required for this deposit due to association with <b><%= submitter_affiliation.smart_name %></b> in <b><%= submitter_affiliation.country_name %></b>.</p>
+		<% elsif @resource.identifier.funder_will_pay? %>
+		<p>Payment for this deposit is sponsored by <b><%= @resource.identifier.funder_payment_info.contributor_name %></b></p>
     <% elsif @resource.identifier.user_must_pay? %>
 	<p>
 	    Dryad charges a fee for data publication that covers curation and preservation of published datasets. Upon

--- a/stash/stash_datacite/spec/config/app_config.yml
+++ b/stash/stash_datacite/spec/config/app_config.yml
@@ -1,3 +1,5 @@
 test:
   feedback_email_from: stash-noreply@example.edu
   feedback_email_to: [stash-dev@example.edu, stash-ops@example.edu]
+  funder_exemptions:
+    - 'Happy Clown School'

--- a/stash/stash_datacite/spec/db/stash_datacite/contributor_spec.rb
+++ b/stash/stash_datacite/spec/db/stash_datacite/contributor_spec.rb
@@ -36,6 +36,30 @@ module StashDatacite
           end
         end
       end
+
+      describe '#payment_exempted?' do
+        before(:each) do
+          stub_const("APP_CONFIG", OpenStruct.new(funder_exemptions: %w{Nugget Sprout}))
+        end
+
+        it 'is not exempted if it is not a funder' do
+          @contrib.update(contributor_name: 'Nugget')
+          @contrib.reload
+          expect(@contrib.payment_exempted?).to be_falsey
+        end
+
+        it 'is not exempted if it does not match' do
+          @contrib.update(contributor_type: 'funder')
+          @contrib.reload
+          expect(@contrib.payment_exempted?).to be_falsey
+        end
+
+        it 'is exempted if it matches a funder' do
+          @contrib.update(contributor_name: 'Nugget', contributor_type: 'funder')
+          @contrib.reload
+          expect(@contrib.payment_exempted?).to be_truthy
+        end
+      end
     end
 
     describe 'affiliations' do

--- a/stash/stash_datacite/spec/db/stash_datacite/contributor_spec.rb
+++ b/stash/stash_datacite/spec/db/stash_datacite/contributor_spec.rb
@@ -39,7 +39,7 @@ module StashDatacite
 
       describe '#payment_exempted?' do
         before(:each) do
-          stub_const("APP_CONFIG", OpenStruct.new(funder_exemptions: %w{Nugget Sprout}))
+          stub_const('APP_CONFIG', OpenStruct.new(funder_exemptions: %w[Nugget Sprout]))
         end
 
         it 'is not exempted if it is not a funder' do

--- a/stash/stash_engine/app/controllers/stash_engine/resources_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/resources_controller.rb
@@ -91,7 +91,10 @@ module StashEngine
     end
 
     # Review responds as a get request to review the resource before saving
-    def review; end
+    def review
+      # record a payment exemption if there is one, before submission
+      @resource&.identifier&.record_payment
+    end
 
     # Submission of the resource to the repository
     def submission; end

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -218,8 +218,7 @@ module StashEngine
     # Check if the user must pay for this identifier, or if payment is
     # otherwise covered
     def user_must_pay?
-      !journal_will_pay? &&
-        !institution_will_pay? &&
+      !journal_will_pay? && !institution_will_pay? && !funder_will_pay? &&
         (!submitter_affiliation.present? || !submitter_affiliation.fee_waivered?)
     end
 
@@ -304,6 +303,14 @@ module StashEngine
 
     def institution_will_pay?
       latest_resource&.tenant&.covers_dpc == true
+    end
+
+    def funder_will_pay?
+      return false if latest_resource.nil?
+
+      latest_resource.contributors.each{ |contrib| return true if contrib.payment_exempted? }
+
+      false
     end
 
     def submitter_affiliation

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -236,8 +236,8 @@ module StashEngine
         self.payment_id = submitter_affiliation.country_name
       elsif funder_will_pay?
         contrib = funder_payment_info
-        self.payment_type = "funder:#{contrib.contributor_name}"
-        self.payment_id = "award:#{contrib.award_number}"
+        self.payment_type = "funder"
+        self.payment_id = "funder:#{contrib.contributor_name}|award:#{contrib.award_number}"
       else
         self.payment_type = 'unknown'
       end

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -236,7 +236,7 @@ module StashEngine
         self.payment_id = submitter_affiliation.country_name
       elsif funder_will_pay?
         contrib = funder_payment_info
-        self.payment_type = "funder"
+        self.payment_type = 'funder'
         self.payment_id = "funder:#{contrib.contributor_name}|award:#{contrib.award_number}"
       else
         self.payment_type = 'unknown'

--- a/stash/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
@@ -72,6 +72,7 @@ module StashEngine
         allow_any_instance_of(Stash::Doi::IdGen).to receive(:update_identifier_metadata).and_return(true)
         allow_any_instance_of(Stash::Payments::Invoicer).to receive(:new).and_return(true)
         allow_any_instance_of(Stash::Payments::Invoicer).to receive(:charge_user_via_invoice).and_return(true)
+        allow_any_instance_of(StashEngine::Resource).to receive(:contributors).and_return([])
       end
 
       context :update_solr do

--- a/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -389,9 +389,9 @@ module StashEngine
           ]
         )
         @identifier.record_payment
-        expect(@identifier.payment_type).to start_with('funder:')
-        expect(@identifier.payment_type).to include('Zorgast Industries')
-        expect(@identifier.payment_id).to start_with('award:')
+        expect(@identifier.payment_type).to eql('funder')
+        expect(@identifier.payment_id).to include('Zorgast Industries')
+        expect(@identifier.payment_id).to include('award:')
         expect(@identifier.payment_id).to include('ZI0027')
       end
     end


### PR DESCRIPTION
Allow some funders to take on payment.

There is a corresponding commit to add Chan Zuck to the private config and it can be tested manually with that one.  Also added UI tests.