### PR TITLE
Zenodo "versioning" for re-editing zenodo copy if published multiple times

### DIFF
--- a/spec/features/stash_datacite/dataset_versioning_spec.rb
+++ b/spec/features/stash_datacite/dataset_versioning_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature 'DatasetVersioning', type: :feature do
     mock_ror!
     mock_datacite!
     mock_stripe!
+    ignore_zenodo!
     @curator = create(:user, role: 'superuser', tenant_id: 'dryad')
     @author = create(:user, tenant_id: 'dryad')
     @document_list = []

--- a/spec/lib/stash/zenodo_replicate/resource_spec.rb
+++ b/spec/lib/stash/zenodo_replicate/resource_spec.rb
@@ -60,6 +60,27 @@ module Stash
           expect(@ztc.error_info).to include('You should never start replicating unless starting from an enqueued state')
           # note error logging is also tested in here
         end
+
+        it 'rejects an out-of-order replication for the same identifier with one deferred' do
+          @ztc.update(state: 'deferred')
+          @resource2 = create(:resource, identifier_id: @resource.identifier_id)
+          @ztc2 = create(:zenodo_copy, resource: @resource2, identifier: @resource.identifier)
+          @szr = Stash::ZenodoReplicate::Resource.new(resource: @resource2)
+          @szr.add_to_zenodo
+          @ztc2.reload
+          expect(@ztc2.state).to eq('error')
+          expect(@ztc2.error_info).to include('Items must replicate in order')
+        end
+
+        it 'rejects an out-of-order replication for the same identifier later replicating first' do
+          @resource2 = create(:resource, identifier_id: @resource.identifier_id)
+          @ztc2 = create(:zenodo_copy, resource: @resource2, identifier: @resource.identifier)
+          @szr = Stash::ZenodoReplicate::Resource.new(resource: @resource2)
+          @szr.add_to_zenodo
+          @ztc2.reload
+          expect(@ztc2.state).to eq('error')
+          expect(@ztc2.error_info).to include('Items must replicate in order')
+        end
       end
     end
   end

--- a/spec/lib/stash/zenodo_replicate/zenodo_connection_spec.rb
+++ b/spec/lib/stash/zenodo_replicate/zenodo_connection_spec.rb
@@ -66,7 +66,7 @@ module Stash
           expect { ZenodoConnection.standard_request(:get, 'https://example.test.com') }.to raise_error(Stash::ZenodoReplicate::ZenodoError)
         end
 
-        it 'raises error if there is an HTTP or parsing error' do
+        it 'raises error if there is a parsing error' do
           stub_request(:get, 'https://example.test.com/?access_token=ThisIsAFakeToken')
             .with(
               headers: {
@@ -74,7 +74,7 @@ module Stash
                 'Host' => 'example.test.com'
               }
             )
-            .to_return(status: 200)
+            .to_return(status: 200, headers: { 'Content-Type' => 'application/json' } )
           expect { ZenodoConnection.standard_request(:get, 'https://example.test.com') }.to raise_error(Stash::ZenodoReplicate::ZenodoError)
         end
       end

--- a/spec/lib/stash/zenodo_replicate/zenodo_connection_spec.rb
+++ b/spec/lib/stash/zenodo_replicate/zenodo_connection_spec.rb
@@ -74,7 +74,7 @@ module Stash
                 'Host' => 'example.test.com'
               }
             )
-            .to_return(status: 200, headers: { 'Content-Type' => 'application/json' } )
+            .to_return(status: 200, headers: { 'Content-Type' => 'application/json' })
           expect { ZenodoConnection.standard_request(:get, 'https://example.test.com') }.to raise_error(Stash::ZenodoReplicate::ZenodoError)
         end
       end

--- a/spec/mocks/curation_activity.rb
+++ b/spec/mocks/curation_activity.rb
@@ -10,6 +10,7 @@ module Mocks
       allow_any_instance_of(StashEngine::CurationActivity).to receive(:process_payment).and_return(true)
       allow_any_instance_of(StashEngine::CurationActivity).to receive(:email_status_change_notices).and_return(true)
       allow_any_instance_of(StashEngine::CurationActivity).to receive(:email_orcid_invitations).and_return(true)
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
     end
 
   end

--- a/spec/mocks/ror.rb
+++ b/spec/mocks/ror.rb
@@ -8,6 +8,10 @@ module Mocks
       stub_ror_id_lookup(university: user.present? && user.affiliation.present? ? user.affiliation.long_name : nil)
     end
 
