### PR TITLE
Journal submit for user

### DIFF
--- a/documentation/apis/submission.md
+++ b/documentation/apis/submission.md
@@ -5,9 +5,11 @@ This document gives practical information for working with the API in order to s
 
 ## Log in to Dryad and request a an application id and secret
 
-Before you can submit from the API, you need to log in to Dryad at least once to create a user record.  You may log in to your associated campus/organization or use the DataONE login with your Google login credentials.
+Before you can submit from the API, you need to log in to Dryad at
+least once to create a user record and (if applicable) associate it
+with your associated campus/organization. 
 
-To request access, please [contact us](mailto:uc3@ucop.edu). (Developers see [Adding a New API Account](README.md))
+To request access, please [contact us](mailto:help@datadryad.org). (Developers see [Adding a New API Account](README.md))
 
 ## Get a token for making requests for secure parts of the API
 Before making secure requests to the Dryad API, you'll need a token.  Currently our tokens last 10 hours and a token will need to be renewed if it expires.  You may get a token using these examples from a few programming environments.  Replace &lt;bracketed&gt; items with the values you were given.  For testing, you may choose to use a bash shell, a programming environment or a tool such as Postman.
@@ -59,7 +61,7 @@ You should see a 200 response and some information something like:
 
 ## Create a new in-progress dataset
 
-The first real step is to create a new in-progress dataset.  Currently, only minimal required DataCite metadata is supported and fuller support will be added soon.  See the example below for example metadata supported.
+The first real step is to create a new in-progress dataset. See the example below for example metadata supported.
 
 After a successful dataset POST, you should see the dataset created with your metadata, an id (DOI identifier) and a versionStatus of 'in_progress'
 
