### PR TITLE
Instead of expiring peer review, send a reminder

### DIFF
--- a/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
+++ b/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
@@ -72,6 +72,17 @@ module StashEngine
            subject: "#{rails_env} REMINDER: Dryad Submission \"#{@resource.title}\"")
     end
 
+    def peer_review_reminder(resource)
+      logger.warn('Unable to send peer_review_reminder; nil resource') unless resource.present?
+      return unless resource.present?
+      user = resource.authors.first || resource.user
+      return unless user.present? && user_email(user).present?
+      @user_name = user_name(user)
+      assign_variables(resource)
+      mail(to: user_email(user),
+           subject: "#{rails_env} REMINDER: Dryad Submission \"#{@resource.title}\"")
+    end
+
     def dependency_offline(dependency)
       return unless dependency.present?
       @dependency = dependency

--- a/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
+++ b/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 module StashEngine
 
   # Mails users about submissions
@@ -114,14 +115,6 @@ module StashEngine
     end
     # rubocop:enable Style/NestedTernaryOperator
 
-    # defer to the StashDatacite::LandingMixin methods to create a citation
-    #  def generate_citation(resource)
-    #   return unless resource.is_a?(StashEngine::Resource)
-    #   publisher = StashDatacite::Publisher.find_by(resource_id: resource.id).try(:publisher)
-    #   resource_type = StashDatacite::ResourceType.find_by(resource_id: resource.id).try(:resource_type_general_friendly)
-    #   citation(resource.authors, resource.title, resource_type, resource.version, resource.identifier, publisher, resource.publication_years)
-    # end
-
     def assign_variables(resource)
       @resource = resource
       @helpdesk_email = APP_CONFIG['helpdesk_email'] || 'help@datadryad.org'
@@ -149,3 +142,4 @@ module StashEngine
   end
 
 end
+# rubocop:enable Metrics/ClassLength

--- a/stash/stash_engine/app/views/stash_engine/user_mailer/peer_review_reminder.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/user_mailer/peer_review_reminder.html.erb
@@ -1,0 +1,19 @@
+<p>Dear <%= @user_name %>,</p>
+
+<p>This is a reminder that your submission to Dryad, “<%= @resource.title %>” is still in private for the peer review
+    status and has not begun the curation process.</p>
+
+<p>If your related article has been accepted or you are ready for the curation and publication process to begin, please:</p>
+<ol>
+    <li>Login to https://datadryad.org</li>
+    <li>Click on “My Datasets”</li>
+    <li>Click “Update” on your dataset</li>
+    <li>On page 3 of the submission form, uncheck the box for private for peer review and click submit</li>
+</ol>
+
+<p>If your related article is still in the peer review process, you may ignore this email.</p>
+
+<p>If your related article has been rejected or you will not be proceeding with the submission of this dataset, please let us know.</p>
+
+<p>Please get in touch with any questions at <a href="mailto:<%= @helpdesk_email %>"><%= @helpdesk_email %></a>.</p>
+

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -154,7 +154,7 @@ namespace :identifiers do
 
   desc 'Email the submitter when a dataset has been in `peer_review` past the deadline, and the last reminder was too long ago'
   task peer_review_reminder: :environment do
-    p "Mailing users whose datasets have been in peer_review for a while..."
+    p 'Mailing users whose datasets have been in peer_review for a while...'
     StashEngine::Resource.where(hold_for_peer_review: true)
       .where('stash_engine_resources.peer_review_end_date <= ?', Date.today)
       .each do |r|
@@ -177,7 +177,7 @@ namespace :identifiers do
     end
   end
 
- desc 'Email the submitter when a dataset has been `in_progress` for 3 days'
+  desc 'Email the submitter when a dataset has been `in_progress` for 3 days'
   task in_progess_reminder: :environment do
     p "Mailing users whose datasets have been in_progress since #{3.days.ago}"
     StashEngine::Resource.joins(:current_resource_state)


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/625

Add a task to email submitters when their default peer_review period has expired. When an email is sent, the task leaves a record in the curation activities, and this record is used to determine whether a follow-up reminder should be sent. This may be repeated; it is intended to be run daily. A follow-up email will be sent if the most recent message was sent more than a month ago.