### PR TITLE
Allow replication to use ActiveJob (delayed job backend) and handle long running

### DIFF
--- a/documentation/zenodo_integration/delayed_jobs.md
+++ b/documentation/zenodo_integration/delayed_jobs.md
@@ -64,3 +64,54 @@ We really may want to move our Merritt submissions to use something
 like this rather than the expansion I made to David's home-baked
 queueing system which still runs inside the UI server processes and
 can have problems if the UI server goes down at a bad time.
+
+
+To test jobs go through and get processed with ActiveJob
+--------------------------------------------------------
+
+```
+RAILS_ENV=local_dev bin/delayed_job start
+```
+
+from RAILS_ENV=local_dev rails console:
+```
+resource = StashEngine::Resource.find(<id>)
+resource.send_to_zenodo
+```
+
+You can now check the stash_engine_zenodo_copies and delayed_jobs tables for status
+or if you want to look at the item on zenodo (it has their id in the table).
+
+
+To test draining long running jobs before a restart
+---------------------------------------------------
+
+In the directory above the application root.  (We don't want this in
+the application root since it gets changed with a new deploy on the
+servers.)
+```
+touch defer_jobs.txt
+```
+
+Send another Zenodo job as documented above for testing jobs go
+through.
+
+Wait for it to run and see that it didn't run and status was changed
+to deferred in the zenodo_copies.state field.
+
+
+To test sending through again later
+-----------------------------------
+
+remove the defer file
+```
+rm defer_jobs.txt
+```
+
+in rails console
+```
+StashEngine::ZenodoCopyJob.enqueue_deferred
+```
+
+Now wait for it to be enqueued and run and check the tables as above
+for status to see it go through.

--- a/spec/jobs/stash_engine/zenodo_copy_job_spec.rb
+++ b/spec/jobs/stash_engine/zenodo_copy_job_spec.rb
@@ -1,0 +1,81 @@
+require 'byebug'
+
+require 'rails_helper'
+require 'fileutils'
+
+RSpec.configure(&:infer_spec_type_from_file_location!)
+
+module StashEngine
+  RSpec.describe ZenodoCopyJob do
+
+    before(:each) do
+      @resource = create(:resource)
+      @new_zen = double('newZenodo')
+      allow(Stash::ZenodoReplicate::Resource).to receive(:new).and_return(@new_zen)
+    end
+
+    describe '#perform' do
+
+      it 'calls to add to zenodo if in correct states' do
+        create(:zenodo_copy, state: 'enqueued', identifier_id: @resource.identifier_id, resource_id: @resource.id)
+        expect(@new_zen).to receive(:add_to_zenodo)
+        zcj = ZenodoCopyJob.new
+        zcj.perform(@resource.id)
+      end
+
+      it "doesn't add to zenodo if no zenodo_copy record is set" do
+        expect(@new_zen).not_to receive(:add_to_zenodo)
+        zcj = ZenodoCopyJob.new
+        zcj.perform(@resource.id)
+      end
+
+      it "doesn't add to zenodo if resource is nil" do
+        expect(@new_zen).not_to receive(:add_to_zenodo)
+        zcj = ZenodoCopyJob.new
+        zcj.perform(nil)
+      end
+
+      it "doesn't add to zenodo if isn't enqueued state" do
+        create(:zenodo_copy, state: 'finished', identifier_id: @resource.identifier_id, resource_id: @resource.id)
+        expect(@new_zen).not_to receive(:add_to_zenodo)
+        zcj = ZenodoCopyJob.new
+        zcj.perform(@resource.id)
+      end
+    end
+
+    describe 'self.should_defer?(resource:)' do
+      it 'returns true and sets deferred if defer file exists' do
+        FileUtils.touch(ZenodoCopyJob::DEFERRED_TOUCH_FILE)
+        create(:zenodo_copy, state: 'enqueued', identifier_id: @resource.identifier_id, resource_id: @resource.id)
+        expect(ZenodoCopyJob.should_defer?(resource: @resource)).to eq(true)
+        @resource.reload
+        expect(@resource.zenodo_copy.state).to eq('deferred')
+        FileUtils.rm(ZenodoCopyJob::DEFERRED_TOUCH_FILE)
+      end
+
+      it "returns false and doesn't defer if defer file doesn't exist" do
+        create(:zenodo_copy, state: 'enqueued', identifier_id: @resource.identifier_id, resource_id: @resource.id)
+        expect(ZenodoCopyJob.should_defer?(resource: @resource)).to eq(false)
+        @resource.reload
+        expect(@resource.zenodo_copy.state).to eq('enqueued')
+      end
+    end
+
+    describe 'self.enqueue_deferred' do
+      include ActiveJob::TestHelper
+
+      it 're-enqueues the deferred items' do
+        create(:zenodo_copy, state: 'deferred', identifier_id: @resource.identifier_id, resource_id: @resource.id)
+        ZenodoCopyJob.enqueue_deferred
+        @resource.reload
+        expect(@resource.zenodo_copy.state).to eq('enqueued')
+        expect(enqueued_jobs).to eq([{ job: StashEngine::ZenodoCopyJob, args: [@resource.id], queue: 'zenodo_copy' }])
+      end
+
+      after(:each) do
+        clear_enqueued_jobs
+      end
+    end
+
+  end
+end