+    def ignore_zenodo!
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
+    end
+
     def stub_ror_heartbeat_check
       stub_request(:get, 'https://api.ror.org/heartbeat')
         .with(

--- a/spec/responses/stash_engine/landing_controller_spec.rb
+++ b/spec/responses/stash_engine/landing_controller_spec.rb
@@ -23,6 +23,7 @@ module StashEngine
       mock_ror!
       mock_datacite!
       mock_stripe!
+      ignore_zenodo!
 
       # below will create @identifier, @resource, @user and the basic required things for an initial version of a dataset
       create_basic_dataset!

--- a/spec/responses/stash_engine/widgets_controller_spec.rb
+++ b/spec/responses/stash_engine/widgets_controller_spec.rb
@@ -19,6 +19,7 @@ module StashEngine
       mock_ror!
       mock_datacite!
       mock_stripe!
+      ignore_zenodo!
       @user = create(:user, role: 'superuser')
       @identifier = create(:identifier)
       @resource = create(:resource, :submitted, identifier: @identifier, user_id: @user.id, tenant_id: @user.tenant_id)

--- a/stash/stash_engine/app/jobs/stash_engine/zenodo_copy_job.rb
+++ b/stash/stash_engine/app/jobs/stash_engine/zenodo_copy_job.rb
@@ -19,7 +19,6 @@ module StashEngine
 
     # the only argument for this is really the resource ID to copy
     def perform(*args)
-      # what do we need to log in here?
       resource = StashEngine::Resource.where(id: args[0]).first
       return if resource.nil? || resource&.zenodo_copy&.state != 'enqueued' || self.class.should_defer?(resource: resource)
 

--- a/stash/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -57,6 +57,10 @@ module StashEngine
                                  latest_curation_status_changed?
                      }
 
+    after_create :copy_to_zenodo, if: proc { |ca|
+      !ca.resource.skip_datacite_update && ca.published? && latest_curation_status_changed?
+    }
+
     # Email the author and/or journal about status changes
     after_create :email_status_change_notices,
                  if: proc { |_ca| latest_curation_status_changed? && !resource.skip_emails }
@@ -149,6 +153,10 @@ module StashEngine
 
     def update_solr
       resource.submit_to_solr
+    end
+
+    def copy_to_zenodo
+      resource.send_to_zenodo
     end
 
     def remove_peer_review

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -604,6 +604,7 @@ module StashEngine
     end
 
     def send_to_zenodo
+      return if file_uploads.empty? # no files? Then don't send to Zenodo for duplication.
       ZenodoCopy.create(state: 'enqueued', identifier_id: identifier_id, resource_id: id) if zenodo_copy.nil?
       ZenodoCopyJob.perform_later(id)
     end

--- a/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
@@ -12,7 +12,7 @@ module Stash
       def metadata
         out_hash = {}.with_indifferent_access
         # took out the DOI since I don't want to use it in zenodo because of versioning problems
