### PR TITLE
Active job configuration and proof-of-concept

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ PATH
       concurrent-ruby (>= 1.0)
       database_cleaner
       datacite-mapping (~> 0.4.0)
+      delayed_job_active_record
       ezid-client (>= 1.5)
       filesize
       font-awesome-rails
@@ -266,6 +267,11 @@ GEM
       xml-mapping_extensions (~> 0.4, >= 0.4.7)
     debug_inspector (0.0.3)
     deep_merge (1.2.1)
+    delayed_job (4.1.8)
+      activesupport (>= 3.0, < 6.1)
+    delayed_job_active_record (4.1.4)
+      activerecord (>= 3.0, < 6.1)
+      delayed_job (>= 3.0, < 5)
     deprecation (1.0.0)
       activesupport
     devise (4.7.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ PATH
       cirneco (>= 0.9.27)
       ckeditor (~> 4.3.0)
       concurrent-ruby (>= 1.0)
+      daemons
       database_cleaner
       datacite-mapping (~> 0.4.0)
       delayed_job_active_record
@@ -261,6 +262,7 @@ GEM
       namae (~> 1.0)
     csl-styles (1.0.1.10)
       csl (~> 1.0)
+    daemons (1.3.1)
     database_cleaner (1.8.3)
     datacite-mapping (0.4.0)
       typesafe_enum (~> 0.1, >= 0.1.7)

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,7 @@ module Dash2
 
     config.time_zone = "UTC"
     config.active_record.default_timezone = :utc
+
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/stash/stash-merritt/spec/spec_helper.rb
+++ b/stash/stash-merritt/spec/spec_helper.rb
@@ -35,6 +35,7 @@ require_relative '../../spec_helpers/rspec_custom_matchers'
 # ActiveRecord
 
 require 'active_record'
+require 'active_job'
 # Note: Even if we're not doing any database work, ActiveRecord callbacks will still raise warnings
 ActiveRecord::Base.raise_in_transactional_callbacks = true
 
@@ -62,7 +63,7 @@ require 'stash_engine'
 ].each do |dir|
   tmp = Dir.glob("#{stash_engine_path}/#{dir}/**/*.rb").sort
   tmp.sort! { |x, y| y.include?('/concerns/').to_s <=> x.include?('/concerns/').to_s } # sort concerns first
-  tmp.each(&method(:require))
+  tmp.reject { |i| i.end_with?('_job.rb') }.each(&method(:require))
 end
 
 $LOAD_PATH.unshift("#{stash_engine_path}/app/models")

--- a/stash/stash_api/Gemfile.lock
+++ b/stash/stash_api/Gemfile.lock
@@ -37,8 +37,10 @@ PATH
       cirneco (>= 0.9.27)
       ckeditor (~> 4.3.0)
       concurrent-ruby (>= 1.0)
+      daemons
       database_cleaner
       datacite-mapping (~> 0.4.0)
+      delayed_job_active_record
       ezid-client (>= 1.5)
       filesize
       font-awesome-rails
@@ -217,11 +219,17 @@ GEM
       namae (~> 1.0)
     csl-styles (1.0.1.10)
       csl (~> 1.0)
+    daemons (1.3.1)
     database_cleaner (1.8.3)
     datacite-mapping (0.4.0)
       typesafe_enum (~> 0.1, >= 0.1.7)
       xml-mapping_extensions (~> 0.4, >= 0.4.7)
     deep_merge (1.2.1)
+    delayed_job (4.1.8)
+      activesupport (>= 3.0, < 6.1)
+    delayed_job_active_record (4.1.4)
+      activerecord (>= 3.0, < 6.1)
+      delayed_job (>= 3.0, < 5)
     deprecation (1.0.0)
       activesupport
     devise (4.7.1)

--- a/stash/stash_datacite/Gemfile.lock
+++ b/stash/stash_datacite/Gemfile.lock
@@ -27,8 +27,10 @@ PATH
       cirneco (>= 0.9.27)
       ckeditor (~> 4.3.0)
       concurrent-ruby (>= 1.0)
+      daemons
       database_cleaner
       datacite-mapping (~> 0.4.0)
+      delayed_job_active_record
       ezid-client (>= 1.5)
       filesize
       font-awesome-rails
@@ -214,11 +216,17 @@ GEM
       namae (~> 1.0)
     csl-styles (1.0.1.10)
       csl (~> 1.0)
