### PR TITLE
Journal API permissions

### DIFF
--- a/documentation/apis/README.md
+++ b/documentation/apis/README.md
@@ -7,3 +7,23 @@ Our most frequently-used API endpoints are summarized at
 https://datadryad.org/api/v2/docs/, with more details in the
 [Submisison API Document](submission.md).
 
+Adding a New API Account
+========================
+
+The user requesting the account must have previously logged in to
+Dryad so they have a user record and you will want to find their user
+record in the database.
+
+To create an API account:
+1. Log into Dryad with a user that has the superuser role (set the
+   role of your user record to 'superuser' if you need to). Go to the
+   path `/oauth/applications` on the server and add a new application.
+2. Fill in an application name and a redirect uri.  The redirect URI
+   isn't used for this case, but it forces a fill-in, anyway.
+3. Figure out the user id in our database for the user who will access
+   the API, also have the application id for this newly-created
+   application for the next steps (it is shown as an ID in the URL when
+   you're viewing that application information).
+4. Then, in the database, update the `oauth_applications` table to
+   relate the user with the application:
+   `update oauth_applications set owner_type = 'StashEngine::User', owner_id = <user id> where id = <application id>;`

--- a/documentation/apis/README.md
+++ b/documentation/apis/README.md
@@ -27,3 +27,12 @@ To create an API account:
 4. Then, in the database, update the `oauth_applications` table to
    relate the user with the application:
    `update oauth_applications set owner_type = 'StashEngine::User', owner_id = <user id> where id = <application id>;`
+
+To set permissions for the API account:
+- The user can be set to a `superuser` or tenant-based `admin` role using
+  either the database or rails console:
+  `update stash_engine_users set role='admin' where id= <user id>;`
+  `StashEngine::User.find(<user id>).update(role: 'admin')`
+- The user can be set as a journal administrator using either the database or rails console:
+  `insert into stash_engine_journal_roles (journal_id, user_id, role) values (1, 3, 'admin');`
+  `StashEngine::JournalRole.new(user:u, journal:j, role:'admin').save`

--- a/documentation/apis/submission.md
+++ b/documentation/apis/submission.md
@@ -7,7 +7,7 @@ This document gives practical information for working with the API in order to s
 
 Before you can submit from the API, you need to log in to Dryad at least once to create a user record.  You may log in to your associated campus/organization or use the DataONE login with your Google login credentials.
 
-To request access, please [contact us](mailto:uc3@ucop.edu). (Developers see [Adding a New API Account](https://confluence.ucop.edu/pages/viewpage.action?spaceKey=Stash&title=Dryad+Operations#DryadOperations-AddingaNewAPIAccountforSubmission))
+To request access, please [contact us](mailto:uc3@ucop.edu). (Developers see [Adding a New API Account](README.md))
 
 ## Get a token for making requests for secure parts of the API
 Before making secure requests to the Dryad API, you'll need a token.  Currently our tokens last 10 hours and a token will need to be renewed if it expires.  You may get a token using these examples from a few programming environments.  Replace &lt;bracketed&gt; items with the values you were given.  For testing, you may choose to use a bash shell, a programming environment or a tool such as Postman.

--- a/spec/factories/stash_engine/journal_roles.rb
+++ b/spec/factories/stash_engine/journal_roles.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+
+  factory :journal_role, class: StashEngine::JournalRole do
+
+    journal
+    user
+
+  end
+
+end

--- a/spec/factories/stash_engine/journals.rb
+++ b/spec/factories/stash_engine/journals.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+
+  factory :journal, class: StashEngine::Journal do
+
+    title { Faker::Company.industry }
+    issn { "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}" }
+
+  end
+
+end

--- a/spec/models/stash_engine/journal_role_spec.rb
+++ b/spec/models/stash_engine/journal_role_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+module StashEngine
+
+  RSpec.describe JournalRole, type: :model do
+
+    describe 'user should be able to find associated journals' do
+
+      let(:journal) { build(:journal) }
+      let(:journal2) { build(:journal) }
+      let(:user) { build(:user) }
+      let!(:journal_role) { create(:journal_role, journal: journal, user: user) }
+      let!(:journal_role2) { create(:journal_role, journal: journal2, user: user, role: 'admin') }
+
+      it 'returns all journals associated with the user' do
+        expect(user.journals.size).to eql(2)
+      end
+
+      it 'returns the single journal that the user administers' do
+        expect(user.journals_as_admin.size).to eql(1)
+        expect(user.journals_as_admin.first).to eql(journal2)
+      end
+
+    end
+
+  end
+
+end

--- a/spec/models/stash_engine/journal_role_spec.rb
+++ b/spec/models/stash_engine/journal_role_spec.rb
@@ -4,21 +4,29 @@ module StashEngine
 
   RSpec.describe JournalRole, type: :model do
 
-    describe 'user should be able to find associated journals' do
+    before(:each) do
+      @journal = build(:journal)
+      @journal2 = build(:journal)
+      @user = build(:user)
+      @journal_role = create(:journal_role, journal: @journal, user: @user)
+      @journal_role2 = create(:journal_role, journal: @journal2, user: @user, role: 'admin')
+    end
 
-      let(:journal) { build(:journal) }
-      let(:journal2) { build(:journal) }
-      let(:user) { build(:user) }
-      let!(:journal_role) { create(:journal_role, journal: journal, user: user) }
-      let!(:journal_role2) { create(:journal_role, journal: journal2, user: user, role: 'admin') }
-
+    describe 'basic JournalRoles are supported' do
+      it 'allows scoping to just administrators' do
+        expect(JournalRole.admins.size).to eql(1)
+        expect(JournalRole.admins.first.journal).to eql(@journal2)
+      end
+    end
+    
+    describe 'users are associated with journals' do        
       it 'returns all journals associated with the user' do
-        expect(user.journals.size).to eql(2)
+        expect(@user.journals.size).to eql(2)
       end
 
       it 'returns the single journal that the user administers' do
-        expect(user.journals_as_admin.size).to eql(1)
-        expect(user.journals_as_admin.first).to eql(journal2)
+        expect(@user.journals_as_admin.size).to eql(1)
+        expect(@user.journals_as_admin.first).to eql(@journal2)
       end
 
     end

--- a/spec/models/stash_engine/journal_role_spec.rb
+++ b/spec/models/stash_engine/journal_role_spec.rb
@@ -18,8 +18,8 @@ module StashEngine
         expect(JournalRole.admins.first.journal).to eql(@journal2)
       end
     end
-    
-    describe 'users are associated with journals' do        
+
+    describe 'users are associated with journals' do
       it 'returns all journals associated with the user' do
         expect(@user.journals.size).to eql(2)
       end

--- a/spec/models/stash_engine/journal_spec.rb
+++ b/spec/models/stash_engine/journal_spec.rb
@@ -1,7 +1,7 @@
-require 'db_spec_helper'
+require 'rails_helper'
 
 module StashEngine
-  describe Journal do
+  RSpec.describe Journal, type: :model do
 
     before(:each) do
       @journal = Journal.create(issn: '1234-5678')

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -21,10 +21,8 @@ module StashEngine
 
     # See https://medium.com/rubyinside/active-records-queries-tricks-2546181a98dd for some good tricks
     # returns the identifiers that have resources with that *latest* curation state you specify (for any of the resources)
-    # These scopes needs some reworking based on changes to the resource state, leaving them commented out for now.
-    # with_visibility, ->(states:, user_id: nil, tenant_id: nil)
     scope :with_visibility, ->(states:, user_id: nil, tenant_id: nil) do
-      joins(:resources).merge(Resource.with_visibility(states: states, user_id: user_id, tenant_id: tenant_id)).distinct
+      where(id: Resource.with_visibility(states: states, user_id: user_id, tenant_id: tenant_id).select("identifier_id").distinct.map(&:identifier_id))
     end
 
     scope :publicly_viewable, -> do

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -21,8 +21,8 @@ module StashEngine
 
     # See https://medium.com/rubyinside/active-records-queries-tricks-2546181a98dd for some good tricks
     # returns the identifiers that have resources with that *latest* curation state you specify (for any of the resources)
-    scope :with_visibility, ->(states:, user_id: nil, tenant_id: nil) do
-      where(id: Resource.with_visibility(states: states, user_id: user_id, tenant_id: tenant_id)
+    scope :with_visibility, ->(states:, journal_issns: nil, user_id: nil, tenant_id: nil) do
+      where(id: Resource.with_visibility(states: states, journal_issns: journal_issns, user_id: user_id, tenant_id: tenant_id)
                         .select('identifier_id').distinct.map(&:identifier_id))
     end
 
@@ -35,10 +35,12 @@ module StashEngine
         publicly_viewable
       elsif user.superuser?
         all
-      elsif user.role == 'admin'
-        with_visibility(states: %w[published embargoed], tenant_id: user.tenant_id)
       else
-        with_visibility(states: %w[published embargoed], user_id: user.id)
+        tenant_admin = (user.tenant_id if user.role == 'admin')
+        with_visibility(states: %w[published embargoed],
+                        tenant_id: tenant_admin,
+                        journal_issns: user.journals_as_admin.map(&:issn),
+                        user_id: user.id)
       end
     end
 

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -22,7 +22,8 @@ module StashEngine
     # See https://medium.com/rubyinside/active-records-queries-tricks-2546181a98dd for some good tricks
     # returns the identifiers that have resources with that *latest* curation state you specify (for any of the resources)
     scope :with_visibility, ->(states:, user_id: nil, tenant_id: nil) do
-      where(id: Resource.with_visibility(states: states, user_id: user_id, tenant_id: tenant_id).select("identifier_id").distinct.map(&:identifier_id))
+      where(id: Resource.with_visibility(states: states, user_id: user_id, tenant_id: tenant_id)
+                        .select('identifier_id').distinct.map(&:identifier_id))
     end
 
     scope :publicly_viewable, -> do

--- a/stash/stash_engine/app/models/stash_engine/journal.rb
+++ b/stash/stash_engine/app/models/stash_engine/journal.rb
@@ -1,6 +1,8 @@
 module StashEngine
   class Journal < ActiveRecord::Base
     validates :issn, uniqueness: true
+    has_many :journal_roles
+    has_many :users, through: :journal_roles
 
     def will_pay?
       payment_plan_type == 'SUBSCRIPTION' ||

--- a/stash/stash_engine/app/models/stash_engine/journal_role.rb
+++ b/stash/stash_engine/app/models/stash_engine/journal_role.rb
@@ -1,0 +1,8 @@
+module StashEngine
+  class JournalRole < ActiveRecord::Base
+    belongs_to :journal
+    belongs_to :user
+
+    scope :admins, -> { where(role: 'admin') }
+  end
+end

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -183,13 +183,38 @@ module StashEngine
       joins(JOIN_FOR_LATEST_CURATION).where(str, *arr)
     end
 
+    JOIN_FOR_INTERNAL_DATA = "INNER JOIN stash_engine_identifiers ON stash_engine_identifiers.id = stash_engine_resources.identifier_id " \
+                       "LEFT OUTER JOIN stash_engine_internal_data ON stash_engine_internal_data.identifier_id = stash_engine_identifiers.id".freeze
+
+    scope :with_journal_visibility, ->(states:, journal_issns:nil, user_id: nil, tenant_id: nil) do
+      my_states = (states.is_a?(String) || states.is_a?(Symbol) ? [states] : states)
+      str = 'stash_engine_curation_activities.status IN (?)'
+      arr = [my_states]
+
+      if user_id
+        str += ' OR stash_engine_resources.user_id = ?'
+        arr.push(user_id)
+      end
+      if tenant_id
+        str += ' OR stash_engine_resources.tenant_id = ?'
+        arr.push(tenant_id)
+      end
+      if journal_issns.present?
+        str += " OR (stash_engine_internal_data.data_type = 'publicationISSN' AND stash_engine_internal_data.value IN (?))"
+        arr.push(journal_issns)
+      end
+      joins(JOIN_FOR_LATEST_CURATION).joins(JOIN_FOR_INTERNAL_DATA).distinct.where(str, *arr)
+    end
+    
     scope :visible_to_user, ->(user:) do
       if user.nil?
         with_visibility(states: %w[published embargoed])
       elsif user.superuser?
         all
       elsif user.role == 'admin'
-        with_visibility(states: %w[published embargoed], tenant_id: user.tenant_id)
+        with_visibility(states: %w[published embargoed], tenant_id: user.tenant_id, user_id: user.id)
+      elsif user.journals_as_admin.size > 0
+        with_journal_visibility(states: %w[published embargoed], journal_issns: user.journals_as_admin.map(&:issn), user_id: user.id)
       else
         with_visibility(states: %w[published embargoed], user_id: user.id)
       end

--- a/stash/stash_engine/app/models/stash_engine/user.rb
+++ b/stash/stash_engine/app/models/stash_engine/user.rb
@@ -33,7 +33,7 @@ module StashEngine
       role == 'superuser'
     end
 
-    def admins_journals
+    def journals_as_admin
       journals.merge(JournalRole.admins)
     end
 

--- a/stash/stash_engine/app/models/stash_engine/user.rb
+++ b/stash/stash_engine/app/models/stash_engine/user.rb
@@ -1,7 +1,10 @@
 module StashEngine
+  # rubocop:disable Metrics/ClassLength
   class User < ActiveRecord::Base
 
     has_many :resources
+    has_many :journal_roles
+    has_many :journals, through: :journal_roles
 
     def self.from_omniauth_orcid(auth_hash:, emails:)
       users = find_by_orcid_or_emails(orcid: auth_hash[:uid], emails: emails)
@@ -28,6 +31,10 @@ module StashEngine
 
     def superuser?
       role == 'superuser'
+    end
+
+    def admins_journals
+      journals.merge(JournalRole.admins)
     end
 
     NO_MIGRATE_STRING = 'xxxxxx'.freeze
@@ -139,4 +146,5 @@ module StashEngine
     end
 
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/stash/stash_engine/db/migrate/20200416174799_create_journal_roles.rb
+++ b/stash/stash_engine/db/migrate/20200416174799_create_journal_roles.rb
@@ -1,0 +1,14 @@
+class CreateJournalRoles < ActiveRecord::Migration
+  def up
+    create_table :stash_engine_journal_roles do |t|
+      t.belongs_to :journal
+      t.belongs_to :user
+      t.string :role
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :stash_engine_journal_roles
+  end
+end

--- a/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
@@ -408,11 +408,12 @@ module StashEngine
 
     describe 'self.need_publishing' do
       before(:each) do
+        @identifier = Identifier.create(identifier: 'dog/cat', identifier_type: 'DOI')
         @resources = []
         @resource_states = []
         @curation_activities = []
         0.upto(3) do
-          res = Resource.create(publication_date: Time.new - 1.day)
+          res = Resource.create(publication_date: Time.new - 1.day, identifier_id: @identifier.id)
           res.current_resource_state.update(resource_state: 'submitted')
           @curation_activities << [
             CurationActivity.create(status: 'submitted', resource_id: res.id),
@@ -426,7 +427,7 @@ module StashEngine
         @resources[2].current_resource_state.update(resource_state: 'in_progress')
       end
 
-      it 'returns only published to merritt, embargoed and out of embargo date item' do
+      it 'returns only items that have been published to merritt, curation status embargoed, and embargo date passed' do
         items = StashEngine::Resource.need_publishing
         expect(items.count).to eq(1) # only the last should be able to be changed
         expect(items.first.id).to eq(@resources[3].id) # only last one should be eligible
@@ -1208,16 +1209,17 @@ module StashEngine
           # user has only user permission and is part of the UCOP tenant
           @user2 = create(:user, first_name: 'Gargola', last_name: 'Jones', email: 'luckin@ucop.edu', tenant_id: 'ucop', role: 'admin')
           @user3 = create(:user, first_name: 'Merga', last_name: 'Flav', email: 'flavin@ucop.edu', tenant_id: 'ucb', role: 'superuser')
-          @resources = [create(:resource, user_id: @user.id, tenant_id: @user.tenant_id),
-                        create(:resource, user_id: @user.id, tenant_id: @user.tenant_id),
-                        create(:resource, user_id: @user.id, tenant_id: @user.tenant_id),
-                        create(:resource, user_id: @user2.id, tenant_id: @user2.tenant_id),
-                        create(:resource, user_id: @user2.id, tenant_id: @user2.tenant_id),
-                        create(:resource, user_id: @user2.id, tenant_id: @user2.tenant_id),
-                        create(:resource, user_id: @user3.id, tenant_id: @user3.tenant_id),
-                        create(:resource, user_id: @user3.id, tenant_id: @user3.tenant_id),
-                        create(:resource, user_id: @user3.id, tenant_id: @user3.tenant_id),
-                        create(:resource, user_id: @user3.id, tenant_id: @user3.tenant_id)]
+          @identifier = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI')
+          @resources = [create(:resource, user_id: @user.id, tenant_id: @user.tenant_id, identifier_id: @identifier.id),
+                        create(:resource, user_id: @user.id, tenant_id: @user.tenant_id, identifier_id: @identifier.id),
+                        create(:resource, user_id: @user.id, tenant_id: @user.tenant_id, identifier_id: @identifier.id),
+                        create(:resource, user_id: @user2.id, tenant_id: @user2.tenant_id, identifier_id: @identifier.id),
+                        create(:resource, user_id: @user2.id, tenant_id: @user2.tenant_id, identifier_id: @identifier.id),
+                        create(:resource, user_id: @user2.id, tenant_id: @user2.tenant_id, identifier_id: @identifier.id),
+                        create(:resource, user_id: @user3.id, tenant_id: @user3.tenant_id, identifier_id: @identifier.id),
+                        create(:resource, user_id: @user3.id, tenant_id: @user3.tenant_id, identifier_id: @identifier.id),
+                        create(:resource, user_id: @user3.id, tenant_id: @user3.tenant_id, identifier_id: @identifier.id),
+                        create(:resource, user_id: @user3.id, tenant_id: @user3.tenant_id, identifier_id: @identifier.id)]
 
           @curation_activities = [[create(:curation_activity_no_callbacks, resource: @resources[0], status: 'in_progress'),
                                    create(:curation_activity_no_callbacks, resource: @resources[0], status: 'curation'),


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/698

Add enhanced permissions to API visibility for journal administrators. 

To test: 
- Make an API user, who is not a superuser, into a journal administrator, e.g., in a console
  `StashEngine::JournalRole.new(user:u, journal:j, role:'admin').save`
- Make API calls as this user. For datasets associated with the target journal, all versions of the dataset should be visible, and the dataset itself should be visible even if it has not yet been published.