### PR TITLE
Make Merritt URLs download from presigned URLs

### DIFF
--- a/spec/lib/stash/download/file_presigned_spec.rb
+++ b/spec/lib/stash/download/file_presigned_spec.rb
@@ -22,28 +22,10 @@ module Stash
         @fp = FilePresigned.new(controller_context: @controller_context)
       end
 
-      describe '#handle_bad_status(r, file)' do
-        it 'raises exception if r.status.success? is false' do
-          r = double
-          allow(r).to receive(:status).and_return({ 'success?': false }.to_ostruct)
-          expect { @fp.handle_bad_status(r, @file_upload) }.to raise_error(Stash::Download::MerrittError)
-        end
-      end
-
-      describe '#url(file:)' do
-        it 'creates the url for a file' do
-          ark = @resource.download_uri.match(/ark.+/).to_s
-          resp = @fp.url(file: @file_upload)
-          out_url = "http://merritt-fake.cdlib.org/api/presign-file/#{ark}/1/producer%2F" \
-            "#{ERB::Util.url_encode(@file_upload.upload_file_name)}?no_redirect=true"
-          expect(resp).to eq(out_url)
-        end
-      end
-
       describe '#download(file:)' do
 
         before(:each) do
-          @stubby = stub_request(:get, @fp.url(file: @file_upload))
+          @stubby = stub_request(:get, @file_upload.merritt_presign_info_url)
             .with(
               headers: {
                 'Authorization' => 'Basic c3Rhc2hfc3VibWl0dGVyOmNvcnJlY3TigItob3JzZeKAi2JhdHRlcnnigItzdGFwbGU=',
@@ -67,7 +49,7 @@ module Stash
         it 'raises an error for bad status response from Merritt' do
           remove_request_stub(@stubby)
 
-          stub_request(:get, @fp.url(file: @file_upload))
+          stub_request(:get, @file_upload.merritt_presign_info_url)
             .with(
               headers: {
                 'Authorization' => 'Basic c3Rhc2hfc3VibWl0dGVyOmNvcnJlY3TigItob3JzZeKAi2JhdHRlcnnigItzdGFwbGU=',

--- a/spec/lib/stash/merritt_download/file_collection_spec.rb
+++ b/spec/lib/stash/merritt_download/file_collection_spec.rb
@@ -47,10 +47,10 @@ module Stash
           # first return from Merritt
           stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 200,
                                                                               body: '{"url": "http://presigned.example.com/is/great/39768945"}',
-                                                                              headers: {'Content-Type': 'application/json' })
+                                                                              headers: { 'Content-Type': 'application/json' })
 
-          stub_request(:get, "http://presigned.example.com/is/great/39768945")
-              .to_return(status: 404, body: '', headers: {})
+          stub_request(:get, 'http://presigned.example.com/is/great/39768945')
+            .to_return(status: 404, body: '', headers: {})
 
           expect { @fc.download_files }.to raise_error(Stash::MerrittDownload::DownloadError)
         end
@@ -59,9 +59,9 @@ module Stash
           # first return from Merritt
           stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 200,
                                                                               body: '{"url": "http://presigned.example.com/is/great/39768945"}',
-                                                                              headers: {'Content-Type': 'application/json' })
+                                                                              headers: { 'Content-Type': 'application/json' })
 
-          stub_request(:get, "http://presigned.example.com/is/great/39768945")
+          stub_request(:get, 'http://presigned.example.com/is/great/39768945')
             .to_return(status: 200, body: '', headers: {})
           @fc.download_files
           expect(@fc.info_hash.keys).to include(@file_upload.upload_file_name)

--- a/spec/lib/stash/merritt_download/file_spec.rb
+++ b/spec/lib/stash/merritt_download/file_spec.rb
@@ -47,7 +47,7 @@ module Stash
           # first return from Merritt
           stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 200,
                                                                               body: '{"url": "http://presigned.example.com/is/great/39768945"}',