+    daemons (1.3.1)
     database_cleaner (1.8.3)
     datacite-mapping (0.4.0)
       typesafe_enum (~> 0.1, >= 0.1.7)
       xml-mapping_extensions (~> 0.4, >= 0.4.7)
     deep_merge (1.2.1)
+    delayed_job (4.1.8)
+      activesupport (>= 3.0, < 6.1)
+    delayed_job_active_record (4.1.4)
+      activerecord (>= 3.0, < 6.1)
+      delayed_job (>= 3.0, < 5)
     deprecation (1.0.0)
       activesupport
     devise (4.7.1)

--- a/stash/stash_engine/Gemfile.lock
+++ b/stash/stash_engine/Gemfile.lock
@@ -16,6 +16,7 @@ PATH
       cirneco (>= 0.9.27)
       ckeditor (~> 4.3.0)
       concurrent-ruby (>= 1.0)
+      daemons
       database_cleaner
       datacite-mapping (~> 0.4.0)
       delayed_job_active_record
@@ -164,6 +165,7 @@ GEM
       namae (~> 1.0)
     csl-styles (1.0.1.10)
       csl (~> 1.0)
+    daemons (1.3.1)
     database_cleaner (1.8.3)
     datacite-mapping (0.4.0)
       typesafe_enum (~> 0.1, >= 0.1.7)

--- a/stash/stash_engine/Gemfile.lock
+++ b/stash/stash_engine/Gemfile.lock
@@ -18,6 +18,7 @@ PATH
       concurrent-ruby (>= 1.0)
       database_cleaner
       datacite-mapping (~> 0.4.0)
+      delayed_job_active_record
       ezid-client (>= 1.5)
       filesize
       font-awesome-rails
@@ -167,6 +168,11 @@ GEM
     datacite-mapping (0.4.0)
       typesafe_enum (~> 0.1, >= 0.1.7)
       xml-mapping_extensions (~> 0.4, >= 0.4.7)
+    delayed_job (4.1.8)
+      activesupport (>= 3.0, < 6.1)
+    delayed_job_active_record (4.1.4)
+      activerecord (>= 3.0, < 6.1)
+      delayed_job (>= 3.0, < 5)
     diff-lcs (1.3)
     diffy (3.3.0)
     docile (1.3.2)
@@ -181,7 +187,7 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
-    excon (0.72.0)
+    excon (0.62.0)
     ezid-client (1.8.0)
       hashie (~> 3.4, >= 3.4.3)
       nokogiri
@@ -190,7 +196,7 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
-    faraday (0.17.3)
+    faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     faraday-encoding (0.0.5)
       faraday
@@ -274,12 +280,12 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    maremma (4.2.1)
+    maremma (4.2.6)
       activesupport (>= 4.2.5, < 6)
       addressable (>= 2.3.6)
       builder (~> 3.2, >= 3.2.2)
-      excon (~> 0.60)
-      faraday (~> 0.14)
+      excon (~> 0.60, < 0.63)
+      faraday (~> 0.14, < 0.15)
       faraday-encoding (~> 0.0.4)
       faraday_middleware (~> 0.12.0)
       multi_json (~> 1.12)

--- a/stash/stash_engine/app/jobs/stash_engine/zenodo_copy_job.rb
+++ b/stash/stash_engine/app/jobs/stash_engine/zenodo_copy_job.rb
@@ -1,0 +1,29 @@
+module StashEngine
+  class ZenodoCopyJob < ActiveJob::Base
+    queue_as :zenodo_copy
+
+    TEST_FILE = Rails.root.join('log', 'test_active_job.txt')
+
+    before_enqueue do |job|
+      File.open(TEST_FILE, 'a') { |f| f.puts "before_enqueue:\n#{job.inspect}\n" }
+    end
+
+    after_enqueue do |job|
+      File.open(TEST_FILE, 'a') { |f| f.puts "after_enqueue:\n#{job.inspect}\n" }
+    end
+
+    before_perform do |job|
+      File.open(TEST_FILE, 'a') { |f| f.puts "before_perform:\n#{job.inspect}\n" }
+    end
+
+    after_perform do |job|
+      File.open(TEST_FILE, 'a') { |f| f.puts "after_perform:\n#{job.inspect}\n" }
+    end
+
+    def perform(*args)
+      # Do something later
+      sleep rand(10)
+      File.open(TEST_FILE, 'a') { |f| f.puts "\n\nRUNNING MY JOB #{args[0]}\n\n" }
+    end
+  end
+end

