### PR TITLE
Allow affiliation long_name to be duplicated

### DIFF
--- a/stash/stash_datacite/app/models/stash_datacite/affiliation.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/affiliation.rb
@@ -11,7 +11,7 @@ module StashDatacite
     has_and_belongs_to_many :authors, class_name: 'StashEngine::Author', join_table: 'dcs_affiliations_authors'
     has_and_belongs_to_many :contributors, class_name: 'StashDatacite::Contributor'
 
-    validates :long_name, presence: true, uniqueness: true
+    validates :long_name, presence: true
 
     before_save :strip_whitespace
 


### PR DESCRIPTION
Addresses https://github.com/CDL-Dryad/dryad-product-roadmap/issues/652

Since ROR doesn't guarantee the uniqueness of long_name, we cannot enforce it to be unique within our database.