### PR TITLE
Expand journal privileges

### DIFF
--- a/stash/stash_api/app/controllers/stash_api/submission_queue_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/submission_queue_controller.rb
@@ -6,7 +6,7 @@ module StashApi
     before_action :require_json_headers
     before_action :doorkeeper_authorize!
     before_action :require_api_user
-    before_action :require_curator # curators and superusers are conflated
+    before_action :require_superuser
 
     # gets the length of items waiting to process ie, queued or held with rejected_shutting_down
     def length

--- a/stash/stash_api/app/models/stash_api/dataset.rb
+++ b/stash/stash_api/app/models/stash_api/dataset.rb
@@ -97,7 +97,8 @@ module StashApi
       res = @se_identifier.latest_resource
       curation_activity = StashEngine::CurationActivity.latest(res&.id)
       hsh[:curationStatus] = curation_activity&.readable_status
-      hsh[:sharingLink] = res&.identifier&.shares&.first&.sharing_link unless curation_activity&.withdrawn?
+      return unless %w[submitted peer_review curation action_required embargoed].include?(curation_activity.status)
+      hsh[:sharingLink] = res&.identifier&.shares&.first&.sharing_link
     end
 
   end

--- a/stash/stash_api/app/models/stash_api/dataset.rb
+++ b/stash/stash_api/app/models/stash_api/dataset.rb
@@ -97,7 +97,7 @@ module StashApi
       res = @se_identifier.latest_resource
       curation_activity = StashEngine::CurationActivity.latest(res&.id)
       hsh[:curationStatus] = curation_activity&.readable_status
-      hsh[:sharingLink] = res&.identifier&.shares&.first&.sharing_link if curation_activity&.peer_review?
+      hsh[:sharingLink] = res&.identifier&.shares&.first&.sharing_link unless curation_activity&.withdrawn?
     end
 
   end

--- a/stash/stash_engine/app/controllers/stash_engine/landing_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/landing_controller.rb
@@ -28,7 +28,7 @@ module StashEngine
       @user_type = 'public'
       res = id.resources.submitted&.by_version_desc&.first
       return res if res.nil? # no submitted resources
-      @resource = if owner?(resource: res) || superuser? || admin?(resource: res)
+      @resource = if admin?(resource: res)
                     @user_type = 'privileged'
                     id.resources.submitted.by_version_desc.first
                   else # everyone else only gets to see published or embargoed metadata latest version

--- a/stash/stash_engine/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/publication_updater_controller.rb
@@ -6,7 +6,7 @@ module StashEngine
     include SharedSecurityController
     include StashEngine::Concerns::Sortable
 
-    before_action :require_admin
+    before_action :require_superuser
     before_action :setup_paging, only: [:index]
     before_action :setup_ds_sorting, only: [:index]
 

--- a/stash/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
@@ -20,12 +20,18 @@ module StashEngine
       redirect_to stash_engine.dashboard_path
     end
 
+    def require_superuser
+      return if current_user && %w[superuser].include?(current_user.role)
+      flash[:alert] = 'You must be a superuser to view this information.'
+      redirect_to stash_engine.dashboard_path
+    end
+
     def ajax_require_curator
       return false unless current_user && %w[superuser].include?(current_user.role)
     end
 
     def require_admin
-      return if current_user && %w[admin superuser].include?(current_user.role)
+      return if current_user && (%w[admin superuser].include?(current_user.role) || current_user.journals_as_admin.present?)
       flash[:alert] = 'You must be an administrator to view this information.'
       redirect_to stash_engine.dashboard_path
     end
@@ -57,7 +63,7 @@ module StashEngine
     end
 
     def admin?(resource:)
-      current_user.present? && (current_user&.tenant_id == resource&.tenant_id && current_user&.role == 'admin')
+      resource.admin_for_this_item?(current_user)
     end
 
     def superuser?

--- a/stash/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
@@ -63,7 +63,7 @@ module StashEngine
     end
 
     def admin?(resource:)
-      resource.admin_for_this_item?(current_user)
+      resource.admin_for_this_item?(user: current_user)
     end
 
     def superuser?

--- a/stash/stash_engine/app/controllers/stash_engine/submission_queue_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/submission_queue_controller.rb
@@ -9,7 +9,7 @@ module StashEngine
     include SharedSecurityController
     # include StashEngine::Concerns::Sortable
 
-    before_action :require_admin
+    before_action :require_superuser
 
     def index
       # nothing just now

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -112,10 +112,8 @@ module StashEngine
     # these are resources that the user can look at because of permissions, some user roles can see non-published others, not
     def latest_viewable_resource(user: nil)
       return latest_resource_with_public_metadata if user.nil?
