### PR TITLE
Move journal metadata into the DB

### DIFF
--- a/stash/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
+++ b/stash/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
@@ -29,8 +29,8 @@ function loadPublications() {
                             dataType: "json",
                             success: function( data ) {
 				$("#internal_datum_publication").val("")
-				if (data.fullName != null) {
-				    $("#internal_datum_publication").val(data.fullName);
+				if (data.title != null) {
+				    $("#internal_datum_publication").val(data.title);
 				}
 			    }
 			});
@@ -51,7 +51,7 @@ function loadPublications() {
 			},
                         success: function (data) {
                             var arr = jQuery.map( data, function( a ) {
-                                return [[ a.issn, a.fullName ]];
+                                return [[ a.issn, a.title ]];
                             });
                             var labels = [];
                             $.each(arr, function(index, value) {

--- a/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -64,7 +64,7 @@ module StashDatacite
     # parse out the "relevant" part of the manuscript ID, ignoring the parts that the journal changes for different versions of the same item
     def parse_msid(issn:, msid:)
       logger.debug("Parsing msid #{msid} for journal #{issn}")
-      regex = @se_id.journal_manuscript_regex
+      regex = @se_id.journal&.manuscript_number_regex
       return msid if regex.blank?
       logger.debug("- found regex /#{regex}/")
       return msid if msid.match(regex).blank?

--- a/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -36,12 +36,12 @@ module StashDatacite
       if partial_term.blank?
         render json: nil
       else
-        # clean the partial_term of unwanted characters so it doesn't cause errors when calling the Journal API
+        # clean the partial_term of unwanted characters so it doesn't cause errors
         partial_term.gsub!(%r{[\/\-\\\(\)~!@%&"\[\]\^\:]}, ' ')
-        response = HTTParty.get("#{APP_CONFIG.old_dryad_url}/api/v1/journals/search",
-                                query: { 'query': partial_term, 'count': 20 },
-                                headers: { 'Content-Type' => 'application/json' })
-        render json: response.body
+
+        matches = StashEngine::Journal.where("title like '%#{partial_term}%'").limit(40)
+
+        render json: bubble_up_exact_matches(result_list: matches, term: partial_term)
       end
     end
 
@@ -50,10 +50,8 @@ module StashDatacite
       target_issn = params['id']
       return if target_issn.blank?
       return unless target_issn =~ /\d+-\w+/
-
-      response = HTTParty.get("#{APP_CONFIG.old_dryad_url}/api/v1/journals/#{target_issn}",
-                              headers: { 'Content-Type' => 'application/json' })
-      render json: response&.parsed_response
+      match = StashEngine::Journal.where(issn: target_issn).first
+      render json: match
     end
 
     def save_form_to_internal_data
@@ -162,6 +160,31 @@ module StashDatacite
       return nil unless @resource.present? && related_identifier_type.present? && relation_type.present?
       StashDatacite::RelatedIdentifier.where(resource_id: @resource.id, relation_type: relation_type,
                                              related_identifier_type: related_identifier_type).first
+    end
+
+    private
+
+    # Re-order a journal list to prioritize exact matches at the beginning of the string, then
+    # exact matches within the string, otherwise leaving the order unchanged
+    def bubble_up_exact_matches(result_list:, term:)
+      exact_match = []
+      matches_at_beginning = []
+      matches_within = []
+      other_items = []
+      match_term = term.downcase
+      result_list.each do |result_item|
+        name = result_item['title'].downcase
+        if name == match_term
+          exact_match << result_item
+        elsif name.start_with?(match_term)
+          matches_at_beginning << result_item
+        elsif name.include?(match_term)
+          matches_within << result_item
+        else
+          other_items << result_item
+        end
+      end
+      exact_match + matches_at_beginning + matches_within + other_items
     end
 
   end

--- a/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
@@ -34,7 +34,7 @@
 <div>
     <h3>Payment</h3>
     <% submitter_affiliation = @resource.identifier.submitter_affiliation %>
-    <% if @resource.identifier.journal_will_pay? %>
+    <% if @resource.identifier.journal&.will_pay? %>
 	<p>Payment for this deposit is sponsored by <b><%= @resource.identifier.journal.title %></b>.</p>
     <% elsif @resource.identifier.institution_will_pay? %>
 	<p>Payment for this deposit is sponsored by <b><%= @resource.tenant.long_name %></b>.</p>

--- a/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
@@ -35,7 +35,7 @@
     <h3>Payment</h3>
     <% submitter_affiliation = @resource.identifier.submitter_affiliation %>
     <% if @resource.identifier.journal_will_pay? %>
-	<p>Payment for this deposit is sponsored by <b><%= @resource.identifier.publication_name %></b>.</p>
+	<p>Payment for this deposit is sponsored by <b><%= @resource.identifier.journal.title %></b>.</p>
     <% elsif @resource.identifier.institution_will_pay? %>
 	<p>Payment for this deposit is sponsored by <b><%= @resource.tenant.long_name %></b>.</p>
     <% elsif submitter_affiliation.present? && submitter_affiliation.fee_waivered? %>

--- a/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
+++ b/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
@@ -24,9 +24,9 @@ module StashEngine
       return unless %w[published embargoed].include?(status)
       return unless APP_CONFIG['send_journal_published_notices']
       assign_variables(resource)
-      return unless @resource&.identifier&.journal_notify_contacts&.present?
+      return unless @resource&.identifier&.journal&.notify_contacts&.present?
 
-      mail(to: @resource&.identifier&.journal_notify_contacts,
+      mail(to: @resource&.identifier&.journal&.notify_contacts,
            subject: "#{rails_env} Dryad Submission: \"#{@resource.title}\"")
     end
 
@@ -35,9 +35,9 @@ module StashEngine
       return unless status == 'peer_review'
       return unless APP_CONFIG['send_journal_published_notices']
       assign_variables(resource)
-      return unless @resource&.identifier&.journal_review_contacts&.present?
+      return unless @resource&.identifier&.journal&.review_contacts&.present?
 
-      mail(to: @resource&.identifier&.journal_review_contacts,
+      mail(to: @resource&.identifier&.journal&.review_contacts,
            subject: "#{rails_env} Dryad Submission: \"#{@resource.title}\"")
     end
 

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -260,9 +260,17 @@ module StashEngine
       return false if journal.blank?
       journal.allow_blackout?
     end
-    
+
     def publication_issn
       internal_data.find_by(data_type: 'publicationISSN')&.value&.strip
+    end
+
+    # This is the name typed by the user. If there is an associated journal, the
+    # journal.title will be the same. But we keep it copied here in case there is no
+    # associated journal object.
+    # Curators will probably create an associated journal object later.
+    def publication_name
+      internal_data.find_by(data_type: 'publicationName')&.value&.strip
     end
 
     def manuscript_number
@@ -278,7 +286,6 @@ module StashEngine
       end
       doi
     end
-
 
     def institution_will_pay?
       latest_resource&.tenant&.covers_dpc == true

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -219,15 +219,20 @@ module StashEngine
     # Check if the user must pay for this identifier, or if payment is
     # otherwise covered
     def user_must_pay?
-      !journal_will_pay? && !institution_will_pay? && !funder_will_pay? &&
+      !journal&.will_pay? && !institution_will_pay? && !funder_will_pay? &&
         (!submitter_affiliation.present? || !submitter_affiliation.fee_waivered?)
+    end
+
+    def journal
+      return nil if publication_issn.nil?
+      Journal.where(issn: publication_issn).first
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity
     def record_payment
       return if payment_type.present? && payment_type != 'unknown'
-      if journal_will_pay?
-        self.payment_type = 'journal-' + publication_data('paymentPlanType')
+      if journal&.will_pay?
+        self.payment_type = 'journal-' + journal.payment_plan_type
         self.payment_id = publication_issn
       elsif institution_will_pay?
         self.payment_type = 'institution'
@@ -246,15 +251,16 @@ module StashEngine
     end
     # rubocop:enable Metrics/CyclomaticComplexity
 
-    def publication_data(field_name)
-      return nil if publication_issn.nil?
-      url = APP_CONFIG.old_dryad_url + '/api/v1/journals/' + publication_issn
-      results = HTTParty.get(url,
-                             query: { access_token: APP_CONFIG.old_dryad_access_token },
-                             headers: { 'Content-Type' => 'application/json' })
-      results.parsed_response[field_name]
+    def allow_review?
+      return true if journal.blank?
+      journal.allow_review_workflow?
     end
 
+    def allow_blackout?
+      return false if journal.blank?
+      journal.allow_blackout?
+    end
+    
     def publication_issn
       internal_data.find_by(data_type: 'publicationISSN')&.value&.strip
     end
@@ -273,44 +279,6 @@ module StashEngine
       doi
     end
 
-    def publication_name
-      publication_data('fullName')
-    end
-
-    def journal_will_pay?
-      plan_type = publication_data('paymentPlanType')
-      plan_type == 'SUBSCRIPTION' ||
-        plan_type == 'PREPAID' ||
-        plan_type == 'DEFERRED'
-    end
-
-    def journal_customer_id
-      publication_data('stripeCustomerID')
-    end
-
-    def journal_sponsor_name
-      publication_data('sponsorName')
-    end
-
-    def journal_notify_contacts
-      publication_data('notifyContacts')
-    end
-
-    def journal_review_contacts
-      publication_data('reviewContacts')
-    end
-
-    def journal_manuscript_regex
-      publication_data('manuscriptNumberRegex')
-    end
-
-    def allow_review?
-      publication_data('allowReviewWorkflow') || publication_name.blank?
-    end
-
-    def allow_blackout?
-      publication_data('allowBlackout').present? && publication_data('allowBlackout')
-    end
 
     def institution_will_pay?
       latest_resource&.tenant&.covers_dpc == true

--- a/stash/stash_engine/app/models/stash_engine/journal.rb
+++ b/stash/stash_engine/app/models/stash_engine/journal.rb
@@ -1,7 +1,5 @@
 module StashEngine
   class Journal < ActiveRecord::Base
 
-
-    
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/journal.rb
+++ b/stash/stash_engine/app/models/stash_engine/journal.rb
@@ -2,11 +2,11 @@ module StashEngine
   class Journal < ActiveRecord::Base
     validates :issn, uniqueness: true
 
-    def will_pay?     
+    def will_pay?
       payment_plan_type == 'SUBSCRIPTION' ||
         payment_plan_type == 'PREPAID' ||
         payment_plan_type == 'DEFERRED'
     end
-    
+
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/journal.rb
+++ b/stash/stash_engine/app/models/stash_engine/journal.rb
@@ -1,5 +1,6 @@
 module StashEngine
   class Journal < ActiveRecord::Base
+    validates :issn, uniqueness: true
 
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/journal.rb
+++ b/stash/stash_engine/app/models/stash_engine/journal.rb
@@ -2,5 +2,11 @@ module StashEngine
   class Journal < ActiveRecord::Base
     validates :issn, uniqueness: true
 
+    def will_pay?     
+      payment_plan_type == 'SUBSCRIPTION' ||
+        payment_plan_type == 'PREPAID' ||
+        payment_plan_type == 'DEFERRED'
+    end
+    
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/journal.rb
+++ b/stash/stash_engine/app/models/stash_engine/journal.rb
@@ -1,0 +1,7 @@
+module StashEngine
+  class Journal < ActiveRecord::Base
+
+
+    
+  end
+end

--- a/stash/stash_engine/db/migrate/20200413135954_create_stash_engine_journals.rb
+++ b/stash/stash_engine/db/migrate/20200413135954_create_stash_engine_journals.rb
@@ -9,6 +9,7 @@ class CreateStashEngineJournals < ActiveRecord::Migration
       t.string :payment_contact
       t.string :manuscript_number_regex
       t.string :sponsor_name
+      t.string :stripe_customer_id
       t.text :notify_contacts
       t.text :review_contacts
       t.boolean :allow_review_workflow

--- a/stash/stash_engine/db/migrate/20200413135954_create_stash_engine_journals.rb
+++ b/stash/stash_engine/db/migrate/20200413135954_create_stash_engine_journals.rb
@@ -1,0 +1,24 @@
+class CreateStashEngineJournals < ActiveRecord::Migration
+  def up
+    create_table :stash_engine_journals do |t|
+      t.string :title, index: true
+      t.string :issn, index: true
+      t.string :website
+      t.text :description
+      t.column :payment_plan_type, "ENUM('PREPAID', 'DEFERRED', 'SUBSCRIPTION')"
+      t.string :payment_contact
+      t.string :manuscript_number_regex
+      t.string :sponsor_name
+      t.text :notify_contacts
+      t.text :review_contacts
+      t.boolean :allow_review_workflow
+      t.boolean :allow_embargo
+      t.boolean :allow_blackout
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :stash_engine_journals
+  end
+end

--- a/stash/stash_engine/lib/stash/payments/invoicer.rb
+++ b/stash/stash_engine/lib/stash/payments/invoicer.rb
@@ -151,7 +151,7 @@ module Stash
       end
 
       def stripe_journal_customer_id
-        resource.identifier&.journal_customer_id
+        resource.identifier&.journal&.stripe_customer_id
       end
 
       def lookup_prior_stripe_customer_id(email)

--- a/stash/stash_engine/lib/tasks/migration.rake
+++ b/stash/stash_engine/lib/tasks/migration.rake
@@ -1,7 +1,30 @@
 require 'pp'
 require_relative 'migration_import'
 require 'database_cleaner'
+
+# Tasks for migration of various content into the Dryad environment. Tasks in this file are not intended for
+# long-term use; they are either for a single migration or for use over a limited time period.
+
 namespace :dryad_migration do
+  
+  desc 'Migrate content from the v1 journal module'
+  task migrate_journal_metadata: :environment do  
+    i = 1
+    File.foreach("journalISSNs.txt") do |issn|
+      issn = issn.strip
+      puts "#{i} #{issn}"
+      i += 1
+      url = APP_CONFIG.old_dryad_url + '/api/v1/journals/' + issn
+      results = HTTParty.get(url,
+                             query: { access_token: APP_CONFIG.old_dryad_access_token },
+                             headers: { 'Content-Type' => 'application/json' })
+      pr = results.parsed_response
+      next if pr['fullName'].blank?
+      puts pr['fullName']
+    end
+  end
+
+  
   desc 'Test reading single item'
   task test: :environment do
     # see https://stackoverflow.com/questions/27913457/ruby-on-rails-specify-environment-in-rake-task

--- a/stash/stash_engine/lib/tasks/migration.rake
+++ b/stash/stash_engine/lib/tasks/migration.rake
@@ -5,12 +5,12 @@ require 'database_cleaner'
 # Tasks for migration of various content into the Dryad environment. Tasks in this file are not intended for
 # long-term use; they are either for a single migration or for use over a limited time period.
 
+# rubocop:disable Metrics/BlockLength
 namespace :dryad_migration do
-  
   desc 'Migrate content from the v1 journal module'
-  task migrate_journal_metadata: :environment do  
+  task migrate_journal_metadata: :environment do
     i = 1
-    File.foreach("journalISSNs.txt") do |issn|
+    File.foreach('journalISSNs.txt') do |issn|
       issn = issn.strip
       puts "#{i} #{issn}"
       i += 1
@@ -24,7 +24,6 @@ namespace :dryad_migration do
     end
   end
 
-  
   desc 'Test reading single item'
   task test: :environment do
     # see https://stackoverflow.com/questions/27913457/ruby-on-rails-specify-environment-in-rake-task
@@ -83,3 +82,4 @@ namespace :dryad_migration do
   end
 
 end
+# rubocop:enable Metrics/BlockLength

--- a/stash/stash_engine/lib/tasks/migration.rake
+++ b/stash/stash_engine/lib/tasks/migration.rake
@@ -35,6 +35,7 @@ namespace :dryad_migration do
                payment_contact: pr['paymentContact'],
                manuscript_number_regex: pr['manuscriptNumberRegex'],
                sponsor_name: pr['sponsorName'],
+               stripe_customer_id: pr['stripeCustomerID'],
                notify_contacts: pr['notifyContacts'],
                review_contacts: pr['reviewContacts'],
                allow_review_workflow: pr['allowReviewWorkflow'],

--- a/stash/stash_engine/lib/tasks/migration.rake
+++ b/stash/stash_engine/lib/tasks/migration.rake
@@ -21,6 +21,7 @@ namespace :dryad_migration do
       pr = results.parsed_response
       next if pr['fullName'].blank?
       puts pr['fullName']
+      j = StashEngine::Journal.create(title: pr['fullName'])
     end
   end
 

--- a/stash/stash_engine/lib/tasks/migration.rake
+++ b/stash/stash_engine/lib/tasks/migration.rake
@@ -9,19 +9,38 @@ require 'database_cleaner'
 namespace :dryad_migration do
   desc 'Migrate content from the v1 journal module'
   task migrate_journal_metadata: :environment do
-    i = 1
     File.foreach('journalISSNs.txt') do |issn|
       issn = issn.strip
-      puts "#{i} #{issn}"
-      i += 1
       url = APP_CONFIG.old_dryad_url + '/api/v1/journals/' + issn
       results = HTTParty.get(url,
                              query: { access_token: APP_CONFIG.old_dryad_access_token },
                              headers: { 'Content-Type' => 'application/json' })
       pr = results.parsed_response
       next if pr['fullName'].blank?
-      puts pr['fullName']
-      j = StashEngine::Journal.create(title: pr['fullName'])
+
+      # The API can return an empty string for paymentPlan; convert to nil
+      pr['paymentPlanType'] = nil if pr['paymentPlanType'] == ''
+
+      # Create/update journals using the ISSN received from the API, because that
+      # is the primary ISSN. We don't want to use a secondary ISSN if it was
+      # present in the input file.
+      j = StashEngine::Journal.find_or_create_by(issn: pr['issn'])
+      puts "migrating journal #{j.id} -- #{j.issn} -- #{pr['fullName']}"
+
+      j.update(title: pr['fullName'],
+               issn: pr['issn'],
+               website: pr['website'],
+               description: pr['description'],
+               payment_plan_type: pr['paymentPlanType'],
+               payment_contact: pr['paymentContact'],
+               manuscript_number_regex: pr['manuscriptNumberRegex'],
+               sponsor_name: pr['sponsorName'],
+               notify_contacts: pr['notifyContacts'],
+               review_contacts: pr['reviewContacts'],
+               allow_review_workflow: pr['allowReviewWorkflow'],
+               allow_embargo: pr['allowEmbargo'],
+               allow_blackout: pr['allowBlackout'])
+      j.save!
     end
   end
 

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -229,7 +229,7 @@ namespace :identifiers do
         submitted_date_str = submitted_date&.strftime('%Y-%m-%d')
         csv << [i.identifier, created_date_str, submitted_date_str, approval_date_str,
                 i.storage_size, i.payment_type, i.payment_id, i.submitter_affiliation&.long_name,
-                i.publication_name, i.journal_sponsor_name]
+                i.publication_name, i.journal&.sponsor_name]
       end
     end
     # Exit cleanly (don't let rake assume that an extra argument is another task to process)

--- a/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -330,7 +330,6 @@ module StashEngine
 
     describe '#user_must_pay?' do
       before(:each) do
-        allow(@identifier).to receive(:journal_will_pay?).and_return(false)
         allow(@identifier).to receive(:institution_will_pay?).and_return(false)
         allow(@identifier).to receive(:funder_will_pay?).and_return(false)
       end
@@ -364,7 +363,6 @@ module StashEngine
       end
 
       it 'records an institution payment' do
-        allow(@identifier).to receive(:journal_will_pay?).and_return(false)
         allow(@identifier).to receive(:institution_will_pay?).and_return(true)
         @identifier.record_payment
         expect(@identifier.payment_type).to eq('institution')

--- a/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -423,7 +423,7 @@ module StashEngine
         expect(identifier.journal.title).to eq(@bogus_title)
       end
 
-      it 'allows review when there is no journal' do        
+      it 'allows review when there is no journal' do
         expect(@identifier.allow_review?).to be(true)
       end
 

--- a/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -340,7 +340,7 @@ module StashEngine
       end
 
       it 'returns false if journal will pay' do
-        allow(@identifier).to receive(:journal_will_pay?).and_return(true)
+        Journal.create(issn: @fake_issn, payment_plan_type: 'SUBSCRIPTION')
         expect(@identifier.user_must_pay?).to eq(false)
       end
 
@@ -358,15 +358,13 @@ module StashEngine
       end
 
       it 'records a journal payment' do
-        allow(@identifier).to receive(:journal_will_pay?).and_return(true)
-        allow(@identifier).to receive(:publication_data).and_return('bogus_journal_data')
+        Journal.create(issn: @fake_issn, payment_plan_type: 'SUBSCRIPTION')
         @identifier.record_payment
         expect(@identifier.payment_type).to match(/journal/)
       end
 
       it 'records an institution payment' do
         allow(@identifier).to receive(:journal_will_pay?).and_return(false)
-        allow(@identifier).to receive(:publication_data).and_return('bogus_journal_data')
         allow(@identifier).to receive(:institution_will_pay?).and_return(true)
         @identifier.record_payment
         expect(@identifier.payment_type).to eq('institution')
@@ -377,13 +375,11 @@ module StashEngine
         allow(affil).to receive(:fee_waivered?).and_return(true)
         allow(affil).to receive(:country_name).and_return('Bogusland')
         allow(@identifier).to receive(:submitter_affiliation).and_return(affil)
-        allow(@identifier).to receive(:publication_data).and_return('bogus_journal_data')
         @identifier.record_payment
         expect(@identifier.payment_type).to eq('waiver')
       end
 
       it 'records a funder-based payment' do
-        allow(@identifier).to receive(:journal_will_pay?).and_return(false) # bypass this one
         allow_any_instance_of(StashEngine::Resource).to receive(:contributors).and_return(
           [
             OpenStruct.new('payment_exempted?': false, contributor_name: 'Johann Strauss University', award_number: 'Latke153'),
@@ -395,16 +391,6 @@ module StashEngine
         expect(@identifier.payment_id).to include('Zorgast Industries')
         expect(@identifier.payment_id).to include('award:')
         expect(@identifier.payment_id).to include('ZI0027')
-      end
-    end
-
-    describe '#publication_data' do
-      it 'reads the value correctly from json body' do
-        stub_request(:any, %r{/journals/#{@fake_issn}})
-          .to_return(body: { blah: 'meow' }.to_json,
-                     status: 200,
-                     headers: { 'Content-Type' => 'application/json' })
-        expect(@identifier.publication_data('blah')).to eql('meow')
       end
     end
 
@@ -430,115 +416,34 @@ module StashEngine
       end
     end
 
-    describe '#publication_name' do
-      it 'retrieves the publication_name' do
-        @fake_journal_name = 'Fake Journal'
-        stub_request(:any, %r{/journals/#{@fake_issn}})
-          .to_return(body: '{"fullName":"' + @fake_journal_name + '",
-                             "issn":"' + @fake_issn + '",
-                             "website":"http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-294X",
-                             "description":"Molecular Ecology publishes papers that utilize molecular genetic techniques..."}',
-                     status: 200,
-                     headers: { 'Content-Type' => 'application/json' })
-        expect(identifier.publication_name).to eq(@fake_journal_name)
+    describe '#journal' do
+      it 'retrieves the associated journal' do
+        @bogus_title = 'Some Bogus Title'
+        Journal.create(issn: @fake_issn, title: @bogus_title)
+        expect(identifier.journal.title).to eq(@bogus_title)
       end
-    end
 
-    describe '#journal_customer_id' do
-      it 'retrieves the journal Stripe customer ID' do
-        @fake_journal_name = 'Fake Journal'
-        @fake_customer_id = 'cust_abc123'
-        stub_request(:any, %r{/journals/#{@fake_issn}})
-          .to_return(body: '{"fullName":"' + @fake_journal_name + '",
-                             "issn":"' + @fake_issn + '",
-                             "website":"http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-294X",
-                             "description":"Molecular Ecology publishes papers that utilize molecular genetic techniques...",
-                             "stripeCustomerID":"' + @fake_customer_id + '"}',
-                     status: 200,
-                     headers: { 'Content-Type' => 'application/json' })
-        expect(identifier.journal_customer_id).to eq(@fake_customer_id)
-      end
-    end
-
-    describe '#journal_sponsor_name' do
-      it 'retrieves the journal sponsorName' do
-        @fake_journal_name = 'Fake Journal'
-        @fake_sponsor_name = 'sponsor_abc123'
-        stub_request(:any, %r{/journals/#{@fake_issn}})
-          .to_return(body: '{"fullName":"' + @fake_journal_name + '",
-                             "issn":"' + @fake_issn + '",
-                             "website":"http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-294X",
-                             "description":"Molecular Ecology publishes papers that utilize molecular genetic techniques...",
-                             "sponsorName":"' + @fake_sponsor_name + '"}',
-                     status: 200,
-                     headers: { 'Content-Type' => 'application/json' })
-        expect(identifier.journal_sponsor_name).to eq(@fake_sponsor_name)
-      end
-    end
-
-    describe '#journal_manuscript_regex' do
-      it 'retrieves the journal regex' do
-        @fake_journal_name = 'Fake Journal'
-        @fake_manuscript_regex = ".*?(\d+-\d+).*?"
-        stub_request(:any, %r{/journals/#{@fake_issn}})
-          .to_return(body: '{"fullName":"' + @fake_journal_name + '",
-                             "issn":"' + @fake_issn + '",
-                             "manuscriptNumberRegex":"' + @fake_manuscript_regex + '"}',
-                     status: 200,
-                     headers: { 'Content-Type' => 'application/json' })
-        expect(identifier.journal_manuscript_regex).to eq(@fake_manuscript_regex)
-      end
-    end
-
-    describe '#journal_allows' do
-      it 'allows review when there is no journal' do
-        allow(@identifier).to receive('publication_name').and_return(nil)
-        allow(@identifier).to receive('publication_data').and_return(false)
+      it 'allows review when there is no journal' do        
         expect(@identifier.allow_review?).to be(true)
       end
 
       it 'allows review when the journal allows review' do
-        allow(@identifier).to receive('publication_name').and_return('fakename')
-        allow(@identifier).to receive('publication_data').and_return(true)
+        Journal.create(issn: @fake_issn, allow_review_workflow: true)
         expect(@identifier.allow_review?).to be(true)
       end
 
       it 'disallows review when the journal disallows review' do
-        allow(@identifier).to receive('publication_name').and_return('fakename')
-        allow(@identifier).to receive('publication_data').and_return(false)
+        Journal.create(issn: @fake_issn, allow_review_workflow: false)
         expect(@identifier.allow_review?).to be(false)
       end
 
       it 'disallows blackout by default' do
-        allow(@identifier).to receive('publication_data').and_return(nil)
         expect(@identifier.allow_blackout?).to be(false)
       end
 
       it 'allows blackout when the journal allows blackout' do
-        allow(@identifier).to receive('publication_data').and_return(true)
+        Journal.create(issn: @fake_issn, allow_blackout: true)
         expect(@identifier.allow_blackout?).to be(true)
-      end
-    end
-
-    describe '#journal_will_pay?' do
-      it 'returns true when there is a PREPAID plan' do
-        allow(@identifier).to receive('publication_data').and_return('PREPAID')
-        expect(@identifier.journal_will_pay?).to be(true)
-      end
-
-      it 'returns true when there is a SUBSCRIPTION plan' do
-        allow(@identifier).to receive('publication_data').and_return('SUBSCRIPTION')
-        expect(@identifier.journal_will_pay?).to be(true)
-      end
-
-      it 'returns false when there is a no plan' do
-        allow(@identifier).to receive('publication_data').and_return(nil)
-        expect(@identifier.journal_will_pay?).to be(false)
-      end
-
-      it 'returns false when there is an unrecognized plan' do
-        allow(@identifier).to receive('publication_data').and_return('BOGUS-PLAN')
-        expect(@identifier.journal_will_pay?).to be(false)
       end
     end
 

--- a/stash/stash_engine/spec/db/stash_engine/journal_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/journal_spec.rb
@@ -1,0 +1,36 @@
+require 'db_spec_helper'
+require 'webmock/rspec'
+require_relative '../../../../spec_helpers/factory_helper'
+require 'byebug'
+
+module StashEngine
+  describe Journal do
+    
+    before(:each) do
+      @journal = Journal.create(issn: '1234-5678')
+    end
+      
+    describe '#will_pay?' do
+      it 'returns true when there is a PREPAID plan' do
+        allow(@journal).to receive('payment_plan_type').and_return('PREPAID')
+        expect(@journal.will_pay?).to be(true)
+      end
+
+      it 'returns true when there is a SUBSCRIPTION plan' do
+        allow(@journal).to receive('payment_plan_type').and_return('SUBSCRIPTION')
+        expect(@journal.will_pay?).to be(true)
+      end
+
+      it 'returns false when there is a no plan' do
+        allow(@journal).to receive('payment_plan_type').and_return(nil)
+        expect(@journal.will_pay?).to be(false)
+      end
+
+      it 'returns false when there is an unrecognized plan' do
+        allow(@journal).to receive('payment_plan_type').and_return('BOGUS-PLAN')
+        expect(@journal.will_pay?).to be(false)
+      end
+    end
+
+  end
+end

--- a/stash/stash_engine/spec/db/stash_engine/journal_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/journal_spec.rb
@@ -5,11 +5,11 @@ require 'byebug'
 
 module StashEngine
   describe Journal do
-    
+
     before(:each) do
       @journal = Journal.create(issn: '1234-5678')
     end
-      
+
     describe '#will_pay?' do
       it 'returns true when there is a PREPAID plan' do
         allow(@journal).to receive('payment_plan_type').and_return('PREPAID')

--- a/stash/stash_engine/spec/db/stash_engine/journal_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/journal_spec.rb
@@ -1,7 +1,4 @@
 require 'db_spec_helper'
-require 'webmock/rspec'
-require_relative '../../../../spec_helpers/factory_helper'
-require 'byebug'
 
 module StashEngine
   describe Journal do


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/697

This PR includes:
1) Creation of a new model, StashEngine::Journal
2) Provides a rake task that reads journal metadata from the Dryad v1 API, and uses this information to populate `stash_engine_journals`
3) Refactors most of the journal-related functionality from the Identifier model into the Journal model.

The Journal model itself is very simplistic. Although it is technically writable, it is currently treated as if it were still a read-only API. The only thing that writes values into the model is the rake task that initializes it. The "writable" fields are still in `stash_engine_internal_data`, associated with Identifier objects. 

Now that the metadata is directly accessible by Rails, I was able to remove a lot of test framework that was stubbing out the API and testing trivial GETs. These are now handled the ActiveRecord automatic getters, so I didn't add new tests to replace them.

To migrate the journal metadata:
1) Run the database migration
2) Copy the file `https://v1.datadryad.org/themes/Mirage/lib/journalISSNs.txt` into the directory where you normally run rake tasks.
3) Run the journal-migration task: `rake dryad_migration:migrate_journal_metadata`
You should see all of the relevant metadata appear in the database, and the updated code now uses these database entries instead of the API. 

There is no new functionality, but all journal functions should still operate as normal, including:
- autocomplete in the submission system
- metadata import (note: this still uses the v1 API)
- payment