--- a/stash/stash_engine/app/jobs/stash_engine/zenodo_copy_job.rb
+++ b/stash/stash_engine/app/jobs/stash_engine/zenodo_copy_job.rb
@@ -21,7 +21,7 @@ module StashEngine
     def perform(*args)
       # what do we need to log in here?
       resource = StashEngine::Resource.where(id: args[0]).first
-      return if resource.nil? || resource.zenodo_copy.state != 'enqueued' || self.class.should_defer?(resource: resource)
+      return if resource.nil? || resource&.zenodo_copy&.state != 'enqueued' || self.class.should_defer?(resource: resource)
 
       zr = Stash::ZenodoReplicate::Resource.new(resource: resource)
       zr.add_to_zenodo

--- a/stash/stash_engine/app/jobs/stash_engine/zenodo_copy_job.rb
+++ b/stash/stash_engine/app/jobs/stash_engine/zenodo_copy_job.rb
@@ -39,7 +39,7 @@ module StashEngine
     def self.enqueue_deferred
       StashEngine::ZenodoCopy.where(state: 'deferred').each do |zc|
         zc.update(state: 'enqueued')
-        self.perform_later(zc.resource_id)
+        perform_later(zc.resource_id)
       end
     end
   end

--- a/stash/stash_engine/app/jobs/stash_engine/zenodo_copy_job.rb
+++ b/stash/stash_engine/app/jobs/stash_engine/zenodo_copy_job.rb
@@ -19,7 +19,6 @@ module StashEngine
 
     # the only argument for this is really the resource ID to copy
     def perform(*args)
-      # what do we need to log in here?
       resource = StashEngine::Resource.where(id: args[0]).first
       return if resource.nil? || resource&.zenodo_copy&.state != 'enqueued' || self.class.should_defer?(resource: resource)
 

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -603,6 +603,12 @@ module StashEngine
       update(solr_indexed: false) if result
     end
 
+    def send_to_zenodo
+      byebug
+      ZenodoCopy.create(state: 'enqueued', identifier_id: identifier_id, resource_id: id)
+      ZenodoCopyJob.perform_later(id)
+    end
+
     private
 
     # -----------------------------------------------------------

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -604,8 +604,7 @@ module StashEngine
     end
 
     def send_to_zenodo
-      byebug
-      ZenodoCopy.create(state: 'enqueued', identifier_id: identifier_id, resource_id: id)
+      ZenodoCopy.create(state: 'enqueued', identifier_id: identifier_id, resource_id: id) if zenodo_copy.nil?
       ZenodoCopyJob.perform_later(id)
     end
 

--- a/stash/stash_engine/config/initializers/delayed_job_config.rb
+++ b/stash/stash_engine/config/initializers/delayed_job_config.rb
@@ -4,7 +4,7 @@ require 'delayed_job_active_record'
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.sleep_delay = 60
 Delayed::Worker.max_attempts = 3
-Delayed::Worker.max_run_time = 180.minutes
+Delayed::Worker.max_run_time = 6.hours
 Delayed::Worker.read_ahead = 10
 Delayed::Worker.default_queue_name = 'default'
 Delayed::Worker.delay_jobs = !Rails.env.test?

--- a/stash/stash_engine/db/migrate/20200402234233_add_deferred_to_enum_for_zenodo_copy.rb
+++ b/stash/stash_engine/db/migrate/20200402234233_add_deferred_to_enum_for_zenodo_copy.rb
@@ -1,0 +1,13 @@
+class AddDeferredToEnumForZenodoCopy < ActiveRecord::Migration
+  def up
+    change_table :stash_engine_zenodo_copies do |t|
+      t.change :state, "ENUM('enqueued','replicating','finished','error','deferred') DEFAULT 'enqueued'"
+    end
+  end
+
+  def down
+    change_table :stash_engine_zenodo_copies do |t|
+      t.change :state, "ENUM('enqueued','replicating','finished','error') DEFAULT 'enqueued'"
+    end
+  end
+end

--- a/stash/stash_engine/lib/stash/download/base.rb
+++ b/stash/stash_engine/lib/stash/download/base.rb
@@ -37,7 +37,7 @@ module Stash
           # We don't want to hold dead download threads open too long for resource and network reasons.
 
           begin
-            http = HTTP.timeout(connect: 30, read: read_timeout).timeout(3.hours).follow(max_hops: 10)
+            http = HTTP.timeout(connect: 30, read: read_timeout).timeout(3.hours.to_i).follow(max_hops: 10)
               .basic_auth(user: tenant.repository.username, pass: tenant.repository.password)
             # .persistent(URI.join(url, '/').to_s)
             merritt_response = http.get(url)

--- a/stash/stash_engine/lib/stash/download/base.rb
+++ b/stash/stash_engine/lib/stash/download/base.rb
@@ -36,7 +36,7 @@ module Stash
           # We don't want to hold dead download threads open too long for resource and network reasons.
 
           begin