-                                                                              headers: {'Content-Type': 'application/json' })
+                                                                              headers: { 'Content-Type': 'application/json' })
 
           # second return from S3
           stub_request(:get, 'http://presigned.example.com/is/great/39768945').to_return(status: 404,
@@ -64,7 +64,7 @@ module Stash
           # first return from Merritt
           stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 200,
                                                                               body: '{"url": "http://presigned.example.com/is/great/39768945"}',
-                                                                              headers: {'Content-Type': 'application/json' })
+                                                                              headers: { 'Content-Type': 'application/json' })
 
           # second return from S3
           stub_request(:get, 'http://presigned.example.com/is/great/39768945').to_return(status: 500,
@@ -77,17 +77,16 @@ module Stash
           expect(dl_status[:error]).to include("resource #{@resource.id}")
         end
 
-
         it 'expects download to return success: true in hash and dl file if 200' do
           # first return from Merritt
           stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 200,
-            body: '{"url": "http://presigned.example.com/is/great/39768945"}',
-            headers: {'Content-Type': 'application/json' })
+                                                                              body: '{"url": "http://presigned.example.com/is/great/39768945"}',
+                                                                              headers: { 'Content-Type': 'application/json' })
 
           # second return from S3
           stub_request(:get, 'http://presigned.example.com/is/great/39768945').to_return(status: 200,
-            body: 'My Best File',
-            headers: {})
+                                                                                         body: 'My Best File',
+                                                                                         headers: {})
 
           dl_status = @file_dl_obj.download_file(db_file: @file_upload)
           expect(dl_status[:success]).to eq(true)
@@ -98,7 +97,7 @@ module Stash
           # first return from Merritt
           stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 200,
                                                                               body: '{"url": "http://presigned.example.com/is/great/39768945"}',
-                                                                              headers: {'Content-Type': 'application/json' })
+                                                                              headers: { 'Content-Type': 'application/json' })
 
           # second return from S3
           stub_request(:get, 'http://presigned.example.com/is/great/39768945').to_return(status: 200,
@@ -115,7 +114,7 @@ module Stash
           # first return from Merritt
           stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 200,
                                                                               body: '{"url": "http://presigned.example.com/is/great/39768945"}',
-                                                                              headers: {'Content-Type': 'application/json' })
+                                                                              headers: { 'Content-Type': 'application/json' })
 
           # second return from S3
           stub_request(:get, 'http://presigned.example.com/is/great/39768945').to_return(status: 200,
@@ -134,7 +133,7 @@ module Stash
           # first return from Merritt
           stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 200,
                                                                               body: '{"url": "http://presigned.example.com/is/great/39768945"}',
-                                                                              headers: {'Content-Type': 'application/json' })
+                                                                              headers: { 'Content-Type': 'application/json' })
 
           # second return from S3
           stub_request(:get, 'http://presigned.example.com/is/great/39768945').to_return(status: 200,

--- a/spec/lib/stash/merritt_download/file_spec.rb
+++ b/spec/lib/stash/merritt_download/file_spec.rb
@@ -24,8 +24,9 @@ module Stash
       end
 
       describe '#download_file' do
-        it 'expects download to return success: false in hash if 404' do
-          stub_request(:get, @file_dl_obj.download_file_url(filename: @file_upload.upload_file_name)).to_return(status: 404, body: '', headers: {})
+        # these are two-step to download: first get presign url and then download it
+        it 'expects download to return success: false in hash if 404 from Merritt' do
+          stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 404, body: '', headers: {})
           dl_status = @file_dl_obj.download_file(db_file: @file_upload)
           expect(dl_status[:success]).to eq(false)
           expect(dl_status[:error]).to include('404')
@@ -33,8 +34,8 @@ module Stash
           expect(dl_status[:error]).to include("resource #{@resource.id}")
         end
 
-        it 'expects download to return success: false in hash if 500' do
-          stub_request(:get, @file_dl_obj.download_file_url(filename: @file_upload.upload_file_name)).to_return(status: 500, body: '', headers: {})
+        it 'expects download to return success: false in hash if 500 from S3' do
+          stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 500, body: '', headers: {})
           dl_status = @file_dl_obj.download_file(db_file: @file_upload)
           expect(dl_status[:success]).to eq(false)
           expect(dl_status[:error]).to include('500')
@@ -42,17 +43,68 @@ module Stash
           expect(dl_status[:error]).to include("resource #{@resource.id}")
         end
 
