### PR TITLE
Update GitHub URLs

### DIFF
--- a/app/views/layouts/_our_platform.html.md
+++ b/app/views/layouts/_our_platform.html.md
@@ -7,7 +7,7 @@ For information about submission to Dryad, see our [guidance here](<%= stash_url
 
 ## Architecture and Implementation
 
-Dryad is completely open source.  Our code is made publicly available on GitHub [https://github.com/CDL-Dryad/dryad](https://github.com/CDL-Dryad/dryad). Dryad is based on an underlying Ruby-on-Rails data publication platform called Stash. Stash encompasses three main functional components: Store, Harvest, and Share.
+Dryad is completely open source.  Our code is made publicly available on GitHub [https://github.com/CDL-Dryad/dryad-app](https://github.com/CDL-Dryad/dryad-app). Dryad is based on an underlying Ruby-on-Rails data publication platform called Stash. Stash encompasses three main functional components: Store, Harvest, and Share.
 
 - Store: The Store component is responsible for the selection of datasets; their description in terms of configurable metadata schemas, including specification of ORCID and Fundref identifiers for researcher and funder disambiguation; the assignment of DOIs for stable citation and retrieval; designation of an optional limited time embargo; and packaging and submission to the integrated repository
 - Harvest: The Harvest component is responsible for retrieval of descriptive metadata from that repository for inclusion into a Solr search index
@@ -19,13 +19,13 @@ Individual dataset landing pages are formatted as an online version of a data pa
 
 To facilitate flexible configuration and future enhancement, all support for the various external service providers and repository protocols are fully encapsulated into pluggable modules. Metadata modules are available for the DataCitemetadata schema. Protocol modules are available for the SWORD 2.0 deposit protocol and the OAI-PMH and ResourceSync harvesting protocols. Authentication modules are available for InCommon/Shibboleth18 and ORCID identity providers (IdPs).
 
-We welcome collaborations to develop additional modules for additional metadata schemas and repository protocols. Please email the Dryad [help desk](mailto:help@datadryad.org) or visit GitHub [https://github.com/CDL-Dryad/dryad](https://github.com/CDL-Dryad/dryad) for more information.
+We welcome collaborations to develop additional modules for additional metadata schemas and repository protocols. Please email the Dryad [help desk](mailto:help@datadryad.org) or visit GitHub [https://github.com/CDL-Dryad/dryad-app](https://github.com/CDL-Dryad/dryad-app) for more information.
 
 ## Features of Dryad service
 
 | Feature | Tech-focused | User-focused | Description |
 |:---------------------------------|:-------------------------:|:------------------:|:--------------|
-| Open Source | X |  | All components open source, MIT licensed code [https://github.com/CDL-Dryad/dryad](https://github.com/CDL-Dryad/dryad) |
+| Open Source | X |  | All components open source, MIT licensed code [https://github.com/CDL-Dryad/dryad-app](https://github.com/CDL-Dryad/dryad-app) |
 | Standards compliant | X |  | Dryad integrates with any SWORD/OAI-PMH-compliant repository |
 | Pluggable Framework | X |  | Inherent extensibility for supporting additional protocols and metadata schemas |
 | Flexible metadata schemas | X |  | Support Datacite metadata schema out-of-the-box, but can be configured to support any schema |

--- a/app/views/layouts/_submission_process.html.md
+++ b/app/views/layouts/_submission_process.html.md
@@ -10,7 +10,7 @@
 <li><strong>When preparing your complete version of a dataset, remember to collate all relevant explantory documents and metadata</strong>. This includes relevant documentation necessary for the re-use and replication of your dataset (e.g., readme.txt files, formal metadata records, or other critical information)</li>
 </ul>
 
-<p><b>Dryad has a REST API that allows for download and submission of data. Check out our <a href="https://datadryad.org/api/v2/docs/">documentation</a> as well as our <a href="https://github.com/CDL-Dryad/dryad/blob/master/stash_api/basic_submission.md">How-To Guide</a>.</b></p>
+<p><b>Dryad has a REST API that allows for download and submission of data. Check out our <a href="https://datadryad.org/api/v2/docs/">documentation</a> as well as our <a href="https://github.com/CDL-Dryad/dryad-app/blob/master/documentation/apis/submission.md">How-To Guide</a>.</b></p>
 
 <p>If you need further assistance, consult our <a href="<%= stash_url_helpers.faq_path %>">FAQ</a> or contact us at <a href=mailto:help@datadryad.org>help@datadryad.org</a>. Log in and go to "My Datasets" to begin your data submission now!</p>
 

--- a/config/solr_config/README.md
+++ b/config/solr_config/README.md
@@ -22,8 +22,8 @@ cp geoblacklight-schema-0.3.2/conf/* ~/apps/solr/server/solr/geoblacklight/conf
 ```
 # copy our customizations
 cd ~/apps/solr/server/solr/geoblacklight/conf/
-wget https://raw.githubusercontent.com/CDL-Dryad/dryad/master/config/solr_config/schema.xml
-wget https://raw.githubusercontent.com/CDL-Dryad/dryad/master/config/solr_config/solrconfig.xml
+wget https://raw.githubusercontent.com/CDL-Dryad/dryad-app/master/config/solr_config/schema.xml
+wget https://raw.githubusercontent.com/CDL-Dryad/dryad-app/master/config/solr_config/solrconfig.xml
 ```
 
 ```

--- a/documentation/apis/submission.md
+++ b/documentation/apis/submission.md
@@ -101,7 +101,7 @@ doi_encoded = URI.escape(doi)
 ```
 ## Dataset options
 
-To see the dataset fields and option in use, see the [Sample Dataset Object](https://github.com/CDL-Dryad/dryad/blob/master/documentation/sample_dataset.json).
+To see the dataset fields and option in use, see the [Sample Dataset Object](https://github.com/CDL-Dryad/dryad-app/blob/master/documentation/sample_dataset.json).
 
 Useful options that control a dataset's behavior:
 - `skipDataciteUpdate` - If true, doesn't send any requests to DataCite when registering the dataset. This is useful when the dataset already has a DOI, which is present in the metadata being submitted.
@@ -162,7 +162,7 @@ To upload a file that is referenced by URL, do a POST to `{{url-domain-name}}/ap
 
 ```
 {
-    "url": "https://raw.githubusercontent.com/CDL-Dryad/dryad/master/documentation/api_submission.md",
+    "url": "https://raw.githubusercontent.com/CDL-Dryad/dryad-app/master/documentation/apis/submission.md",
     "digest": "aca3032d20c829a6060f1b90afda6d14",
     "digestType": "md5",
     "description": "This is the best file ever!",

--- a/documentation/dryad_install.md
+++ b/documentation/dryad_install.md
@@ -7,8 +7,7 @@ The Dryad application is made of a number of parts intended to keep it more flex
 You'll need the following parts installed and configured on a (local) UI development server to do development on the full UI application.  Don't worry, there are more detailed installation instructions in other sections below and this is meant to give an overview of the larger dependencies to configure.
 
 - (Recommended) A ruby version manager such as [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/)
-- The [bare Dryad application](https://github.com/CDL-Dryad/dryad) cloned from github
-- The [stash](https://github.com/CDL-Dryad/stash) repository cloned from github
+- The [bare Dryad application](https://github.com/CDL-Dryad/dryad-app) cloned from github
 
 You'll also need the following components installed either on the same server or on separate servers for all the application features to work:
 
@@ -28,8 +27,7 @@ The application also requires some means to log in outside of a development envi
 Open a (bash) shell and type these commands inside a directory where you want to work with this code. These will clone the development code and an example config.
 
 ```
-git clone https://github.com/CDL-Dryad/dryad
-git clone https://github.com/CDL-Dryad/stash
+git clone https://github.com/CDL-Dryad/dryad-app
 ```
 
 Your config files will be stored in a separate directory from your application. It can be handy to keep them apart from the application so that you can back them up or commit them to a private repository for configuration separate from the application.  The application will need to have these configuration files symlinked into the application. To copy the example config to an external directory and symlink the files in using a bash shell, type these commands:

--- a/documentation/migration.md
+++ b/documentation/migration.md
@@ -42,7 +42,7 @@ The DSpace implementation lives in these Java files:
 - DashService = API communications with Dash
 - TransferToDash = curation task that manages bulk transfer of packages to Dash
 
-The DASH implementation lives primarily in the [DASH submission API](https://github.com/CDL-Dryad/dryad/blob/master/documentation/api_submission.md).
+The DASH implementation lives primarily in the [DASH submission API](https://github.com/CDL-Dryad/dryad-app/blob/master/documentation/apis/submission.md).
 
 ## Statistics Migration
 

--- a/spec/mocks/url_upload.rb
+++ b/spec/mocks/url_upload.rb
@@ -2,7 +2,7 @@ module Mocks
 
   module UrlUpload
     def mock_github_head_request!
-      stub_request(:head, 'http://github.com/CDL-Dryad/dryad/raw/master/app/assets/images/favicon.ico')
+      stub_request(:head, 'http://github.com/CDL-Dryad/dryad-app/raw/master/app/assets/images/favicon.ico')
         .with(
           headers: {
             'Accept' => '*/*'
@@ -18,7 +18,7 @@ module Mocks
     end
 
     def mock_github_bad_head_request!
-      stub_request(:head, 'http://github.com/CDL-Dryad/dryad/raw/master/app/assets/images/favicon.ico')
+      stub_request(:head, 'http://github.com/CDL-Dryad/dryad-app/raw/master/app/assets/images/favicon.ico')
         .with(
           headers: {
             'Accept' => '*/*'

--- a/spec/responses/stash_api/urls_controller_spec.rb
+++ b/spec/responses/stash_api/urls_controller_spec.rb
@@ -24,7 +24,7 @@ module StashApi
 
       FILE_HASH = {
         'skipValidation' => true,
-        'url' => 'http://github.com/CDL-Dryad/dryad/raw/master/app/assets/images/favicon.ico',
+        'url' => 'http://github.com/CDL-Dryad/dryad-app/raw/master/app/assets/images/favicon.ico',
         'digestType' => 'md5',
         'path' => 'favicon.ico',
         'mimeType' => 'image/vnd.microsoft.icon',
@@ -65,12 +65,12 @@ module StashApi
     describe '#create' do
       it 'will retrive, validate and fill in info from a URL from the internet by HEAD request' do
         mock_github_head_request!
-        test_url = 'http://github.com/CDL-Dryad/dryad/raw/master/app/assets/images/favicon.ico'
+        test_url = 'http://github.com/CDL-Dryad/dryad-app/raw/master/app/assets/images/favicon.ico'
         response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
         expect(response_code).to eq(201)
         hsh = response_body_hash
         expect(hsh['path']).to eq('favicon.ico')
-        expect(hsh['url']).to eq('http://github.com/CDL-Dryad/dryad/raw/master/app/assets/images/favicon.ico')
+        expect(hsh['url']).to eq('http://github.com/CDL-Dryad/dryad-app/raw/master/app/assets/images/favicon.ico')
         expect(hsh['size']).to eq(6318)
         expect(hsh['mimeType']).to eq('image/vnd.microsoft.icon')
         expect(hsh['status']).to eq('created')
@@ -93,14 +93,14 @@ module StashApi
 
       it "doesn't allow anonymous (not logged in) users to add urls" do
         mock_github_head_request!
-        test_url = 'http://github.com/CDL-Dryad/dryad/raw/master/app/assets/images/favicon.ico'
+        test_url = 'http://github.com/CDL-Dryad/dryad-app/raw/master/app/assets/images/favicon.ico'
         response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_json_headers
         expect(response_code).to eq(401)
       end
 
       it "doesn't allow adding the same URL multiple times" do
         mock_github_head_request!
-        test_url = 'http://github.com/CDL-Dryad/dryad/raw/master/app/assets/images/favicon.ico'
+        test_url = 'http://github.com/CDL-Dryad/dryad-app/raw/master/app/assets/images/favicon.ico'
         post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
         response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
         expect(response_code).to eq(403)
@@ -116,7 +116,7 @@ module StashApi
 
       it 'gives an error for non-validating urls (404)' do
         mock_github_bad_head_request!
-        test_url = 'http://github.com/CDL-Dryad/dryad/raw/master/app/assets/images/favicon.ico'
+        test_url = 'http://github.com/CDL-Dryad/dryad-app/raw/master/app/assets/images/favicon.ico'
         response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
         expect(response_code).to eq(403)
         expect(response_body_hash.key?('error')).to eq(true)
@@ -126,7 +126,7 @@ module StashApi
         @resources[0].current_resource_state.update(resource_state: 'submitted')
         @resources[1].current_resource_state.update(resource_state: 'processing')
         mock_github_head_request!
-        test_url = 'http://github.com/CDL-Dryad/dryad/raw/master/app/assets/images/favicon.ico'
+        test_url = 'http://github.com/CDL-Dryad/dryad-app/raw/master/app/assets/images/favicon.ico'
         response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls", { url: test_url }.to_json, default_authenticated_headers
         expect(response_code).to eq(403)
         expect(response_body_hash.key?('error')).to eq(true)

--- a/stash/README.md
+++ b/stash/README.md
@@ -29,7 +29,7 @@ repository.
 
 The next generation of [Dryad](https://datadryad.org) is being rebuilt
 with the Stash core. For the Dryad source code, see the
-[dryad](https://github.com/CDL-Dryad/dryad) repository.
+[dryad](https://github.com/CDL-Dryad/dryad-app) repository.
 
 ## Architecture
 

--- a/stash/stash_api/public/openapi.yml
+++ b/stash/stash_api/public/openapi.yml
@@ -8,7 +8,7 @@ info:
     The API for the [Dryad](https://datadryad.org) data publication and
     preservation platform.
 
-    In addition to this documentation, please see the [API Submission Examples](https://github.com/CDL-Dryad/dryad/blob/master/documentation/api_submission.md) which give concrete examples of submission through the Dryad API.
+    In addition to this documentation, please see the [API Submission Examples](https://github.com/CDL-Dryad/dryad-app/blob/master/documentation/apis/submission.md) which give concrete examples of submission through the Dryad API.
 
     Our [Github Documentation Directory](https://github.com/CDL-Dryad/dryad/tree/master/documentation) may also be expanded further in the future as more documentation is created (though not all of it may be relevant to API users).
 


### PR DESCRIPTION
Update GitHub URLs in text pages and documentation to reflect the move to the dryad-app repository. 