-            http = HTTP.timeout(connect: 30, read: read_timeout).timeout(7200).follow(max_hops: 10)
+            http = HTTP.timeout(connect: 30, read: read_timeout).timeout(3.hours).follow(max_hops: 10)
               .basic_auth(user: tenant.repository.username, pass: tenant.repository.password)
             # .persistent(URI.join(url, '/').to_s)
             merritt_response = http.get(url)

--- a/stash/stash_engine/lib/stash/download/base.rb
+++ b/stash/stash_engine/lib/stash/download/base.rb
@@ -24,6 +24,7 @@ module Stash
       end
 
       # this is a method that should be overridden
+      # rubocop:disable Metrics/AbcSize
       def stream_response(url:, tenant:, filename:, read_timeout: 30)
         cc.request.env['rack.hijack'].call
         user_stream = cc.request.env['rack.hijack_io']
@@ -49,6 +50,7 @@ module Stash
         end
         cc.response.close
       end
+      # rubocop:enable Metrics/AbcSize
 
       # these send methods are the streaming methods for a 'rack.hijack',
       def send_headers(stream:, header_obj:, filename:)

--- a/stash/stash_engine/lib/stash/merritt_download/file.rb
+++ b/stash/stash_engine/lib/stash/merritt_download/file.rb
@@ -49,7 +49,7 @@ module Stash
 
       # gets the file url and returns an HTTP.get(url) response object
       def get_url(url:, read_timeout: 30)
-        http = HTTP.timeout(connect: 30, read: read_timeout).timeout(6.hours).follow(max_hops: 10)
+        http = HTTP.timeout(connect: 30, read: read_timeout).timeout(6.hours.to_i).follow(max_hops: 10)
         http.get(url)
       end
 

--- a/stash/stash_engine/lib/stash/merritt_download/file.rb
+++ b/stash/stash_engine/lib/stash/merritt_download/file.rb
@@ -49,7 +49,7 @@ module Stash
 
       # gets the file url and returns an HTTP.get(url) response object
       def get_url(url:, read_timeout: 30)
-        http = HTTP.timeout(connect: 30, read: read_timeout).timeout(7200).follow(max_hops: 10)
+        http = HTTP.timeout(connect: 30, read: read_timeout).timeout(6.hours).follow(max_hops: 10)
         http.get(url)
       end
 

--- a/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -17,7 +17,7 @@ module Stash
       end
 
       def self.standard_request(method, url, **args)
-        http = HTTP.timeout(connect: 30, read: 60).timeout(6.hours).follow(max_hops: 10)
+        http = HTTP.timeout(connect: 30, read: 60).timeout(6.hours.to_i).follow(max_hops: 10)
 
         my_params = { access_token: APP_CONFIG[:zenodo][:access_token] }.merge(args.fetch(:params, {}))
         my_headers = { 'Content-Type': 'application/json' }.merge(args.fetch(:headers, {}))

--- a/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -17,7 +17,7 @@ module Stash
       end
 
       def self.standard_request(method, url, **args)
-        http = HTTP.timeout(connect: 30, read: 60).timeout(7200).follow(max_hops: 10)
+        http = HTTP.timeout(connect: 30, read: 60).timeout(6.hours).follow(max_hops: 10)
 
         my_params = { access_token: APP_CONFIG[:zenodo][:access_token] }.merge(args.fetch(:params, {}))
         my_headers = { 'Content-Type': 'application/json' }.merge(args.fetch(:headers, {}))


### PR DESCRIPTION
We need a way to allow ActiveJob to close out anything running before shutting down so it doesn't interrupt things in the middle.  Surprisingly both it and delayed job don't seem to have a lot of control of the queue for it, so I need to add addtional states and let the queue empty and or re-fill it myself.

Instructions to test manually.  I have other tickets about making startup scripts and we'll need scripts for starting it, stopping it and another for stopping new processing ahead of stopping or restarting a server.

```
# To test jobs go through and get processed with ActiveJob
# --------------------------------------------------------
RAILS_ENV=local_dev bin/delayed_job start

# from RAILS_ENV=local_dev rails console
resource = StashEngine::Resource.find(<id>)
resource.send_to_zenodo

# you can now check the stash_engine_zenodo_copies and delayed_jobs tables for status
# or if you want to look at the item on zenodo (it has their id in the table)


# To test draining long running jobs before a restart
# ---------------------------------------------------

# in the directory above the application root.  (We don't want this in
# the application root since it gets changed with a new deploy on the servers.)
touch defer_jobs.txt

# send another Zenodo job as documented above for testing jobs go through.

# wait for it to run and see that it didn't run and status was changed to deferred
# in the zenodo_copies.state field.


# To test sending through again later
# -----------------------------------

# remove the defer file
rm defer_jobs.txt

# in rails console
StashEngine::ZenodoCopyJob.enqueue_deferred

# Now wait for it to be enqueued and run and check the tables as above for status to see it go through.
```