--- a/stash/stash_engine/config/initializers/delayed_job_config.rb
+++ b/stash/stash_engine/config/initializers/delayed_job_config.rb
@@ -1,0 +1,12 @@
+require 'delayed_job_active_record'
+# see https://axiomq.com/blog/deal-with-long-running-rails-tasks-with-delayed-job/
+
+Delayed::Worker.destroy_failed_jobs = false
+Delayed::Worker.sleep_delay = 60
+Delayed::Worker.max_attempts = 3
+Delayed::Worker.max_run_time = 180.minutes
+Delayed::Worker.read_ahead = 10
+Delayed::Worker.default_queue_name = 'default'
+Delayed::Worker.delay_jobs = !Rails.env.test?
+Delayed::Worker.raise_signal_exceptions = :term
+Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))

--- a/stash/stash_engine/db/migrate/20200219223350_create_delayed_jobs2.rb
+++ b/stash/stash_engine/db/migrate/20200219223350_create_delayed_jobs2.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs2 < ActiveRecord::Migration
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/stash/stash_engine/db/migrate/20200219223350_create_delayed_jobs2.rb
+++ b/stash/stash_engine/db/migrate/20200219223350_create_delayed_jobs2.rb
@@ -13,7 +13,7 @@ class CreateDelayedJobs2 < ActiveRecord::Migration
       table.timestamps null: true
     end
 
-    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+    add_index :delayed_jobs, %i[priority run_at], name: 'delayed_jobs_priority'
   end
 
   def self.down

--- a/stash/stash_engine/stash_engine.gemspec
+++ b/stash/stash_engine/stash_engine.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_dependency 'concurrent-ruby', '>= 1.0'
   s.add_dependency 'database_cleaner' # for one migration task, but need to keep capistrano from barfing can remove after migration
   s.add_dependency 'datacite-mapping', '~> 0.4.0'
+  s.add_dependency 'delayed_job_active_record'
   s.add_dependency 'ezid-client', '>= 1.5'
   s.add_dependency 'filesize'
   s.add_dependency 'font-awesome-rails'

--- a/stash/stash_engine/stash_engine.gemspec
+++ b/stash/stash_engine/stash_engine.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_dependency 'cirneco', '>= 0.9.27'
   s.add_dependency 'ckeditor', '~> 4.3.0' # lock to 4.x series since upgrading to 5.x blows up until we figure out the upgrade path
   s.add_dependency 'concurrent-ruby', '>= 1.0'
+  s.add_dependency 'daemons'
   s.add_dependency 'database_cleaner' # for one migration task, but need to keep capistrano from barfing can remove after migration
   s.add_dependency 'datacite-mapping', '~> 0.4.0'
   s.add_dependency 'delayed_job_active_record'


### PR DESCRIPTION
This queueing system isn't hooked into any actions yet.  This is related to https://github.com/CDL-Dryad/dryad-product-roadmap/issues/649 which has some examples of a manual test in it.

config/application.rb sets the queue adapter as delayed_job.

I had to add some fixes to the tests loading to stop errors.

stash/stash_engine/app/jobs/stash_engine/zenodo_copy_job.rb is basically a proof-of-concept stub right now and all it does is write things to a file in various queue lifecycle states to show what is happening in the queue.  It can be changed and expanded later but currently isn't called by anything except manual actions from Rails Console.  Examples I tried in the Rails Console:

```
StashEngine::ZenodoCopyJob.perform_later('my cat has fleas')
StashEngine::ZenodoCopyJob.perform_later('my dog has fleas')
StashEngine::ZenodoCopyJob.perform_later('my rat has fleas')
```

The delayed job daemon can be started and stopped with commands like these and it is what picks jobs up off the queue and runs them when it is running in the background.

```
RAILS_ENV=local_dev bin/delayed_job start
RAILS_ENV=local_dev bin/delayed_job stop
```

A settings initializer is at stash/stash_engine/config/initializers/delayed_job_config.rb .

There is a migration to add the database table needed to store job info at stash/stash_engine/db/migrate/20200219223350_create_delayed_jobs2.rb .  It appears someone migrated and then unmigrated the table in the past in 2016 so I needed to rename this migration file slightly (the 2 at the end).

