### PR TITLE
Fixes our failing dependency checks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -554,7 +554,7 @@ GEM
     passenger (6.0.4)
       rack
       rake (>= 0.8.1)
-    posix-spawn (0.3.13)
+    posix-spawn (0.3.14)
     postrank-uri (1.0.24)
       addressable (>= 2.4.0)
       nokogiri (>= 1.8.0)

--- a/stash/stash_engine/app/services/stash_engine/status_dashboard/dependency_checker_service.rb
+++ b/stash/stash_engine/app/services/stash_engine/status_dashboard/dependency_checker_service.rb
@@ -31,9 +31,15 @@ module StashEngine
       end
 
       def extract_last_log_date(log)
-        contents = File.open(log).to_a
+        contents = read_end_of_file(log)
         last_run_date = Time.parse(contents.last.match(DATE_TIME_MATCHER).to_s) unless contents.empty?
         last_run_date
+      end
+
+      def read_end_of_file(log)
+        f = File.new(log)
+        f.seek(-512, IO::SEEK_END) # to 512 bytes before end of file
+        f.read.strip.split("\n") # this reads just end of file, strips whitespace and converts to array of lines
       end
 
     end

--- a/stash/stash_engine/app/services/stash_engine/status_dashboard/oai_service.rb
+++ b/stash/stash_engine/app/services/stash_engine/status_dashboard/oai_service.rb
@@ -9,8 +9,8 @@ module StashEngine
 
       def ping_dependency
         super
-        env = Rails.env.production? ? 'prd' : 'stg'
-        target = "http://uc3-mrtoai-#{env}.cdlib.org:37001/mrtoai/state"
+        env = Rails.env.production? ? 'mrtoai.cdlib.org' : 'mrtoai-stg.cdlib.org'
+        target = "http://#{env}:37001/mrtoai/state"
         resp = HTTParty.get(target)
         online = resp.code == 200
         msg = resp.body unless online


### PR DESCRIPTION
The OAI server moved and the Notifier had blank lines at the end of the log, so the last line always being a date isn't great assumption.

if there is whitespace at the end, strip the string of all the blank space.  Also optimizes for only reading in the last 512 bytes instead of loading a possibly huge entire huge log file into memory and an array just check the last line.