### PR TITLE
Filter whitespace out of DOI strings

### DIFF
--- a/stash/stash_datacite/lib/stash/import/crossref.rb
+++ b/stash/stash_datacite/lib/stash/import/crossref.rb
@@ -21,7 +21,7 @@ module Stash
       class << self
         def query_by_doi(resource:, doi:)
           return nil unless resource.present? && doi.present?
-          resp = Serrano.works(ids: doi.strip)
+          resp = Serrano.works(ids: doi.gsub(/\s+/, ''))
           return nil unless resp.first.present? && resp.first['message'].present?
 
           new(resource: resource, crossref_json: resp.first['message'])


### PR DESCRIPTION
Users often add whitespace into DOIs, like "doi: 10.1111/oik.07059", which throws an error in the CrossRef lookup.

This removes any extra whitespace.