-        %i[upload_type publication_date title creators description access_right license
+        %i[doi upload_type publication_date title creators description access_right license
            keywords notes related_identifiers method].each do |meth|
           result = send(meth)
           out_hash[meth] = result unless result.blank?

--- a/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
@@ -21,7 +21,7 @@ module Stash
       end
 
       def doi
-        "https://doi.org/#{@resource.identifier.identifier}"
+        "https://doi.org/#{bork_doi_for_zenodo_sandbox(doi: @resource.identifier.identifier)}"
       end
 
       def upload_type
@@ -89,6 +89,17 @@ module Stash
 
       def method
         @resource.descriptions.where(description_type: 'methods')&.map(&:description)&.join("\n")
+      end
+
+      private
+
+      # this is a workaround for the zenodo sandbox in non-production environments since they claim all test DOIs
+      # as their own and their added functionality for re-editing things doesn't work with them unless we give them
+      # a non-test DOI so they don't do the wrong thing.
+      def bork_doi_for_zenodo_sandbox(doi:)
+        return doi if Rails.env == 'production'
+
+        doi.gsub(/^10\.5072/, '10.55072') # bork our datacite test dois into non-test shoulders because Zenodo reserves them as their own
       end
 
     end

--- a/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
@@ -11,7 +11,6 @@ module Stash
       # returns a hash of the metadata from the list of methods, you can make it into json to send
       def metadata
         out_hash = {}.with_indifferent_access
-        # took out the DOI since I don't want to use it in zenodo because of versioning problems
         %i[doi upload_type publication_date title creators description access_right license
            keywords notes related_identifiers method].each do |meth|
           result = send(meth)

--- a/stash/stash_engine/lib/stash/zenodo_replicate/resource.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/resource.rb
@@ -79,7 +79,7 @@ module Stash
       def error_if_out_of_order
         # this is a little similar to error_if_replicating, but catches defered or other odd states
         prev_unfinished_count = StashEngine::ZenodoCopy.where(identifier_id: @resource.identifier_id)
-            .where("id < ?", @resource.zenodo_copy.id).where.not(state: 'finished').count
+          .where('id < ?', @resource.zenodo_copy.id).where.not(state: 'finished').count
         return if prev_unfinished_count == 0
 
         raise ZenodoError, "identifier_id #{@resource.identifier.id}: Cannot replicate a version when a previous version " \

--- a/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -33,7 +33,7 @@ module Stash
 
         raise ZenodoError, "Zenodo response: #{r.status.code}\n#{resp} for \nhttp.#{method} #{url}\n#{resp}" unless r.status.success?
         resp
-      rescue HTTP::Error => e
+      rescue HTTP::Error, JSON::ParserError => e
         raise ZenodoError, "Error from HTTP #{method} #{url}\nOriginal error: #{e}\n#{e.backtrace.join("\n")}"
       end
       # rubocop:enable Metrics/AbcSize

--- a/stash/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
@@ -10,6 +10,7 @@ module StashEngine
       # reload so that it picks up any associated models that are initialized
       # (e.g. CurationActivity and ResourceState)
       @resource.reload
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
     end
 
     context :new do
@@ -38,6 +39,7 @@ module StashEngine
     context :readable_status do
       before(:each) do
         @ca = CurationActivity.create(resource_id: @resource.id)
+        allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
       end
 
       it 'class method allows conversion of status to humanized status' do
@@ -73,6 +75,8 @@ module StashEngine
         allow_any_instance_of(Stash::Payments::Invoicer).to receive(:new).and_return(true)
         allow_any_instance_of(Stash::Payments::Invoicer).to receive(:charge_user_via_invoice).and_return(true)
         allow_any_instance_of(StashEngine::Resource).to receive(:contributors).and_return([])
+        allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
+        allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
       end
 
       context :update_solr do

--- a/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -27,6 +27,8 @@ module StashEngine
           upload_file_name: "created#{i}.bin",
           upload_file_size: i * 3
         )
+
+        allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
       end
 
       @fake_issn = 'bogus-issn-value'

--- a/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
@@ -29,6 +29,8 @@ module StashEngine
       # Mock all the mailers fired by callbacks because these tests don't load everything we need
       allow_any_instance_of(CurationActivity).to receive(:email_status_change_notices).and_return(true)
       allow_any_instance_of(CurationActivity).to receive(:email_orcid_invitations).and_return(true)
+
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
     end
 
     describe :tenant do

--- a/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
@@ -1340,6 +1340,7 @@ module StashEngine
         require_relative '../../../app/jobs/stash_engine/zenodo_copy_job'
 
         @resource = create(:resource)
+        create(:file_upload, resource: @resource)
       end
 
       it 'creates a zenodo_copy record in database' do

--- a/stash/stash_engine/spec/unit/models/curation_activity_spec.rb
+++ b/stash/stash_engine/spec/unit/models/curation_activity_spec.rb
@@ -10,6 +10,11 @@ require 'byebug'
 module StashEngine
   RSpec.describe CurationActivity do
     # this is just a basic test to be sure FactoryBot works.  It likes to break a lot.
+
+    before(:each) do
+      allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
+    end
+
     describe :factories do
       it 'creates a FactoryBot factory that works' do
         @identifier = create(:identifier)


### PR DESCRIPTION
This builds on previous pull requests for zenodo.  It allows a version to be published more than once and to make the changes to re-edit the zenodo copy as it changes.  See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/695 for cases you can test.

To test, basically create a dataset and then go into curation and publish it.  Then make more changes after publication and publish it again.

This requires the delayed_job daemon to be running.  I'll see if I can deploy this and start this all on dev so it can be tested there.

I also had to make changes to a bunch of tests to ignore the callbacks for this publication event for the 3rd copy when they were tests for unrelated things.