+        it 'expects download to return success: false in hash if 404 from S3' do
+          # first return from Merritt
+          stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 200,
+                                                                              body: '{"url": "http://presigned.example.com/is/great/39768945"}',
+                                                                              headers: {'Content-Type': 'application/json' })
+
+          # second return from S3
+          stub_request(:get, 'http://presigned.example.com/is/great/39768945').to_return(status: 404,
+                                                                                         body: '',
+                                                                                         headers: {})
+          dl_status = @file_dl_obj.download_file(db_file: @file_upload)
+          expect(dl_status[:success]).to eq(false)
+          expect(dl_status[:error]).to include('404')
+          expect(dl_status[:error]).to include(@file_upload.upload_file_name)
+          expect(dl_status[:error]).to include("resource #{@resource.id}")
+        end
+
+        it 'expects download to return success: false in hash if 500 from S3' do
+          # first return from Merritt
+          stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 200,
+                                                                              body: '{"url": "http://presigned.example.com/is/great/39768945"}',
+                                                                              headers: {'Content-Type': 'application/json' })
+
+          # second return from S3
+          stub_request(:get, 'http://presigned.example.com/is/great/39768945').to_return(status: 500,
+                                                                                         body: '',
+                                                                                         headers: {})
+          dl_status = @file_dl_obj.download_file(db_file: @file_upload)
+          expect(dl_status[:success]).to eq(false)
+          expect(dl_status[:error]).to include('500')
+          expect(dl_status[:error]).to include(@file_upload.upload_file_name)
+          expect(dl_status[:error]).to include("resource #{@resource.id}")
+        end
+
+
         it 'expects download to return success: true in hash and dl file if 200' do
-          stub_request(:get, @file_dl_obj.download_file_url(filename: @file_upload.upload_file_name))
-            .to_return(status: 200, body: 'My Best File', headers: {})
+          # first return from Merritt
+          stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 200,
+            body: '{"url": "http://presigned.example.com/is/great/39768945"}',
+            headers: {'Content-Type': 'application/json' })
+
+          # second return from S3
+          stub_request(:get, 'http://presigned.example.com/is/great/39768945').to_return(status: 200,
+            body: 'My Best File',
+            headers: {})
+
           dl_status = @file_dl_obj.download_file(db_file: @file_upload)
           expect(dl_status[:success]).to eq(true)
           expect(::File.exist?(::File.join(@file_dl_obj.path, @file_upload.upload_file_name))).to eq(true)
         end
 
         it 'expects downloads to have correct digests' do
-          stub_request(:get, @file_dl_obj.download_file_url(filename: @file_upload.upload_file_name))
-            .to_return(status: 200, body: 'So many fun times', headers: {})
+          # first return from Merritt
+          stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 200,
+                                                                              body: '{"url": "http://presigned.example.com/is/great/39768945"}',
+                                                                              headers: {'Content-Type': 'application/json' })
+
+          # second return from S3
+          stub_request(:get, 'http://presigned.example.com/is/great/39768945').to_return(status: 200,
+                                                                                         body: 'So many fun times',
+                                                                                         headers: {})
+
           dl_status = @file_dl_obj.download_file(db_file: @file_upload)
           expect(dl_status[:success]).to eq(true)
           expect(dl_status[:md5_hex]).to eq('c5849711a1f1ff03de4d96873defa382')
@@ -60,8 +112,16 @@ module Stash
         end
 
         it 'expect digest not to match normal values if body is changed' do
-          stub_request(:get, @file_dl_obj.download_file_url(filename: @file_upload.upload_file_name))
-            .to_return(status: 200, body: 'The cat meows in my face.', headers: {})
+          # first return from Merritt
+          stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 200,
+                                                                              body: '{"url": "http://presigned.example.com/is/great/39768945"}',
+                                                                              headers: {'Content-Type': 'application/json' })
+
+          # second return from S3
+          stub_request(:get, 'http://presigned.example.com/is/great/39768945').to_return(status: 200,
+                                                                                         body: 'The cat meows in my face.',
+                                                                                         headers: {})
+
           dl_status = @file_dl_obj.download_file(db_file: @file_upload)
           expect(dl_status[:success]).to eq(true)
           expect(dl_status[:md5_hex]).not_to eq('c5849711a1f1ff03de4d96873defa382')
@@ -70,25 +130,26 @@ module Stash
 
         it "should raise an error if a digest is specified in the database and it doesn't match" do
           @file_upload = create(:file_upload, resource_id: @resource.id, digest_type: 'md5', digest: 'c5849711a1f1ff03de4d96873defa382')
-          stub_request(:get, @file_dl_obj.download_file_url(filename: @file_upload.upload_file_name))
-            .to_return(status: 200, body: 'The cat meows in my face.', headers: {})
+
+          # first return from Merritt
+          stub_request(:get, @file_upload.merritt_presign_info_url).to_return(status: 200,
+                                                                              body: '{"url": "http://presigned.example.com/is/great/39768945"}',
+                                                                              headers: {'Content-Type': 'application/json' })
+
+          # second return from S3
+          stub_request(:get, 'http://presigned.example.com/is/great/39768945').to_return(status: 200,
+                                                                                         body: 'The cat meows in my face.',
+                                                                                         headers: {})
+
           expect { @file_dl_obj.download_file(db_file: @file_upload) }.to raise_error(Stash::MerrittDownload::DownloadError)
         end
       end
 
