### PR TITLE
API update -- download fix, curationStatus

### DIFF
--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -111,18 +111,10 @@ module StashApi
     # get /datasets/<id>/download
     def download
       res = @stash_identifier.latest_downloadable_resource(user: @user)
-
-      #render text: " was going to log res #{res.id}, current_user #{@user.id}", status: 404
-      logger.info(" res #{res.id}, current_user #{@user.id}")
-      if res.may_download?(ui_user: @user)
+      if res&.may_download?(ui_user: @user)
         @version_streamer.download(resource: res) do
-          redirect_to landing_show_path(id: res.identifier_str, big: 'showme') # if it's an async
+          redirect_to stash_url_helpers.landing_show_path(id: res.identifier_str, big: 'showme') # if it's an async
         end
-
-      #if res&.download_uri
-      #  StashEngine::CounterLogger.version_download_hit(request: request, resource: res) if res
-      #  redirect_to res.merritt_producer_download_uri # latest version, friendly download because that's what we do in UI for object
-
       else
         render text: 'download for this version of the dataset is unavailable', status: 404
       end

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -28,7 +28,7 @@ module StashApi
       @version_streamer = Stash::Download::Version.new(controller_context: self)
       @file_streamer = Stash::Download::File.new(controller_context: self)
     end
-    
+
     # get /datasets/<id>
     def show
       ds = Dataset.new(identifier: @stash_identifier.to_s, user: @user)

--- a/stash/stash_api/app/models/stash_api/version/metadata.rb
+++ b/stash/stash_api/app/models/stash_api/version/metadata.rb
@@ -8,6 +8,7 @@ module StashApi
         @resource = resource
       end
 
+      # rubocop:disable Metrics/AbcSize
       def value
         # setting some false values to nil because they get compacted.  Don't really want to advertise these options for
         # use by others besides ourselves because we don't want others to use them.
@@ -24,6 +25,7 @@ module StashApi
           relatedWorks: RelatedWorks.new(resource: @resource).value,
           versionNumber: @resource.try(:stash_version).try(:version),
           versionStatus: @resource.current_state,
+          curationStatus: StashEngine::CurationActivity.latest(@resource&.id)&.readable_status,
           userId: @resource.user_id,
           skipDataciteUpdate: @resource.skip_datacite_update || nil,
           skipEmails: @resource.skip_emails || nil,
@@ -31,6 +33,7 @@ module StashApi
           loosenValidation: @resource.loosen_validation || nil
         }
       end
+      # rubocop:enable Metrics/AbcSize
 
     end
   end

--- a/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
@@ -81,6 +81,7 @@ module StashEngine
 
     # method to download by the secret sharing link, must match the string they generated to look up and download
     def share
+      return if params.blank?
       @shares = Share.where(secret_id: params[:id])
       raise ActionController::RoutingError, 'Not Found' if @shares.count < 1
 

--- a/stash/stash_engine/app/views/stash_engine/pages/home.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/pages/home.html.erb
@@ -7,7 +7,7 @@
 <div class="t-home__quote-search-group">
   <div class="t-home__quote o-quote">
     <div class="o-quote__quote">
-      Dryad is a community-owned resource
+      Dryad is a community-owned resource.
       <br>
       <a href="<%= stash_url_helpers.our_community_path %>" class="o-quote__quote">Learn more about our organizational memberships</a>
     </div>

--- a/stash/stash_engine/app/views/stash_engine/pages/home.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/pages/home.html.erb
@@ -7,7 +7,7 @@
 <div class="t-home__quote-search-group">
   <div class="t-home__quote o-quote">
     <div class="o-quote__quote">
-      Dryad is a community-owned resource.
+      Dryad is a community-owned resource
       <br>
       <a href="<%= stash_url_helpers.our_community_path %>" class="o-quote__quote">Learn more about our organizational memberships</a>
     </div>


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/556
Modify the API for /datasets/{doi}/download so the file actually downloads instead of getting into a Merritt redirect loop.

For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/659
Allow API users to see the curation status of a version directly in the version's description. 

Also, guard against nil object errors when people construct fake URLs in an attempt to view peer_review content.