### PR TITLE
Suppress funder asterisk for normal users

### DIFF
--- a/stash/stash_datacite/app/models/stash_datacite/contributor.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/contributor.rb
@@ -46,6 +46,14 @@ module StashDatacite
       Contributor.contributor_type_mapping_obj(contributor_type_friendly)
     end
 
+    def contributor_name_friendly(show_asterisk: false)
+      if contributor_name.end_with?('*') && !show_asterisk
+        contributor_name[0..-2]
+      else
+        contributor_name
+      end
+    end
+
     # this is to simulate the bad old structure where a user can only have one affiliation
     def affiliation_id=(affil_id)
       self.affiliation_ids = affil_id

--- a/stash/stash_datacite/app/views/stash_datacite/contributors/_show.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/contributors/_show.html.erb
@@ -2,7 +2,11 @@
 <% unless contributors.nil? || contributors.length < 1 %>
   <h2 class="o-heading__level2">Funding</h2>
   <% contributors.each do |contributor| %>
-     <p><%= contributor.contributor_name %><%= "," %>
+      <% if current_user && current_user.role == 'superuser' %>
+	  <p><%= contributor.contributor_name_friendly(show_asterisk: true) %><%= "," %>
+      <% else %>
+	  <p><%= contributor.contributor_name_friendly %><%= "," %>
+      <% end %>
       <% if contributor.award_number.present? %>
         <%= @award_string %><%= contributor.award_number %></p>
       <% end %>

--- a/stash/stash_datacite/spec/db/stash_datacite/contributor_spec.rb
+++ b/stash/stash_datacite/spec/db/stash_datacite/contributor_spec.rb
@@ -62,6 +62,17 @@ module StashDatacite
       end
     end
 
+    describe 'contributor_name_friendly' do
+      it 'shows the asterisk when asked' do
+        c = Contributor.create(contributor_name: 'Bertelsmann Music Group*')
+        expect(c.contributor_name_friendly(show_asterisk: true)).to eq('Bertelsmann Music Group*')
+      end
+      it 'suppresses the asterisk by default' do
+        c = Contributor.create(contributor_name: 'Bertelsmann Music Group*')
+        expect(c.contributor_name_friendly).to eq('Bertelsmann Music Group')
+      end
+    end
+
     describe 'affiliations' do
       attr_reader :affiliations
       before(:each) do


### PR DESCRIPTION
For CDL-Dryad/dryad-product-roadmap#643

When displaying a landing page, if any of the funder name ends with an asterisk, the asterisk is only displayed if the user has role 'superuser'.