-      describe '#get_url' do
+      describe '#get_url(url:)' do
         it 'creates http.rb response object' do
-          stub_request(:get, @file_dl_obj.download_file_url(filename: @file_upload.upload_file_name)).to_return(status: 404, body: '', headers: {})
-          dl_url = @file_dl_obj.get_url(filename: @file_upload.upload_file_name)
+          stub_request(:get, 'http://test.the.url.example.com').to_return(status: 404, body: '', headers: {})
+          dl_url = @file_dl_obj.get_url(url: 'http://test.the.url.example.com')
           expect(dl_url).to be_a(HTTP::Response)
-        end
-      end
-
-      describe '#download_file_url' do
-        it 'generates a Merritt Express file url' do
-          dl_url = @file_dl_obj.download_file_url(filename: @file_upload.upload_file_name)
-          expect(dl_url).to start_with("#{APP_CONFIG.merritt_express_base_url}/dv/#{@resource.stash_version.merritt_version}")
-          expect(dl_url).to end_with(ERB::Util.url_encode(@file_upload.upload_file_name))
         end
       end
 

--- a/stash/stash_engine/app/models/stash_engine/file_upload.rb
+++ b/stash/stash_engine/app/models/stash_engine/file_upload.rb
@@ -86,7 +86,8 @@ module StashEngine
       "#{domain}/d/#{ark}/#{resource.stash_version.merritt_version}/#{ERB::Util.url_encode(upload_file_name)}"
     end
 
-    def presign_info_url
+    # the Merritt URL to query in order to get the information on the presigned URL
+    def merritt_presign_info_url
       domain, local_id = resource.merritt_protodomain_and_local_id
       "#{domain}/api/presign-file/#{local_id}/#{resource.stash_version.merritt_version}/" \
           "producer%2F#{ERB::Util.url_encode(upload_file_name)}?no_redirect=true"

--- a/stash/stash_engine/app/models/stash_engine/file_upload.rb
+++ b/stash/stash_engine/app/models/stash_engine/file_upload.rb
@@ -86,6 +86,12 @@ module StashEngine
       "#{domain}/d/#{ark}/#{resource.stash_version.merritt_version}/#{ERB::Util.url_encode(upload_file_name)}"
     end
 
+    def presign_info_url
+      domain, local_id = resource.merritt_protodomain_and_local_id
+      "#{domain}/api/presign-file/#{local_id}/#{resource.stash_version.merritt_version}/" \
+          "producer%2F#{ERB::Util.url_encode(upload_file_name)}?no_redirect=true"
+    end
+
     # example
     # http://mrtexpress-stage.cdlib.org/dv/<version>/<ark>/<file pathname>
     def merritt_express_url

--- a/stash/stash_engine/app/models/stash_engine/file_upload.rb
+++ b/stash/stash_engine/app/models/stash_engine/file_upload.rb
@@ -102,7 +102,7 @@ module StashEngine
       raise Stash::Download::MerrittError, "Tenant not defined for resource_id: #{resource&.id}" if resource&.tenant.blank?
 
       http = HTTP.timeout(connect: 30, read: 30).timeout(60).follow(max_hops: 2)
-                 .basic_auth(user: resource.tenant.repository.username, pass: resource.tenant.repository.password)
+        .basic_auth(user: resource.tenant.repository.username, pass: resource.tenant.repository.password)
 
       r = http.get(merritt_presign_info_url)
 

--- a/stash/stash_engine/app/models/stash_engine/file_upload.rb
+++ b/stash/stash_engine/app/models/stash_engine/file_upload.rb
@@ -1,5 +1,6 @@
 require 'zaru'
 require 'cgi'
+require 'stash/download/file_presigned' # to import the Stash::Download::Merritt exception
 
 # rubocop:disable Metrics/ClassLength
 module StashEngine
@@ -91,6 +92,24 @@ module StashEngine
       domain, local_id = resource.merritt_protodomain_and_local_id
       "#{domain}/api/presign-file/#{local_id}/#{resource.stash_version.merritt_version}/" \
           "producer%2F#{ERB::Util.url_encode(upload_file_name)}?no_redirect=true"
