### PR TITLE
Improve logic for sending an invoice

### DIFF
--- a/stash/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -250,7 +250,7 @@ module StashEngine
     def ready_for_payment?
       resource&.identifier&.reload
       StashEngine.app&.payments&.service == 'stripe' &&
-        resource&.identifier&.payment_id.nil? &&
+        (resource&.identifier&.payment_type.nil? || resource&.identifier&.payment_type == 'unknown') &&
         (status == 'published' || status == 'embargoed')
     end
 


### PR DESCRIPTION
Updating the logic for determining whether to send an invoice. This shouldn't change any existing behavior, but it's a little more future-proof based on to the way usage of `payment_id` and `payment_type` has evolved.