### PR TITLE
This changes the download for individual files to use Merritt presigned urls

### DIFF
--- a/spec/lib/stash/download/file_presigned_spec.rb
+++ b/spec/lib/stash/download/file_presigned_spec.rb
@@ -1,0 +1,85 @@
+# testing in here since testing is much better with real loading of the engines and application without wonky problems
+# from the manual setup that doesn't really load rails right in the engines
+require 'stash/download/file_presigned'
+require 'byebug'
+
+require 'rails_helper'
+
+RSpec.configure(&:infer_spec_type_from_file_location!)
+
+module Stash
+  module Download
+
+    RSpec.describe FilePresigned do
+      before(:each) do
+        @resource = create(:resource)
+        @file_upload = create(:file_upload, resource_id: @resource.id)
+
+        @controller_context = double
+        allow(@controller_context).to receive(:redirect_to).and_return('redirected')
+        allow(@controller_context).to receive(:render).and_return('rendered 404')
+
+        @fp = FilePresigned.new(controller_context: @controller_context)
+      end
+
+      describe '#handle_bad_status(r, file)' do
+        it 'raises exception if r.status.success? is false' do
+          r = double
+          allow(r).to receive(:status).and_return({ 'success?': false }.to_ostruct)
+          expect { @fp.handle_bad_status(r, @file_upload) }.to raise_error(Stash::Download::MerrittError)
+        end
+      end
+
+      describe '#url(file:)' do
+        it 'creates the url for a file' do
+          ark = @resource.download_uri.match(/ark.+/).to_s
+          resp = @fp.url(file: @file_upload)
+          out_url = "http://merritt-fake.cdlib.org/api/presign-file/#{ark}/1/producer%2F" \
+            "#{ERB::Util.url_encode(@file_upload.upload_file_name)}?no_redirect=true"
+          expect(resp).to eq(out_url)
+        end
+      end
+
+      describe '#download(file:)' do
+
+        before(:each) do
+          @stubby = stub_request(:get, @fp.url(file: @file_upload))
+            .with(
+              headers: {
+                'Authorization' => 'Basic c3Rhc2hfc3VibWl0dGVyOmNvcnJlY3TigItob3JzZeKAi2JhdHRlcnnigItzdGFwbGU=',
+                'Host' => 'merritt-fake.cdlib.org'
+              }
+            )
+            .to_return(status: 200, body: '{"url":"https://my.testing.url.example.com"}',
+                       headers: { 'Content-Type' => 'application/json' })
+        end
+
+        it 'redirects to a url' do
+          resp = @fp.download(file: @file_upload)
+          expect(resp).to eq('redirected')
+        end
+
+        it 'gives a 404 for missing file' do
+          expect(@controller_context).to receive(:render)
+          @fp.download(file: nil)
+        end
+
+        it 'raises an error for bad status response from Merritt' do
+          remove_request_stub(@stubby)
+
+          stub_request(:get, @fp.url(file: @file_upload))
+            .with(
+              headers: {
+                'Authorization' => 'Basic c3Rhc2hfc3VibWl0dGVyOmNvcnJlY3TigItob3JzZeKAi2JhdHRlcnnigItzdGFwbGU=',
+                'Host' => 'merritt-fake.cdlib.org'
+              }
+            )
+            .to_return(status: 500, body: '{"url":"https://my.testing.url.example.com"}',
+                       headers: { 'Content-Type' => 'application/json' })
+
+          expect { @fp.download(file: @file_upload) }.to raise_error(Stash::Download::MerrittError)
+        end
+      end
+    end
+  end
+end

--- a/stash/stash_api/app/controllers/stash_api/files_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/files_controller.rb
@@ -5,7 +5,7 @@
 require 'fileutils'
 
 require_dependency 'stash_api/application_controller'
-require 'stash/download/file'
+require 'stash/download/file_presigned'
 
 # rubocop:disable Metrics/ClassLength
 module StashApi
@@ -69,9 +69,9 @@ module StashApi
     # GET /files/<id>/download
     def download
       if @resource.may_download?(ui_user: @user)
