### PR TITLE
Only count users created in AD times

### DIFF
--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller/stats.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller/stats.rb
@@ -3,10 +3,10 @@ module StashEngine
   class AdminDatasetsController
     class Stats
 
-      PREHISTORIC_TIME = Time.new(-60_000, 1, 1).utc
+      START_OF_AD_TIME = Time.new(0000, 1, 1).utc
 
       # leave tenant_id blank if you want stats for all
-      def initialize(tenant_id: nil, since: PREHISTORIC_TIME)
+      def initialize(tenant_id: nil, since: START_OF_AD_TIME)
         @tenant_id = tenant_id
         @since = since
       end

--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller/stats.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller/stats.rb
@@ -3,7 +3,7 @@ module StashEngine
   class AdminDatasetsController
     class Stats
 
-      START_OF_AD_TIME = Time.new(0000, 1, 1).utc
+      START_OF_AD_TIME = Time.new(0, 1, 1).utc
 
       # leave tenant_id blank if you want stats for all
       def initialize(tenant_id: nil, since: START_OF_AD_TIME)


### PR DESCRIPTION
The stats were trying to count users since 60,000BC. Which would be fine, except some MySQL installs don't like negative dates and throw an error. So this adjusts it to only count user accounts that were created in AD times.