### PR TITLE
Improve handling of submitted_date

### DIFF
--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -359,7 +359,7 @@ module StashEngine
     # Date on which the user first submitted this dataset
     # (for peer_review datasets, the date at which it came out of peer_review)
     def submitted_date
-      curation_activities.order(:id).where(status: 'submitted')&.first&.created_at
+      curation_activities.order(:id).where("status = 'submitted' OR status = 'curation'")&.first&.created_at
     end
 
     # Create the initial CurationActivity

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -220,10 +220,13 @@ namespace :identifiers do
               'Size', 'Payment Type', 'Payment ID', 'Institution Name',
               'Journal Name', 'Sponsor Name']
       StashEngine::Identifier.publicly_viewable.each do |i|
-        created_date_str = i.created_at&.strftime('%Y-%m-%d')
-        submitted_date_str = i.first_submitted_resource&.submitted_date&.strftime('%Y-%m-%d')
         approval_date_str = i.approval_date&.strftime('%Y-%m-%d')
         next unless approval_date_str&.start_with?(year_month)
+        created_date_str = i.created_at&.strftime('%Y-%m-%d')
+        submitted_date = i.resources.submitted.each do |r|
+          break r.submitted_date if r.submitted_date.present?
+        end
+        submitted_date_str = submitted_date&.strftime('%Y-%m-%d')
         csv << [i.identifier, created_date_str, submitted_date_str, approval_date_str,
                 i.storage_size, i.payment_type, i.payment_id, i.submitter_affiliation&.long_name,
                 i.publication_name, i.journal_sponsor_name]

--- a/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
@@ -1184,6 +1184,15 @@ module StashEngine
           expect(res.submitted_date.to_date).to eql(Date.parse('2020-01-02'))
         end
 
+        it 'returns the correct submitted_date when an item went straight from peer_review to curation' do
+          res = create(:resource, user_id: @user.id, tenant_id: @user.tenant_id)
+          create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-01', status: 'in_progress')
+          create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-02', status: 'peer_review')
+          create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-03', status: 'curation')
+          create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-04', status: 'published')
+          expect(res.submitted_date.to_date).to eql(Date.parse('2020-01-03'))
+        end
+
         it 'returns nil if there is no submitted_date' do
           res = create(:resource, user_id: @user.id, tenant_id: @user.tenant_id)
           create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-01', status: 'in_progress')


### PR DESCRIPTION
After running the quarterly shopping_cart_report, I noticed that some items weren't getting a submitted_date. The cause for this was that identifier.first_submitted_resource refers to `resource_state == submitted`, rather than `curation_status == submitted`. So some logic changes were required. Also, it is possible for an item to never have curation_status == submitted, if the curators manually pull it out of peer_review status.