-        @file_streamer = Stash::Download::File.new(controller_context: self)
+        @file_presigned = Stash::Download::FilePresigned.new(controller_context: self)
         StashEngine::CounterLogger.general_hit(request: request, file: @stash_file)
-        @file_streamer.download(file: @stash_file)
+        @file_presigned.download(file: @stash_file)
       else
         render status: 404, text: 'Not found'
       end

--- a/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
@@ -1,5 +1,5 @@
 require_dependency 'stash_engine/application_controller'
-require 'stash/download/file'
+require 'stash/download/file_presigned'
 require 'stash/download/version'
 
 # rubocop:disable Metrics/ClassLength
@@ -40,7 +40,7 @@ module StashEngine
     # set up the Merritt file & version objects so they have access to the controller context before continuing
     def setup_streaming
       @version_streamer = Stash::Download::Version.new(controller_context: self)
-      @file_streamer = Stash::Download::File.new(controller_context: self)
+      @file_presigned = Stash::Download::FilePresigned.new(controller_context: self)
     end
 
     # for downloading the full version
@@ -106,7 +106,7 @@ module StashEngine
       file_upload = FileUpload.find(params[:file_id])
       if file_upload&.resource&.may_download?(ui_user: current_user)
         CounterLogger.general_hit(request: request, file: file_upload)
-        @file_streamer.download(file: file_upload)
+        @file_presigned.download(file: file_upload)
       else
         render status: 403, text: 'You are not authorized to download this file until it has been published.'
       end

--- a/stash/stash_engine/lib/stash/download/file_presigned.rb
+++ b/stash/stash_engine/lib/stash/download/file_presigned.rb
@@ -21,7 +21,7 @@ module Stash
       def download(file:)
         tenant = file&.resource&.tenant
         if file.blank? || tenant.blank?
-          render status: 404, text: 'Not found'
+          cc.render status: 404, text: 'Not found'
           return
         end
 

--- a/stash/stash_engine/lib/stash/download/file_presigned.rb
+++ b/stash/stash_engine/lib/stash/download/file_presigned.rb
@@ -1,0 +1,57 @@
+require 'byebug'
+require 'http'
+
+# a significantly simplified class for dealing with Files instead of sending them through our server
+# and redirects to a S3 presigned URL
+module Stash
+  module Download
+
+    class MerrittError < StandardError; end
+
+    class FilePresigned
+      attr_reader :cc
+
+      # passing the controller context allows us to do actions the controller would normally do such as redirecting
+      # or rendering within the rails context
+      def initialize(controller_context:)
+        @cc = controller_context
+      end
+
+      # file is file_upload from ActiveRecord
+      def download(file:)
+        tenant = file&.resource&.tenant
+        if file.blank? || tenant.blank?
+          render status: 404, text: 'Not found'
+          return
+        end
+
+        http = HTTP.timeout(connect: 30, read: 30).timeout(7200).follow(max_hops: 2)
+          .basic_auth(user: tenant.repository.username, pass: tenant.repository.password)
+
+        # ui: GET /api/presign-file/:object/:version/producer%2F:file
+        r = http.get(url(file: file))
+        handle_bad_status(r, file)
+        resp = r.parse.with_indifferent_access
+        cc.redirect_to resp[:url]
+      rescue HTTP::Error => e
+        raise MerrittError, "HTTP Error while creating presigned URL with Merritt\n" \
+          "#{url(file: file)}\n" \
+          "Original HTTP library error: #{e}\n" \
+          "#{e.backtrace.join("\n")}"
+      end
+
+      def url(file:)
+        resource = file.resource
+        domain, local_id = resource.merritt_protodomain_and_local_id
+        "#{domain}/api/presign-file/#{local_id}/#{resource.stash_version.merritt_version}/" \
+          "producer%2F#{ERB::Util.url_encode(file.upload_file_name)}?no_redirect=true"
+      end
+
+      def handle_bad_status(r, file)
+        return if r.status.success?
+
+        raise MerrittError, "Merritt couldn't create presigned URL for #{url(file: file)}\nHttp status code: #{r.status.code}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
When you click the download in the UI or go to a link in the API it obtains and gives a redirect to the presigned URL.