### PR TITLE
Prevent out-of-order submission and hook into publishing: ticket #688

### DIFF
--- a/spec/features/stash_datacite/dataset_versioning_spec.rb
+++ b/spec/features/stash_datacite/dataset_versioning_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature 'DatasetVersioning', type: :feature do
     mock_ror!
     mock_datacite!
     mock_stripe!
+    ignore_zenodo!
     @curator = create(:user, role: 'superuser', tenant_id: 'dryad')
     @author = create(:user, tenant_id: 'dryad')
     @document_list = []

--- a/spec/lib/stash/zenodo_replicate/resource_spec.rb
+++ b/spec/lib/stash/zenodo_replicate/resource_spec.rb
@@ -60,6 +60,27 @@ module Stash
           expect(@ztc.error_info).to include('You should never start replicating unless starting from an enqueued state')
           # note error logging is also tested in here
         end
+
+        it 'rejects an out-of-order replication for the same identifier with one deferred' do
+          @ztc.update(state: 'deferred')
+          @resource2 = create(:resource, identifier_id: @resource.identifier_id)
+          @ztc2 = create(:zenodo_copy, resource: @resource2, identifier: @resource.identifier)
+          @szr = Stash::ZenodoReplicate::Resource.new(resource: @resource2)
+          @szr.add_to_zenodo
+          @ztc2.reload
+          expect(@ztc2.state).to eq('error')
+          expect(@ztc2.error_info).to include('Items must replicate in order')
+        end
+
+        it 'rejects an out-of-order replication for the same identifier later replicating first' do
+          @resource2 = create(:resource, identifier_id: @resource.identifier_id)
+          @ztc2 = create(:zenodo_copy, resource: @resource2, identifier: @resource.identifier)
+          @szr = Stash::ZenodoReplicate::Resource.new(resource: @resource2)
+          @szr.add_to_zenodo
+          @ztc2.reload
+          expect(@ztc2.state).to eq('error')
+          expect(@ztc2.error_info).to include('Items must replicate in order')
+        end
       end
     end
   end

--- a/spec/mocks/curation_activity.rb
+++ b/spec/mocks/curation_activity.rb
@@ -10,6 +10,7 @@ module Mocks
       allow_any_instance_of(StashEngine::CurationActivity).to receive(:process_payment).and_return(true)
       allow_any_instance_of(StashEngine::CurationActivity).to receive(:email_status_change_notices).and_return(true)
       allow_any_instance_of(StashEngine::CurationActivity).to receive(:email_orcid_invitations).and_return(true)
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
     end
 
   end

--- a/spec/mocks/ror.rb
+++ b/spec/mocks/ror.rb
@@ -8,6 +8,10 @@ module Mocks
       stub_ror_id_lookup(university: user.present? && user.affiliation.present? ? user.affiliation.long_name : nil)
     end
 
+    def ignore_zenodo!
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
+    end
+
     def stub_ror_heartbeat_check
       stub_request(:get, 'https://api.ror.org/heartbeat')
         .with(

--- a/spec/responses/stash_engine/landing_controller_spec.rb
+++ b/spec/responses/stash_engine/landing_controller_spec.rb
@@ -23,6 +23,7 @@ module StashEngine
       mock_ror!
       mock_datacite!
       mock_stripe!
+      ignore_zenodo!
 
       # below will create @identifier, @resource, @user and the basic required things for an initial version of a dataset
       create_basic_dataset!

--- a/spec/responses/stash_engine/widgets_controller_spec.rb
+++ b/spec/responses/stash_engine/widgets_controller_spec.rb
@@ -19,6 +19,7 @@ module StashEngine
       mock_ror!
       mock_datacite!
       mock_stripe!
+      ignore_zenodo!
       @user = create(:user, role: 'superuser')
       @identifier = create(:identifier)
       @resource = create(:resource, :submitted, identifier: @identifier, user_id: @user.id, tenant_id: @user.tenant_id)

--- a/stash/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -57,6 +57,10 @@ module StashEngine
                                  latest_curation_status_changed?
                      }
 
