### PR TITLE
Handle nil error on review page

### DIFF
--- a/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
@@ -90,7 +90,7 @@ $(document).ready(function(){
 });
 </script>
 
-<% if current_user.id != @resource.user_id %>
+<% if current_user&.id != @resource.user_id %>
   <script>
     $('#agree_to_license, #agree_to_tos, #agree_to_dda').prop('disabled', true);
   </script>


### PR DESCRIPTION
Prevent error reports like:
```
An ActionView::Template::Error occurred in resources#review:

 undefined method `id' for nil:NilClass
 /apps/dryad/local/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
```