### PR TITLE
More guards against nil errors

### DIFF
--- a/stash/stash_datacite/app/controllers/stash_datacite/contributors_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/contributors_controller.rb
@@ -52,6 +52,7 @@ module StashDatacite
 
     # GET /contributors/autocomplete?term={query_term}
     def autocomplete
+      return if params.blank?
       partial_term = params['term']
       if partial_term.blank?
         render json: nil
@@ -61,9 +62,10 @@ module StashDatacite
         response = HTTParty.get('https://api.crossref.org/funders',
                                 query: { 'query': partial_term },
                                 headers: { 'Content-Type' => 'application/json' })
+        return if response.parsed_response.blank?
+        return if response.parsed_response['message'].blank?
         result_list = response.parsed_response['message']['items']
         render json: bubble_up_exact_matches(result_list: result_list, term: partial_term)
-        # render json: response.body
       end
     end
 
@@ -92,6 +94,7 @@ module StashDatacite
       other_items = []
       match_term = term.downcase
       result_list.each do |result_item|
+        next if result_item.blank?
         name = result_item['name'].downcase
         if name.start_with?(match_term)
           matches_at_beginning << result_item

--- a/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
@@ -12,6 +12,7 @@ module StashEngine
     def check_user_agent
       # This reads a text file with one line and a regular expression in it and blocks if the user-agent matches the regexp
       agent_path = Rails.root.join('uploads', 'blacklist_agents.txt').to_s
+      return if request.user_agent.blank?
       head(429) if File.exist?(agent_path) && request.user_agent[Regexp.new(File.read(agent_path))]
     end
 


### PR DESCRIPTION
We're still getting emails about nil errors from the affiliation autocomplete and share links. Unfortunately, I haven't been able to reproduce these. This PR has a few more guards that attempt to prevent the errors.