### PR TITLE
API update -- curationStatus

### DIFF
--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -19,7 +19,14 @@ module StashApi
     # before_action :require_in_progress_resource, only: :update
     before_action :require_permission, only: :update
     before_action :lock_down_admin_only_params, only: %i[create update]
+    before_action :setup_streaming
 
+    # set up the Merritt file & version objects so they have access to the controller context before continuing
+    def setup_streaming
+      @version_streamer = Stash::Download::Version.new(controller_context: self)
+      @file_streamer = Stash::Download::File.new(controller_context: self)
+    end
+    
     # get /datasets/<id>
     def show
       ds = Dataset.new(identifier: @stash_identifier.to_s, user: @user)
@@ -102,9 +109,14 @@ module StashApi
     # get /datasets/<id>/download
     def download
       res = @stash_identifier.latest_viewable_resource(user: @user)
-      if res&.download_uri
-        StashEngine::CounterLogger.version_download_hit(request: request, resource: res) if res
-        redirect_to res.merritt_producer_download_uri # latest version, friendly download because that's what we do in UI for object
+
+      if @resource.may_download?(ui_user: current_user)
+        @version_streamer.download(resource: @resource) do
+          redirect_to landing_show_path(id: @resource.identifier_str, big: 'showme') # if it's an async
+        end
+      #if res&.download_uri
+      #  StashEngine::CounterLogger.version_download_hit(request: request, resource: res) if res
+      #  redirect_to res.merritt_producer_download_uri # latest version, friendly download because that's what we do in UI for object
       else
         render text: 'download for this version of the dataset is unavailable', status: 404
       end

--- a/stash/stash_api/app/models/stash_api/version/metadata.rb
+++ b/stash/stash_api/app/models/stash_api/version/metadata.rb
@@ -8,6 +8,7 @@ module StashApi
         @resource = resource
       end
 
+      # rubocop:disable Metrics/AbcSize
       def value
         # setting some false values to nil because they get compacted.  Don't really want to advertise these options for
         # use by others besides ourselves because we don't want others to use them.
@@ -32,6 +33,7 @@ module StashApi
           loosenValidation: @resource.loosen_validation || nil
         }
       end
+      # rubocop:enable Metrics/AbcSize
 
     end
   end

--- a/stash/stash_api/app/models/stash_api/version/metadata.rb
+++ b/stash/stash_api/app/models/stash_api/version/metadata.rb
@@ -24,6 +24,7 @@ module StashApi
           relatedWorks: RelatedWorks.new(resource: @resource).value,
           versionNumber: @resource.try(:stash_version).try(:version),
           versionStatus: @resource.current_state,
+          curationStatus: StashEngine::CurationActivity.latest(@resource&.id)&.readable_status,
           userId: @resource.user_id,
           skipDataciteUpdate: @resource.skip_datacite_update || nil,
           skipEmails: @resource.skip_emails || nil,

--- a/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
@@ -81,7 +81,7 @@ module StashEngine
 
     # method to download by the secret sharing link, must match the string they generated to look up and download
     def share
-      @shares = Share.where(secret_id: params[:id])
+      @shares = Share.where(secret_id: params&[:id])
       raise ActionController::RoutingError, 'Not Found' if @shares.count < 1
 
       @resource = @shares.first.identifier&.last_submitted_resource

--- a/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
@@ -81,7 +81,7 @@ module StashEngine
 
     # method to download by the secret sharing link, must match the string they generated to look up and download
     def share
-      @shares = Share.where(secret_id: params&[:id])
+      @shares = Share.where(secret_id: params & [:id])
       raise ActionController::RoutingError, 'Not Found' if @shares.count < 1
 
       @resource = @shares.first.identifier&.last_submitted_resource

--- a/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
@@ -81,7 +81,8 @@ module StashEngine
 
     # method to download by the secret sharing link, must match the string they generated to look up and download
     def share
-      @shares = Share.where(secret_id: params & [:id])
+      return if params.blank?
+      @shares = Share.where(secret_id: params[:id])
       raise ActionController::RoutingError, 'Not Found' if @shares.count < 1
 
       @resource = @shares.first.identifier&.last_submitted_resource


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/659

Allow API users to see the curation status of a version directly in the version's description. 

Also, guard against nil object errors when people construct fake URLs in an attempt to view peer_review content.