### PR TITLE
Disable test that intermittently fails due to webmock problem

### DIFF
--- a/spec/features/stash_datacite/affiliation_autofill_spec.rb
+++ b/spec/features/stash_datacite/affiliation_autofill_spec.rb
@@ -24,7 +24,9 @@ RSpec.feature 'AffiliationAutofill', type: :feature do
       expect(page).to have_text('University of Testing v2')
     end
 
-    it 'sets the ROR id when user selects an option', js: true do
+    # Temporarily disabling this test because for some reason WebMock
+    # doesn't always load properly in this class and the test randomly fails.
+    xit 'sets the ROR id when user selects an option', js: true do
       stub_ror_id_lookup(university: 'University of Testing v2')
       fill_in 'author[affiliation][long_name]', with: 'Testing'
       first('.ui-menu-item-wrapper', wait: 5).click


### PR DESCRIPTION
This test fails randomly, with an error about web requests being disabled, even though the request in question *should* already have been stubbed out by the time this code runs.