+    end
+
+    # this will do the http request to Merritt to get the presigned URL, putting here instead of other classes since it gets
+    # reused in a few places.  If we move to a different repo this will need to change.
+    #
+    # If you use this method, you need to rescue the HTTP::Error and Stash::Download::Merritt errors if you don't want them raised
+    def s3_presigned_url
+      raise Stash::Download::MerrittError, "Tenant not defined for resource_id: #{resource&.id}" if resource&.tenant.blank?
+
+      http = HTTP.timeout(connect: 30, read: 30).timeout(60).follow(max_hops: 2)
+                 .basic_auth(user: resource.tenant.repository.username, pass: resource.tenant.repository.password)
+
+      r = http.get(merritt_presign_info_url)
+
+      return r.parse.with_indifferent_access[:url] if r.status.success?
+
+      raise Stash::Download::MerrittError,
+            "Merritt couldn't create presigned URL for #{merritt_presign_info_url}\nHttp status code: #{r.status.code}"
     end
 
     # example

--- a/stash/stash_engine/lib/stash/download/file_presigned.rb
+++ b/stash/stash_engine/lib/stash/download/file_presigned.rb
@@ -29,13 +29,13 @@ module Stash
           .basic_auth(user: tenant.repository.username, pass: tenant.repository.password)
 
         # ui: GET /api/presign-file/:object/:version/producer%2F:file
-        r = http.get(file.presign_info_url)
+        r = http.get(file.merritt_presign_info_url)
         handle_bad_status(r, file)
         resp = r.parse.with_indifferent_access
         cc.redirect_to resp[:url]
       rescue HTTP::Error => e
         raise MerrittError, "HTTP Error while creating presigned URL with Merritt\n" \
-          "#{file.presign_info_url}\n" \
+          "#{file.merritt_presign_info_url}\n" \
           "Original HTTP library error: #{e}\n" \
           "#{e.backtrace.join("\n")}"
       end

--- a/stash/stash_engine/lib/stash/download/file_presigned.rb
+++ b/stash/stash_engine/lib/stash/download/file_presigned.rb
@@ -29,22 +29,15 @@ module Stash
           .basic_auth(user: tenant.repository.username, pass: tenant.repository.password)
 
         # ui: GET /api/presign-file/:object/:version/producer%2F:file
-        r = http.get(url(file: file))
+        r = http.get(file.presign_info_url)
         handle_bad_status(r, file)
         resp = r.parse.with_indifferent_access
         cc.redirect_to resp[:url]
       rescue HTTP::Error => e
         raise MerrittError, "HTTP Error while creating presigned URL with Merritt\n" \
-          "#{url(file: file)}\n" \
+          "#{file.presign_info_url}\n" \
           "Original HTTP library error: #{e}\n" \
           "#{e.backtrace.join("\n")}"
-      end
-
-      def url(file:)
-        resource = file.resource
-        domain, local_id = resource.merritt_protodomain_and_local_id
-        "#{domain}/api/presign-file/#{local_id}/#{resource.stash_version.merritt_version}/" \
-          "producer%2F#{ERB::Util.url_encode(file.upload_file_name)}?no_redirect=true"
       end
 
       def handle_bad_status(r, file)

--- a/stash/stash_engine/lib/stash/download/file_presigned.rb
+++ b/stash/stash_engine/lib/stash/download/file_presigned.rb
@@ -25,25 +25,14 @@ module Stash
           return
         end
 
-        http = HTTP.timeout(connect: 30, read: 30).timeout(7200).follow(max_hops: 2)
-          .basic_auth(user: tenant.repository.username, pass: tenant.repository.password)
+        url = file.s3_presigned_url
 
-        # ui: GET /api/presign-file/:object/:version/producer%2F:file
-        r = http.get(file.merritt_presign_info_url)
-        handle_bad_status(r, file)
-        resp = r.parse.with_indifferent_access
-        cc.redirect_to resp[:url]
+        cc.redirect_to url
       rescue HTTP::Error => e
         raise MerrittError, "HTTP Error while creating presigned URL with Merritt\n" \
           "#{file.merritt_presign_info_url}\n" \
           "Original HTTP library error: #{e}\n" \
           "#{e.backtrace.join("\n")}"
-      end
-
-      def handle_bad_status(r, file)
-        return if r.status.success?
-
-        raise MerrittError, "Merritt couldn't create presigned URL for #{url(file: file)}\nHttp status code: #{r.status.code}"
       end
     end
   end

--- a/stash/stash_engine/lib/stash/merritt_download/file.rb
+++ b/stash/stash_engine/lib/stash/merritt_download/file.rb
@@ -24,7 +24,7 @@ module Stash
         s3_resp = get_url(url: db_file.s3_presigned_url)
 
         unless s3_resp.status.success?
