### PR TITLE
Suppress asterisks for affiliation

### DIFF
--- a/stash/stash_datacite/app/models/stash_datacite/affiliation.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/affiliation.rb
@@ -16,9 +16,14 @@ module StashDatacite
     before_save :strip_whitespace
 
     # prefer short_name if it is set over long name and make string
-    def smart_name
+    def smart_name(show_asterisk: false)
       return '' if short_name.blank? && long_name.blank?
-      (short_name.blank? ? long_name.strip : short_name.strip)
+      chosen_name = (short_name.blank? ? long_name.strip : short_name.strip)
+      if chosen_name.end_with?('*') && !show_asterisk
+        chosen_name[0..-2]
+      else
+        chosen_name
+      end
     end
 
     def country_name

--- a/stash/stash_datacite/app/views/stash_datacite/authors/_show.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/_show.html.erb
@@ -1,15 +1,26 @@
 <% unless authors.nil? %>
-  <% authors.each do |author| %>
+    <% authors.each do |author| %>
+	<div class="o-metadata__group1">
+	    <% if current_user && current_user.role == 'superuser' %>
+		<%= ([ (author.author_full_name ?
+			"<span class='o-metadata__author'>#{h(author.author_full_name)}</span>" : nil) ] +
+		     author.affiliations.map{|i|
+					     (i.try(:smart_name) ? "<span class='o-metadata__affiliation'>#{h(i.smart_name(show_asterisk: true))}</span>" : nil)
+		     } +
+		     [ (author.author_orcid ? "<a class='c-orcid__icon' title='orcid_website' href='http://orcid.org'></a><span>#{display_author_orcid(author)}</span>" : nil) ])
+		     .flatten.reject(&:blank?).join(", ").html_safe %>
+	    <% else %>
+		<%= ([ (author.author_full_name ?
+			"<span class='o-metadata__author'>#{h(author.author_full_name)}</span>" : nil) ] +
+		     author.affiliations.map{|i|
+					     (i.try(:smart_name) ? "<span class='o-metadata__affiliation'>#{h(i.try(:smart_name))}</span>" : nil)
+		     } +
+		     [ (author.author_orcid ? "<a class='c-orcid__icon' title='orcid_website' href='http://orcid.org'></a><span>#{display_author_orcid(author)}</span>" : nil) ])
+		     .flatten.reject(&:blank?).join(", ").html_safe %>
+	    <% end %>
+	</div>
+    <% end %>
     <div class="o-metadata__group1">
-      <%= ([ (author.author_full_name ?
-              "<span class='o-metadata__author'>#{h(author.author_full_name)}</span>" : nil) ] +
-         author.affiliations.map{|i|
-              (i.try(:smart_name) ? "<span class='o-metadata__affiliation'>#{h(i.try(:smart_name))}</span>" : nil) } +
-         [ (author.author_orcid ? "<a class='c-orcid__icon' title='orcid_website' href='http://orcid.org'></a><span>#{display_author_orcid(author)}</span>" : nil) ])
-          .flatten.reject(&:blank?).join(", ").html_safe %>
+	<%= authors.map{ |author| author.author_email }.reject(&:blank?).join(", ").html_safe  %>
     </div>
-  <% end %>
-  <div class="o-metadata__group1">
-    <%= authors.map{ |author| author.author_email }.reject(&:blank?).join(", ").html_safe  %>
-  </div>
 <% end %>

--- a/stash/stash_datacite/spec/db/stash_datacite/affiliation_spec.rb
+++ b/stash/stash_datacite/spec/db/stash_datacite/affiliation_spec.rb
@@ -25,6 +25,14 @@ module StashDatacite
         affil = StashDatacite::Affiliation.create(long_name: 'Bertelsmann Music Group')
         expect(affil.smart_name).to eq('Bertelsmann Music Group')
       end
+      it 'shows the asterisk when asked' do
+        affil = StashDatacite::Affiliation.create(long_name: 'Bertelsmann Music Group*')
+        expect(affil.smart_name(show_asterisk: true)).to eq('Bertelsmann Music Group*')
+      end
+      it 'suppresses the asterisk by default' do
+        affil = StashDatacite::Affiliation.create(long_name: 'Bertelsmann Music Group*')
+        expect(affil.smart_name).to eq('Bertelsmann Music Group')
+      end
     end
 
     describe :fee_waivered? do


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/643

When displaying a landing page, if any of the affiliation names end with an asterisk, the asterisk is only displayed if the user has role 'superuser'.