### PR TITLE
Add some info on Merritt operations

### DIFF
--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -6,9 +6,43 @@ Some common problems and how to deal with them.
 Also see the notes on
 [handling failed submissions](https://confluence.ucop.edu/display/Stash/Dryad+Operations#DryadOperations-FixingaFailedSubmission).
 
+Interactions with Merritt
+===========================
+
+Submissions to Merritt can be started and stopped from the
+[GUI Submission Queue page](https://datadryad.org/stash/submission_queue). However,
+actions on this page will only affect the single server that you are
+attached to, and not all servers in a load-balanced system.
+
+Stopping Merritt Submissions
+-----------------------------
+
+To pause Merritt submissions, on each server:
+```
+touch apps/ui/releases/hold-submissions.txt
+```
+
+(Re)Starting Merritt Submissions
+-----------------------------
+
+To restart Merrit submissions, on each server:
+```
+rm apps/ui/releases/hold-submissions.txt
+```
+
+THEN, on one server, in the Rails console:
+```
+resource_ids =
+StashEngine::RepoQueueState.latest_per_resource.where(state:
+'rejected_shutting_down').order(:updated_at).map(&:resource_id)
+resource_ids.each do |res_id|
+StashEngine.repository.submit(resource_id: res_id)
+end
+```
+
 
 Merrit async download check
-===========================
+----------------------------
 
 This error typically means that the account being used by the Dryad UI
 to access Merritt does not have permisisons for the object being


### PR DESCRIPTION
Adding some troubleshooting info about starting/stopping Merritt submissions.

The remaining info from Confluence will be moved eventually as part of the ongoing documentation project. 