@@ -103,7 +105,7 @@ doi_encoded = URI.escape(doi)
 
 To see the dataset fields and option in use, see the [Sample Dataset Object](https://github.com/CDL-Dryad/dryad-app/blob/master/documentation/sample_dataset.json).
 
-Useful options that control a dataset's behavior:
+Superusers have access to some extra options that control a dataset's behavior:
 - `skipDataciteUpdate` - If true, doesn't send any requests to DataCite when registering the dataset. This is useful when the dataset already has a DOI, which is present in the metadata being submitted.
 - `skipEmails` - If true, prevents emails from being sent to users on submission. Prevents emails regardless of whether the submission is successful or an error. Also stopps the emails that ask co-authors to register their ORCID. Does *not* stop the internal emails that are sent to Dryad admins if there is a submission error.
 - `preserveCurationStatus` - If true, prevents Dryad from automatically setting the curation status to "submitted". This is useful when the dataset already has a curation status that will be set in a later API call.

--- a/documentation/apis/submission.md
+++ b/documentation/apis/submission.md
@@ -103,7 +103,11 @@ doi_encoded = URI.escape(doi)
 ```
 ## Dataset options
 
-To see the dataset fields and option in use, see the [Sample Dataset Object](https://github.com/CDL-Dryad/dryad-app/blob/master/documentation/sample_dataset.json).
+To see the dataset fields and options in use, see the [Sample Dataset Object](https://github.com/CDL-Dryad/dryad-app/blob/master/documentation/sample_dataset.json).
+
+Journal administrators that are creating a dataset on behalf of
+another user *must* include the `publicationISSN` field to indicate
+the associated journal. They *may* also include `publicationName` and `manuscriptNumber`.
 
 Superusers have access to some extra options that control a dataset's behavior:
 - `skipDataciteUpdate` - If true, doesn't send any requests to DataCite when registering the dataset. This is useful when the dataset already has a DOI, which is present in the metadata being submitted.

--- a/documentation/sample_dataset.json
+++ b/documentation/sample_dataset.json
@@ -9,9 +9,13 @@
 		     "identifier" : "10.1111/j.1558-5646.2007.00022.x"
 		     } ],
  "publicationISSN" : "1558-5646",
+ "publicationName" : "Evolution",
+ "manuscriptNumber" : "ABC123", 
  "authors" : [ {
-		"firstName" : "Brian",
-		"lastName" : "Sidlauskas"
+     "firstName" : "Brian",
+     "lastName" : "Sidlauskas",
+     "email" : "brian_sidlauskas@somewhere.com",
+     "orcid" : "0000-0003-0597-4085"
 		} ],
  "funders": [ {
 	       "organization": "Savannah River Operations Office, U.S. Department of Energy",

--- a/documentation/sample_dataset.json
+++ b/documentation/sample_dataset.json
@@ -8,6 +8,7 @@
 		     "identifierType" : "DOI",
 		     "identifier" : "10.1111/j.1558-5646.2007.00022.x"
 		     } ],
+ "publicationISSN" : "1558-5646",
  "authors" : [ {
 		"firstName" : "Brian",
 		"lastName" : "Sidlauskas"

--- a/spec/fixtures/stash_api/metadata.rb
+++ b/spec/fixtures/stash_api/metadata.rb
@@ -24,6 +24,10 @@ module Fixtures
         add_author
       end
 
+      def add_field(field_name:, value: nil)
+        @metadata[field_name.to_sym] = value
+      end
+
       def add_title
         @metadata.merge!(title: Faker::Book.title)
       end
@@ -34,6 +38,7 @@ module Fixtures
           { "firstName": Faker::Name.first_name,
             "lastName": Faker::Name.last_name,
             email: Faker::Internet.email,
+            orcid: "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}",
             affiliation: Faker::University.name }.with_indifferent_access
         )
       end

--- a/spec/fixtures/stash_api/metadata.rb
+++ b/spec/fixtures/stash_api/metadata.rb
@@ -38,7 +38,8 @@ module Fixtures
           { "firstName": Faker::Name.first_name,
             "lastName": Faker::Name.last_name,
             email: Faker::Internet.email,
-            orcid: "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}",
+            orcid: "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}-" \
+                   "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}",
             affiliation: Faker::University.name }.with_indifferent_access
         )
       end

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -217,10 +217,6 @@ module StashApi
         render json: { error: 'Unauthorized: only superusers and journal administrators may set a specific user' }.to_json, status: 401
         return false
       end
-      # users = StashEngine::User.where(id: params['userId'])
-      # return if users.count == 1
-      # render(json: { error: 'Bad Request: the userId you chose is invalid' }.to_json, status: 400)
-      # false
     end
 
     def check_may_set_payment_id

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -213,14 +213,14 @@ module StashApi
       return if params['userId'].nil?
       unless @user.role == 'superuser' ||
              params['userId'].to_i == @user.id || # or it is your own user
-             @user.journals_as_admin&.map(&:issn)&.include?(params['dataset']['publicationISSN'])
+             @user.journals_as_admin&.map(&:issn)&.include?(params['dataset']['publicationISSN']) # or you admin the target journal
         render json: { error: 'Unauthorized: only superusers and journal administrators may set a specific user' }.to_json, status: 401
         return false
       end
-      users = StashEngine::User.where(id: params['userId'])
-      return if users.count == 1
-      render(json: { error: 'Bad Request: the userId you chose is invalid' }.to_json, status: 400)
-      false
+      # users = StashEngine::User.where(id: params['userId'])
+      # return if users.count == 1
+      # render(json: { error: 'Bad Request: the userId you chose is invalid' }.to_json, status: 400)
+      # false
     end
 
     def check_may_set_payment_id

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -211,8 +211,10 @@ module StashApi
 
     def check_may_set_user_id
       return if params['userId'].nil?
-      unless @user.role == 'superuser' || params['userId'].to_i == @user.id # or it is your own user
-        render json: { error: 'Unauthorized: only superuser roles may set a specific user' }.to_json, status: 401
+      unless @user.role == 'superuser' ||
+             params['userId'].to_i == @user.id || # or it is your own user
+             @user.journals_as_admin&.map(&:issn)&.include?(params['dataset']['publicationISSN'])
+        render json: { error: 'Unauthorized: only superusers and journal administrators may set a specific user' }.to_json, status: 401
         return false
       end
       users = StashEngine::User.where(id: params['userId'])

--- a/stash/stash_api/app/models/stash_api/dataset.rb
+++ b/stash/stash_api/app/models/stash_api/dataset.rb
@@ -70,12 +70,13 @@ module StashApi
 
     private
 
-    # a simple identifier without any versions, shouldn't be happening but it did on dev at least
+    # a simple identifier without any versions, indicates that we created
+    # an identifier that cannot be viewed
     def simple_identifier
       {
         identifier: @se_identifier.to_s,
         id: @se_identifier.id,
-        message: 'identifier is missing required elements'
+        message: 'identifier cannot be viewed, may be missing required elements'
       }
     end
 

--- a/stash/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser.rb
@@ -48,9 +48,9 @@ module StashApi
     private
 
     def establish_owning_user_id
-      if @hash['userId']&.match(/\d{4}-\d{4}-\d{4}-\d{3,4}X?/)
+      if @hash['userId']&.to_s&.match(/\d{4}-\d{4}-\d{4}-\d{3,4}X?/)
         owning_user_id_from_orcid
-      elsif @hash['userId']&.match(/\A\d+\z/)
+      elsif @hash['userId'].to_s&.match(/\A\d+\z/)
         # If the userId is an integer, treat it as the id of an existing user
         begin
           StashEngine::User.find(@hash['userId']).id

--- a/stash/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 module StashApi
   # takes a dataset hash, parses it out and saves it to the appropriate places in the database
   class DatasetParser
@@ -23,11 +24,11 @@ module StashApi
     # this is the basic required metadata
     def parse
       clear_previous_metadata
-      user_id = @hash['userId'] || @user.id
+      owning_user_id = establish_owning_user_id
       @resource.update(
         title: @hash['title'],
-        user_id: user_id,
-        current_editor_id: user_id,
+        user_id: owning_user_id,
+        current_editor_id: owning_user_id,
         skip_datacite_update: @hash['skipDataciteUpdate'] || false,
         skip_emails: @hash['skipEmails'] || false,
         preserve_curation_status: @hash['preserveCurationStatus'] || false,
@@ -45,6 +46,41 @@ module StashApi
     end
 
     private
+
+    def establish_owning_user_id
+      if @hash['userId']&.match(/\d{4}-\d{4}-\d{4}-\d{3,4}X?/)
+        owning_user_id_from_orcid
+      elsif @hash['userId']&.match(/\A\d+\z/)
+        # If the userId is an integer, treat it as the id of an existing user
+        begin
+          StashEngine::User.find(@hash['userId']).id
+        rescue ActiveRecord::RecordNotFound
+          raise 'The userId is not known to Dryad. Please supply the id of an existing Drayd user, or an orcid matching an author of the dataset.'
+        end
+      else
+        # otherwise, give ownership to the API user
+        @user.id
+      end
+    end
+
+    def owning_user_id_from_orcid
+      # Since userId is specified as an orcid, determine whether we know this user;
+      # otherwise, create them
+      owning_user = StashEngine::User.where(orcid: @hash['userId'])&.first
+      if owning_user.nil?
+        # check if any authors listed in the dataset have this orcid
+        found_author = nil
+        @hash['authors'].each do |a|
+          found_author = a if a['orcid']&.match(@hash['userId'])
+        end
+        raise 'The userId orcid is not known to Dryad. Please supply a matching orcid in the dataset author list.' unless found_author
+        owning_user = StashEngine::User.create(orcid: @hash['userId'],
+                                               first_name: found_author['firstName'],
+                                               last_name: found_author['lastName'],
+                                               email: found_author['email'])
+      end
+      owning_user.id
+    end
 
     def parse_internal_data
       INTERNAL_DATA_FIELDS.each do |int_field|
@@ -70,7 +106,9 @@ module StashApi
     end
 
     def create_dataset(doi_string: nil)
-      # resource needs to be created early, since minting an ID is based on the resource's tenant, add identifier afterward
+      # Resource needs to be created early, since minting an ID is based on the resource's tenant, add identifier afterward
+      # The user_id is initially set to the user that made the API call, though ownership may be changed
+      # to a different user in the `parse` method based on metadata sent in the API call.
       @resource = StashEngine::Resource.create(
         user_id: @user.id, current_editor_id: @user.id, title: '', tenant_id: @user.tenant_id
       )
@@ -128,3 +166,4 @@ module StashApi
 
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/stash/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser.rb
@@ -55,7 +55,7 @@ module StashApi
         begin
           StashEngine::User.find(@hash['userId']).id
         rescue ActiveRecord::RecordNotFound
-          raise 'The userId is not known to Dryad. Please supply the id of an existing Drayd user, or an orcid matching an author of the dataset.'
+          raise 'The userId is not known to Dryad. Please supply the id of an existing Dryad user, or an orcid matching an author of the dataset.'
         end
       else
         # otherwise, give ownership to the API user

--- a/stash/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser.rb
@@ -88,7 +88,7 @@ module StashApi
         author_first_name: json_author[:firstName],
         author_last_name: json_author[:lastName],
         author_email: json_author[:email],
-        author_orcid: @previous_orcids["#{json_author[:firstName]} #{json_author[:lastName]}"],
+        author_orcid: json_author[:orcid] || @previous_orcids["#{json_author[:firstName]} #{json_author[:lastName]}"],
         resource_id: @resource.id
       )
 

--- a/stash/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
+++ b/stash/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
@@ -130,16 +130,19 @@ module StashApi
         expect(des.description_type).to eq('abstract')
       end
 
+      it 'puts the paymentId on the identifier' do
+        expect(@stash_identifier.payment_id). to eq('invoice-123')
+        expect(@stash_identifier.payment_type). to eq('stripe')
+      end
+    end
+
+    describe 'dataset ownership' do
       it 'sets the owner' do
         resource = @stash_identifier.resources.first
         expect(resource.user_id). to eq(@user2.id)
         expect(resource.current_editor_id).to eq(@user2.id)
       end
 
-      it 'puts the paymentId on the identifier' do
-        expect(@stash_identifier.payment_id). to eq('invoice-123')
-        expect(@stash_identifier.payment_type). to eq('stripe')
-      end
     end
 
     describe 'identifier handling' do

--- a/stash/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
+++ b/stash/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
@@ -46,6 +46,9 @@ module StashApi
         'abstract' =>
               'Cyberneticists agree that concurrent models are an interesting new topic in the field of machine learning.',
         'userId' => @user2.id,
+        'publicationISSN' => '0000-1111',
+        'publicationName' => 'Some Great Journal',
+        'manuscriptNumber' => 'ABC123',
         'paymentId' => 'invoice-123',
         'paymentType' => 'stripe'
       }.with_indifferent_access
@@ -130,6 +133,12 @@ module StashApi
         expect(des.description_type).to eq('abstract')
       end
 
+      it 'creates internal data for the publication metadata' do
+        expect(@stash_identifier.publication_issn).to eq('0000-1111')
+        expect(@stash_identifier.publication_name).to eq('Some Great Journal')
+        expect(@stash_identifier.manuscript_number).to eq('ABC123')
+      end
+
       it 'puts the paymentId on the identifier' do
         expect(@stash_identifier.payment_id). to eq('invoice-123')
         expect(@stash_identifier.payment_type). to eq('stripe')
@@ -139,8 +148,86 @@ module StashApi
     describe 'dataset ownership' do
       it 'sets the owner' do
         resource = @stash_identifier.resources.first
-        expect(resource.user_id). to eq(@user2.id)
+        expect(resource.user_id).to eq(@user2.id)
         expect(resource.current_editor_id).to eq(@user2.id)
+      end
+
+      it 'sets the owner to an existing user from an ORCID' do
+        test_user = StashEngine::User.create(first_name: 'Lena',
+                                             last_name: 'Jarre',
+                                             email: 'lj123@ucop.edu',
+                                             orcid: '1234-5678-0000-1111')
+        test_metadata = {
+          'title' => 'Visualizing Congestion Control Using Self-Learning Epistemologies',
+          'authors' => [{
+            'firstName' => 'Wanda',
+            'lastName' => 'Jackson',
+            'email' => 'wanda.jackson@example.com'
+          }],
+          'abstract' => 'Cyberneticists agree that concurrent models are fun.',
+          'userId' => test_user.orcid
+        }.with_indifferent_access
+
+        dp = DatasetParser.new(hash: test_metadata, id: nil, user: @user)
+        test_identifier = dp.parse
+
+        resource = test_identifier.resources.first
+        expect(resource.user_id).to eq(test_user.id)
+      end
+
+      it 'sets the owner to user specified in the metadata with an ORCID' do
+        test_orcid = '0000-1111-2222-3333'
+        test_metadata = {
+          'title' => 'Visualizing Congestion Control Using Self-Learning Epistemologies',
+          'authors' => [{
+            'firstName' => 'Wanda',
+            'lastName' => 'Jackson',
+            'email' => 'wanda.jackson@example.com',
+            'orcid' => test_orcid
+          }],
+          'abstract' => 'Cyberneticists agree that concurrent models are fun.',
+          'userId' => test_orcid
+        }.with_indifferent_access
+
+        dp = DatasetParser.new(hash: test_metadata, id: nil, user: @user)
+        test_identifier = dp.parse
+        resource = test_identifier.resources.first
+        expect(resource.user.first_name).to eq('Wanda')
+      end
+
+      it 'defaults ownership to the submitter when the userId is invalid' do
+        test_metadata = {
+          'title' => 'Visualizing Congestion Control Using Self-Learning Epistemologies',
+          'authors' => [{
+            'firstName' => 'Wanda',
+            'lastName' => 'Jackson',
+            'email' => 'wanda.jackson@example.com'
+          }],
+          'abstract' => 'Cyberneticists agree that concurrent models are fun.',
+          'userId' => 'BOGUS-junk'
+        }.with_indifferent_access
+
+        dp = DatasetParser.new(hash: test_metadata, id: nil, user: @user)
+        test_identifier = dp.parse
+        resource = test_identifier.resources.first
+        expect(resource.user).to eq(@user)
+      end
+
+      it 'errors when the userId is an ORCID, but does not match one set in the author list' do
+        test_metadata = {
+          'title' => 'Visualizing Congestion Control Using Self-Learning Epistemologies',
+          'authors' => [{
+            'firstName' => 'Wanda',
+            'lastName' => 'Jackson',
+            'email' => 'wanda.jackson@example.com',
+            'orcid' => '4444-4444-4444-4444'
+          }],
+          'abstract' => 'Cyberneticists agree that concurrent models are fun.',
+          'userId' => '5555-5555-5555-5555'
+        }.with_indifferent_access
+
+        dp = DatasetParser.new(hash: test_metadata, id: nil, user: @user)
+        expect { dp.parse }.to raise_error(RuntimeError)
       end
 
     end


### PR DESCRIPTION
Support for most of https://github.com/CDL-Dryad/dryad-product-roadmap/issues/700

- API users with a role of journal administrator can now submit content on behalf of a user. 
- The userId string in the API submission can either be the (integer) id of a User object in Dryad, or an ORCID. If it is an ORCID, it must either match an existing user in Dryad, OR a matching ORCID must be supplied with one of the authors of the dataset.
- The internal_data fields may be set via the API. (The `publicationISSN` must be present if the submitter is using their privileges as a journal administrator)

Not included in this PR, but forthcoming:
- More documentation improvements
- Better handling of author affiliations