### PR TITLE
Minor state change. Only reopen "done" states

### DIFF
--- a/stash/stash_engine/lib/stash/zenodo_replicate/deposit.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/deposit.rb
@@ -41,6 +41,7 @@ module Stash
         resp
       end
 
+      # POST /api/deposit/depositions/123/actions/edit
       def reopen_for_editing
         ZC.standard_request(:post, @links[:edit])
       end

--- a/stash/stash_engine/lib/stash/zenodo_replicate/resource.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/resource.rb
@@ -104,7 +104,7 @@ module Stash
         else
           # retrieve and open for editing
           resp = @deposit.get_by_deposition(deposition_id: @deposition_id)
-          @deposit.reopen_for_editing unless resp[:state] == 'inprogress'
+          @deposit.reopen_for_editing if resp[:state] == 'done'
         end
         resp
       end


### PR DESCRIPTION
The other two states are  "inprogress" and "unsubmitted" in the zenodo system and I don't think either of them needs to be reopened for editing.

This is a very small change that I don't believe fixes our few errors with Zenodo (they move to later steps of metadata update), but I believe is the correct logic for getting an editable dataset there.