### PR TITLE
Ensure items are in peer_review status before moving to submitted

### DIFF
--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -141,7 +141,7 @@ namespace :identifiers do
             note: 'Expire Peer Review CRON - reached the peer review expiration date, changing status to `submitted`'
           )
         else
-          p "Removing peer review for: Identifier: #{r.identifier_id}, Resource: #{r.id} due to non-peer review curation status"
+          p "Removing peer review for: Identifier: #{r.identifier_id}, Resource: #{r.id} due to non-peer_review curation status"
           r.update(hold_for_peer_review: false, peer_review_end_date: nil)
         end
       rescue StandardError => e


### PR DESCRIPTION
Associated with https://github.com/CDL-Dryad/dryad-product-roadmap/issues/625

Ensure that the `expire_peer_review` task only changes the status of items that are actually in `peer_review` status.