### PR TITLE
Apply journal's regex when saving a manuscript number to internal_data

### DIFF
--- a/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -69,6 +69,7 @@ module StashDatacite
       regex = @se_id.journal_manuscript_regex
       return msid if regex.blank?
       logger.debug("- found regex /#{regex}/")
+      return msid if msid.match(regex).blank?
       logger.debug("- after regex applied: #{msid.match(regex)[1]}")
       result = msid.match(regex)[1]
       if result.present?

--- a/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -59,7 +59,22 @@ module StashDatacite
     def save_form_to_internal_data
       @pub_issn = manage_internal_datum(identifier: @se_id, data_type: 'publicationISSN', value: params[:internal_datum][:publication_issn])
       @pub_name = manage_internal_datum(identifier: @se_id, data_type: 'publicationName', value: params[:internal_datum][:publication_name])
-      @msid = manage_internal_datum(identifier: @se_id, data_type: 'manuscriptNumber', value: params[:internal_datum][:msid])
+      parsed_msid = parse_msid(issn: params[:internal_datum][:publication_issn], msid: params[:internal_datum][:msid])
+      @msid = manage_internal_datum(identifier: @se_id, data_type: 'manuscriptNumber', value: parsed_msid)
+    end
+
+    # parse out the "relevant" part of the manuscript ID, ignoring the parts that the journal changes for different versions of the same item
+    def parse_msid(issn:, msid:)
+      logger.debug("Parsing msid #{msid} for journal #{issn}")
+      regex = @se_id.journal_manuscript_regex
+      logger.debug("- found regex /#{regex}/")
+      logger.debug("- after regex applied: #{msid.match(regex)[1]}")
+      result = msid.match(regex)[1]
+      if result.present?
+        result
+      else
+        msid
+      end
     end
 
     def update_manuscript_metadata

--- a/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -67,6 +67,7 @@ module StashDatacite
     def parse_msid(issn:, msid:)
       logger.debug("Parsing msid #{msid} for journal #{issn}")
       regex = @se_id.journal_manuscript_regex
+      return msid if regex.blank?
       logger.debug("- found regex /#{regex}/")
       logger.debug("- after regex applied: #{msid.match(regex)[1]}")
       result = msid.match(regex)[1]

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -299,6 +299,10 @@ module StashEngine
       publication_data('reviewContacts')
     end
 
+    def journal_manuscript_regex
+      publication_data('manuscriptNumberRegex')
+    end
+
     def allow_review?
       publication_data('allowReviewWorkflow') || publication_name.blank?
     end

--- a/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -474,6 +474,20 @@ module StashEngine
       end
     end
 
+    describe '#journal_manuscript_regex' do
+      it 'retrieves the journal sponsorName' do
+        @fake_journal_name = 'Fake Journal'
+        @fake_manuscript_regex = ".*?(\d+-\d+).*?"
+        stub_request(:any, %r{/journals/#{@fake_issn}})
+          .to_return(body: '{"fullName":"' + @fake_journal_name + '",
+                             "issn":"' + @fake_issn + '",
+                             "manuscriptNumberRegex":"' + @fake_manuscript_regex + '"}',
+                     status: 200,
+                     headers: { 'Content-Type' => 'application/json' })
+        expect(identifier.journal_manuscript_regex).to eq(@fake_manuscript_regex)
+      end
+    end
+
     describe '#journal_allows' do
       it 'allows review when there is no journal' do
         allow(@identifier).to receive('publication_name').and_return(nil)

--- a/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -475,7 +475,7 @@ module StashEngine
     end
 
     describe '#journal_manuscript_regex' do
-      it 'retrieves the journal sponsorName' do
+      it 'retrieves the journal regex' do
         @fake_journal_name = 'Fake Journal'
         @fake_manuscript_regex = ".*?(\d+-\d+).*?"
         stub_request(:any, %r{/journals/#{@fake_issn}})


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/507 and https://github.com/CDL-Dryad/dryad-product-roadmap/issues/621

When the user enters a manuscript number in the submission form, first look up the regex for the associated journal, and apply it to get the "canonical" manuscript number, removing version numbers and other meaningless metadata that journals add into their manuscript numbers. 

This allows communication with the journal module to always be based on the canonical manuscript numbers, ensuring that the numbers match more frequently.

To test, enter a journal name and manuscript number in the submission system, then verify that the manuscript number has no extraneous information when saved in `stash_engine_internal_data`. Some sample journals and manuscript numbers:
- Royal Society Open Science, RSOS-191815.R1
- eLife, 11-09-2019-RA-eLife-51810R1 (should remove the date, "RA" article type, and the version number)