-
       lr = latest_resource
-      return lr if user.id == lr&.user_id || user.superuser? || (user.role == 'admin' && user.tenant_id == lr&.tenant_id)
-
+      return lr if lr.admin_for_this_item?(user: user)
       latest_resource_with_public_metadata
     end
 
@@ -126,7 +124,7 @@ module StashEngine
     def latest_downloadable_resource(user: nil)
       return latest_resource_with_public_download if user.nil?
       lr = resources.submitted_only.by_version_desc.first
-      return lr if user.id == lr&.user_id || user.superuser? || (user.role == 'admin' && user.tenant_id == lr&.tenant_id)
+      return lr if lr.admin_for_this_item?(user: user)
       latest_resource_with_public_download
     end
 

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -488,6 +488,7 @@ module StashEngine
     end
 
     def admin_for_this_item?(user: nil)
+      return false if user.nil?
       user.superuser? ||
         user_id == user.id ||
         (user.tenant_id == tenant_id && user.role == 'admin') ||

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -491,7 +491,10 @@ module StashEngine
     def permission_to_edit?(user:)
       return false unless user
       # superuser, dataset owner or admin for the same tenant
-      user.superuser? || user_id == user.id || (user.tenant_id == tenant_id && user.role == 'admin')
+      user.superuser? ||
+        user_id == user.id ||
+        (user.tenant_id == tenant_id && user.role == 'admin') ||
+        user.journals_as_admin.include?(identifier&.journal)
     end
 
     # Checks if someone may download files for this resource
@@ -505,7 +508,10 @@ module StashEngine
       return false unless current_resource_state&.resource_state == 'submitted' # is available in Merritt
       return true if files_published? # published and this one available for download
       return false if ui_user.blank? # the rest of the cases require users
-      return true if ui_user.id == user_id || ui_user.role == 'superuser' || (ui_user.role == 'admin' && ui_user.tenant_id == tenant_id)
+      return true if ui_user.id == user_id ||
+                     ui_user.role == 'superuser' ||
+                     (ui_user.role == 'admin' && ui_user.tenant_id == tenant_id) ||
+                     ui_user.journals_as_admin.include?(identifier&.journal)
       false # nope. Not sure if it would ever get here, though
     end
     # rubocop:enable Metrics/CyclomaticComplexity
@@ -515,7 +521,10 @@ module StashEngine
     def may_view?(ui_user: nil)
       return true if metadata_published? # anyone can view
       return false if ui_user.blank? # otherwise unknown person can't view and this prevents later nil checks
-      return true if user_id == ui_user.id || ui_user.superuser? || (ui_user.role == 'admin' && ui_user.tenant_id == tenant_id)
+      return true if user_id == ui_user.id ||
+                     ui_user.superuser? ||
+                     (ui_user.role == 'admin' && ui_user.tenant_id == tenant_id) ||
+                     ui_user.journals_as_admin.include?(identifier&.journal)
       false
     end
     # rubocop:enable Metrics/CyclomaticComplexity

--- a/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -267,6 +267,14 @@ module StashEngine
             @res3.update(tenant_id: 'localhost')
             expect(@identifier.latest_viewable_resource(user: user2)).to eql(@identifier.latest_resource_with_public_metadata)
           end
+
+          it 'returns the latest non-published for an admin from journal' do
+            user2 = User.new(role: 'user', tenant_id: 'localhost')
+            journal = Journal.create(title: 'Test Journal', issn: '1234-4321')
+            InternalDatum.create(identifier_id: @identifier.id, data_type: 'publicationISSN', value: journal.issn)
+            JournalRole.create(journal: journal, user: user2, role: 'admin')
+            expect(@identifier.latest_viewable_resource(user: user2)).to eql(@identifier.latest_resource)
+          end
         end
 
         describe '#latest_resource_with_public_download' do


### PR DESCRIPTION
Several updates associated with privileges for journal admins:
- adds the peer_review sharing link to the API for items that aren't in peer_review status, so journals and other API users can pass a download link to their end-users while an item is processing
- allows journal admins to see more content (both API and UI), similar to tenant admins
- for views, refines the distinctions between `require_admin` and `require_superuser`, since journal/tenant admins should not be able to e.g., stop the submission queue
- refactors the logic for determining visibility of a resource, so the critical code is in only one place
- adds some journal-oriented tests (there is some duplicated code in the tests, which can more easily be factored out when these tests are moved out of the engine)
