### PR TITLE
fix file download path

### DIFF
--- a/stash/stash_api/app/models/stash_api/file.rb
+++ b/stash/stash_api/app/models/stash_api/file.rb
@@ -45,7 +45,7 @@ module StashApi
     end
 
     def add_download!(hsh)
-      hsh['stash:download'] = { href: api_url_helper.file_download_path(@se_file_upload.id) } if @se_file_upload.resource.submitted? &&
+      hsh['stash:download'] = { href: api_url_helper.download_file_path(@se_file_upload.id) } if @se_file_upload.resource.submitted? &&
           @se_file_upload.resource.may_download?(ui_user: nil)
     end
 


### PR DESCRIPTION
Correcting a typo from https://github.com/CDL-Dryad/dryad-app/pull/83. I did all the testing on the development branch, since actual downloads don't work on my test server, but somehow the words got switched in the actual PR to master.