### PR TITLE
Migrate email when migrating ORCID

### DIFF
--- a/stash/stash_engine/app/controllers/stash_engine/dashboard_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/dashboard_controller.rb
@@ -134,6 +134,7 @@ module StashEngine
 
       # make the newer user inaccessible from the database (rather than deleting for now in case anything goes awry, we can purge later)
       old_current_user.update(orcid: "#{old_current_user.orcid}-migrated", migration_token: StashEngine::User::NO_MIGRATE_STRING)
+      old_current_user.update(email: "#{old_current_user.email}.migrated") unless old_current_user.email.blank?
     end
 
   end


### PR DESCRIPTION
When a user "migrates" their account information from Dryad v1 to current Dryad, duplicate email addresses can be left in the database, which Doorkeeper doesn't like, preventing the user from subsequent logins. This guarantees that when their ORCID is updated with a "-migrated" suffix, any existing email is also updated with a ".migrated" suffix.