### PR TITLE
Fixed leap-year calculation problems

### DIFF
--- a/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
@@ -12,7 +12,7 @@ module StashEngine
 
     before(:all) do
       tomorrow = Date.today + 1
-      @future_date = Date.new(tomorrow.year + 1, tomorrow.month, tomorrow.day)
+      @future_date = tomorrow + 366.days
     end
 
     before(:each) do


### PR DESCRIPTION
Just adding 366 days for a date over a year out instead of the ugly date creating stuff that was there before.