-          return { success: false, error: "#{mrt_resp.status.code} status code retrieving '#{db_file.upload_file_name}' " \
+          return { success: false, error: "#{s3_resp.status.code} status code retrieving '#{db_file.upload_file_name}' " \
               "for resource #{@resource.id}" }
         end
 
@@ -43,6 +43,8 @@ module Stash
         get_digests(md5_obj: md5, sha256_obj: sha256, db_file: db_file).merge(success: true)
       rescue HTTP::Error => ex
         { success: false, error: "Error downloading file for resource #{@resource.id}\nHTTP::Error #{ex}" }
+      rescue Stash::Download::MerrittError => ex
+        { success: false, error: "Error downloading file for resource #{@resource.id}\nMerrittError: #{ex}"}
       end
 
       # gets the file url and returns an HTTP.get(url) response object

--- a/stash/stash_engine/lib/stash/merritt_download/file.rb
+++ b/stash/stash_engine/lib/stash/merritt_download/file.rb
@@ -44,7 +44,7 @@ module Stash
       rescue HTTP::Error => ex
         { success: false, error: "Error downloading file for resource #{@resource.id}\nHTTP::Error #{ex}" }
       rescue Stash::Download::MerrittError => ex
-        { success: false, error: "Error downloading file for resource #{@resource.id}\nMerrittError: #{ex}"}
+        { success: false, error: "Error downloading file for resource #{@resource.id}\nMerrittError: #{ex}" }
       end
 
       # gets the file url and returns an HTTP.get(url) response object

--- a/stash/stash_engine/lib/stash/merritt_download/file.rb
+++ b/stash/stash_engine/lib/stash/merritt_download/file.rb
@@ -1,7 +1,6 @@
 # I have been favoring the 'httprb/http' gem recently since it is small, fast and pretty easy to use, similar to Python's
 # requests library. See https://twin.github.io/httprb-is-great/ .
 require 'http'
-require 'cgi'
 require 'byebug'
 require 'digest'
 require 'fileutils'
@@ -22,9 +21,9 @@ module Stash
 
       # download file a and return a hash, we should be tracking success routinely since downloads are error-prone
       def download_file(db_file:)
-        mrt_resp = get_url(filename: db_file.upload_file_name)
+        s3_resp = get_url(url: db_file.s3_presigned_url)
 
-        unless mrt_resp.status.success?
+        unless s3_resp.status.success?
           return { success: false, error: "#{mrt_resp.status.code} status code retrieving '#{db_file.upload_file_name}' " \
               "for resource #{@resource.id}" }
         end
@@ -34,7 +33,7 @@ module Stash
 
         # this doesn't load everything into memory at once and writes in chunks and calculates digests at the same time
         ::File.open(::File.join(@path, db_file.upload_file_name), 'wb') do |f|
-          mrt_resp.body.each do |chunk|
+          s3_resp.body.each do |chunk|
             f.write(chunk)
             md5.update(chunk)
             sha256.update(chunk)
@@ -47,21 +46,9 @@ module Stash
       end
 
       # gets the file url and returns an HTTP.get(url) response object
-      def get_url(filename:, read_timeout: 30)
-        url = download_file_url(filename: filename)
-
+      def get_url(url:, read_timeout: 30)
         http = HTTP.timeout(connect: 30, read: read_timeout).timeout(7200).follow(max_hops: 10)
-          .basic_auth(user: @resource.tenant.repository.username, pass: @resource.tenant.repository.password)
-
         http.get(url)
-      end
-
-      def download_file_url(filename:)
-        # domain is not used for MerrittExpress, because the domain is different than the one given by SWORD, only for Merritt UI
-        _domain, ark = @resource.merritt_protodomain_and_local_id
-
-        "#{APP_CONFIG.merritt_express_base_url}/dv/#{@resource.stash_version.merritt_version}" \
-          "/#{CGI.unescape(ark)}/#{ERB::Util.url_encode(filename).gsub('%252F', '%2F')}"
       end
 
       # rubocop:disable Metrics/CyclomaticComplexity


### PR DESCRIPTION
This should be pretty much the same procedure as the previous PR if you want to test manually ( https://github.com/CDL-Dryad/dryad-app/pull/95 ), but now it's using S3 instead.  It adds another query (Merritt) in addition to S3 to download.

I also had to refactor and redo lots of mocks/stubs and testing.