### PR TITLE
Zenodo funding in notes

### DIFF
--- a/spec/factories/stash_datacite/contributors.rb
+++ b/spec/factories/stash_datacite/contributors.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+
+  factory :contributor, class: StashDatacite::Contributor do
+
+    resource
+
+    contributor_name    { Faker::Company.name }
+    contributor_type    { 'funder' }
+    name_identifier_id  { Faker::Pid.doi }
+    award_number        { Faker::Alphanumeric.alphanumeric(number: 8, min_alpha: 2, min_numeric: 4) }
+  end
+
+end

--- a/spec/lib/stash/zenodo_replicate/metadata_generator_spec.rb
+++ b/spec/lib/stash/zenodo_replicate/metadata_generator_spec.rb
@@ -4,6 +4,7 @@ require 'stash/zenodo_replicate'
 require 'byebug'
 require 'http'
 require 'fileutils'
+require 'cgi'
 
 require 'rails_helper'
 
@@ -87,11 +88,11 @@ module Stash
       end
 
       it 'puts funder information into notes' do
-        expect(@mg.notes).to include("Funding provided by: #{@funder1.contributor_name}")
-        expect(@mg.notes).to include("Crossref Funder Registry ID: #{@funder1.name_identifier_id}")
-        expect(@mg.notes).to include("Award Number: #{@funder1.award_number}")
-        expect(@mg.notes).to include("Funding provided by: #{@funder2.contributor_name}")
-        expect(@mg.notes).to include("Crossref Funder Registry ID: #{@funder2.name_identifier_id}")
+        expect(@mg.notes).to include(CGI.escapeHTML("Funding provided by: #{@funder1.contributor_name}"))
+        expect(@mg.notes).to include(CGI.escapeHTML("Crossref Funder Registry ID: #{@funder1.name_identifier_id}"))
+        expect(@mg.notes).to include(CGI.escapeHTML("Award Number: #{@funder1.award_number}"))
+        expect(@mg.notes).to include(CGI.escapeHTML("Funding provided by: #{@funder2.contributor_name}"))
+        expect(@mg.notes).to include(CGI.escapeHTML("Crossref Funder Registry ID: #{@funder2.name_identifier_id}"))
         expect(@mg.notes.scan(/Award Number/).count).to eq(1)
       end
 

--- a/spec/lib/stash/zenodo_replicate/metadata_generator_spec.rb
+++ b/spec/lib/stash/zenodo_replicate/metadata_generator_spec.rb
@@ -30,6 +30,9 @@ module Stash
         create(:description, description_type: 'other', resource_id: @resource.id)
         create(:description, description_type: 'methods', resource_id: @resource.id)
 
+        @funder1 = create(:contributor, resource_id: @resource.id)
+        @funder2 = create(:contributor, resource_id: @resource.id, award_number: nil)
+
         @resource.reload
 
         @mg = Stash::ZenodoReplicate::MetadataGenerator.new(resource: @resource)
@@ -80,7 +83,16 @@ module Stash
       end
 
       it 'has notes output' do
-        expect(@mg.notes).to eq(@resource.descriptions.where(description_type: 'other').first.description)
+        expect(@mg.notes).to include(@resource.descriptions.where(description_type: 'other').first.description)
+      end
+
+      it 'puts funder information into notes' do
+        expect(@mg.notes).to include("Funding provided by: #{@funder1.contributor_name}")
+        expect(@mg.notes).to include("Crossref Funder Registry ID: #{@funder1.name_identifier_id}")
+        expect(@mg.notes).to include("Award Number: #{@funder1.award_number}")
+        expect(@mg.notes).to include("Funding provided by: #{@funder2.contributor_name}")
+        expect(@mg.notes).to include("Crossref Funder Registry ID: #{@funder2.name_identifier_id}")
+        expect(@mg.notes.scan(/Award Number/).count).to eq(1)
       end
 
       it 'has related_identifiers output for itself' do

--- a/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
@@ -73,7 +73,9 @@ module Stash
       end
 
       def notes
-        @resource.descriptions.where(description_type: 'other')&.map(&:description)&.join("\n")
+        my_notes = @resource.descriptions.where(description_type: 'other')&.map(&:description)&.join("\n")
+        funder_info = @resource.contributors.where(contributor_type: 'funder').map { |contrib| funding_text(contrib) }.join("\n\n")
+        "#{my_notes}\n\n#{funder_info}".strip
       end
 
       def related_identifiers
@@ -120,6 +122,12 @@ module Stash
         return doi if Rails.env == 'production'
 
         doi.gsub(/^10\.5072/, '10.55072') # bork our datacite test dois into non-test shoulders because Zenodo reserves them as their own
+      end
+
+      def funding_text(contributor)
+        ["Funding provided by: #{contributor.contributor_name}",
+         (contributor.name_identifier_id.nil? ? nil : "Crossref Funder Registry ID: #{contributor.name_identifier_id}"),
+         (contributor.award_number.nil? ? nil : "Award Number: #{contributor.award_number}")].compact.join("\n")
       end
 
     end

--- a/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module Stash
   module ZenodoReplicate
 
@@ -74,8 +76,9 @@ module Stash
 
       def notes
         my_notes = @resource.descriptions.where(description_type: 'other')&.map(&:description)&.join("\n")
-        funder_info = @resource.contributors.where(contributor_type: 'funder').map { |contrib| funding_text(contrib) }.join("\n\n")
-        "#{my_notes}\n\n#{funder_info}".strip
+        funder_info = @resource.contributors.where(contributor_type: 'funder').map { |contrib| funding_text(contrib) }.join('</p><p>')
+        funder_info = "<p>#{funder_info}</p>" unless funder_info.blank?
+        "#{my_notes}#{funder_info}".strip
       end
 
       def related_identifiers
@@ -125,9 +128,9 @@ module Stash
       end
 
       def funding_text(contributor)
-        ["Funding provided by: #{contributor.contributor_name}",
-         (contributor.name_identifier_id.nil? ? nil : "Crossref Funder Registry ID: #{contributor.name_identifier_id}"),
-         (contributor.award_number.nil? ? nil : "Award Number: #{contributor.award_number}")].compact.join("\n")
+        ["Funding provided by: #{CGI.escapeHTML(contributor.contributor_name)}",
+         (contributor.name_identifier_id.nil? ? nil : "Crossref Funder Registry ID: #{CGI.escapeHTML(contributor.name_identifier_id)}"),
+         (contributor.award_number.nil? ? nil : "Award Number: #{CGI.escapeHTML(contributor.award_number)}")].compact.join('<br/>')
       end
 
     end


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/715 .  This adds the funding information into the output for notes.

Has tests and looks like these when submitted to Zenodo.  https://sandbox.zenodo.org/record/541797 and https://sandbox.zenodo.org/api/deposit/depositions/541797 .

