### PR TITLE
Don't send whitespace to crossref

### DIFF
--- a/stash/stash_datacite/lib/stash/import/crossref.rb
+++ b/stash/stash_datacite/lib/stash/import/crossref.rb
@@ -21,8 +21,7 @@ module Stash
       class << self
         def query_by_doi(resource:, doi:)
           return nil unless resource.present? && doi.present?
-
-          resp = Serrano.works(ids: doi)
+          resp = Serrano.works(ids: doi.strip)
           return nil unless resp.first.present? && resp.first['message'].present?
 
           new(resource: resource, crossref_json: resp.first['message'])


### PR DESCRIPTION
People sometimes add whitespace into the DOI lookup field on the submission form. Filter this out before it goes through Serrano so it doesn't cause an error.