### PR TITLE
Force WebMock to be enabled any time mock_ror is called

### DIFF
--- a/spec/mocks/ror.rb
+++ b/spec/mocks/ror.rb
@@ -3,6 +3,7 @@ module Mocks
   module Ror
 
     def mock_ror!(user = nil)
+      WebMock.enable!
       stub_ror_heartbeat_check
       stub_ror_name_lookup(name: user.present? && user.affiliation.present? ? user.affiliation.long_name : nil)
       stub_ror_id_lookup(university: user.present? && user.affiliation.present? ? user.affiliation.long_name : nil)


### PR DESCRIPTION
This may address the intermittent testing failures for ROR functionality.