+    after_create :copy_to_zenodo, if: proc { |ca|
+      !ca.resource.skip_datacite_update && ca.published? && latest_curation_status_changed?
+    }
+
     # Email the author and/or journal about status changes
     after_create :email_status_change_notices,
                  if: proc { |_ca| latest_curation_status_changed? && !resource.skip_emails }
@@ -149,6 +153,10 @@ module StashEngine
 
     def update_solr
       resource.submit_to_solr
+    end
+
+    def copy_to_zenodo
+      resource.send_to_zenodo
     end
 
     def remove_peer_review

--- a/stash/stash_engine/lib/stash/zenodo_replicate/resource.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/resource.rb
@@ -79,7 +79,7 @@ module Stash
       def error_if_out_of_order
         # this is a little similar to error_if_replicating, but catches defered or other odd states
         prev_unfinished_count = StashEngine::ZenodoCopy.where(identifier_id: @resource.identifier_id)
-            .where("id < ?", @resource.zenodo_copy.id).where.not(state: 'finished').count
+          .where('id < ?', @resource.zenodo_copy.id).where.not(state: 'finished').count
         return if prev_unfinished_count == 0
 
         raise ZenodoError, "identifier_id #{@resource.identifier.id}: Cannot replicate a version when a previous version " \

--- a/stash/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
@@ -76,7 +76,6 @@ module StashEngine
         allow_any_instance_of(Stash::Payments::Invoicer).to receive(:charge_user_via_invoice).and_return(true)
         allow_any_instance_of(StashEngine::Resource).to receive(:contributors).and_return([])
         allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
-        allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
       end
 
       context :update_solr do

--- a/stash/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
@@ -10,6 +10,7 @@ module StashEngine
       # reload so that it picks up any associated models that are initialized
       # (e.g. CurationActivity and ResourceState)
       @resource.reload
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
     end
 
     context :new do
@@ -38,6 +39,7 @@ module StashEngine
     context :readable_status do
       before(:each) do
         @ca = CurationActivity.create(resource_id: @resource.id)
+        allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
       end
 
       it 'class method allows conversion of status to humanized status' do
@@ -73,6 +75,8 @@ module StashEngine
         allow_any_instance_of(Stash::Payments::Invoicer).to receive(:new).and_return(true)
         allow_any_instance_of(Stash::Payments::Invoicer).to receive(:charge_user_via_invoice).and_return(true)
         allow_any_instance_of(StashEngine::Resource).to receive(:contributors).and_return([])
+        allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
+        allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
       end
 
       context :update_solr do

--- a/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -27,6 +27,8 @@ module StashEngine
           upload_file_name: "created#{i}.bin",
           upload_file_size: i * 3
         )
+
+        allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
       end
 
       @fake_issn = 'bogus-issn-value'

--- a/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
@@ -29,6 +29,8 @@ module StashEngine
       # Mock all the mailers fired by callbacks because these tests don't load everything we need
       allow_any_instance_of(CurationActivity).to receive(:email_status_change_notices).and_return(true)
       allow_any_instance_of(CurationActivity).to receive(:email_orcid_invitations).and_return(true)
+
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
     end
 
     describe :tenant do

--- a/stash/stash_engine/spec/unit/models/curation_activity_spec.rb
+++ b/stash/stash_engine/spec/unit/models/curation_activity_spec.rb
@@ -10,6 +10,11 @@ require 'byebug'
 module StashEngine
   RSpec.describe CurationActivity do
     # this is just a basic test to be sure FactoryBot works.  It likes to break a lot.
+
+    before(:each) do
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
+    end
+
     describe :factories do
       it 'creates a FactoryBot factory that works' do
         @identifier = create(:identifier)


### PR DESCRIPTION
This hooks copying to zenodo into publication and also prevents out of order submission (errors).  This also includes code from the previous branch (PR) since this is building on top of it. It also fixes a bunch of tests that broke with the publication callback.

To test:

Start the delayed_job daemon.

```RAILS_ENV=local_dev bin/delayed_job start```

Create a new dataset, add files and then after it is submitted go to the curation area.  Choose to publish the dataset.  At that point it will be enqueued in delayed_job for replication.

You can monitor the state of it in the zenodo_copies table.   After it finishes you can look it up on the zenodo sandbox site such as urls like https://sandbox.zenodo.org/record/520032 (just substitute your deposition_id from the database at the end of the URL).