### PR TITLE
Minor change for domain name for notifier.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock '3.12.0'
+lock '3.14.0'
 
 set :application, 'dryad'
 set :repo_url, 'https://github.com/CDL-Dryad/dryad-app.git'

--- a/stash/stash-notifier/config/notifier.yml
+++ b/stash/stash-notifier/config/notifier.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   update_base_url: http://localhost:3000/stash/dataset
-  oai_base_url: http://uc3-mrtoai-stg.cdlib.org:37001/mrtoai/oai/v2
+  oai_base_url: http://mrtoai-stg.cdlib.org:37001/mrtoai/oai/v2
 
 test:
   <<: *defaults

--- a/stash/stash-notifier/spec/unit/config_spec.rb
+++ b/stash/stash-notifier/spec/unit/config_spec.rb
@@ -24,7 +24,7 @@ class ConfigSpec
       end
 
       it 'sets oai_base_url' do
-        expect(Config.oai_base_url).to be_eql('http://uc3-mrtoai-stg.cdlib.org:37001/mrtoai/oai/v2')
+        expect(Config.oai_base_url).to be_eql('http://mrtoai-stg.cdlib.org:37001/mrtoai/oai/v2')
       end
 
       it 'sets sets' do


### PR DESCRIPTION
This is a very small change to use a merritt-oai machine CNAME they can use on new machines without changing the domain every time the hardware changes (such as the linux 2 upgrade).