### PR TITLE
Fix path mangling

### DIFF
--- a/stash/stash_engine/app/models/stash_engine/file_upload.rb
+++ b/stash/stash_engine/app/models/stash_engine/file_upload.rb
@@ -99,10 +99,11 @@ module StashEngine
     # reused in a few places.  If we move to a different repo this will need to change.
     #
     # If you use this method, you need to rescue the HTTP::Error and Stash::Download::Merritt errors if you don't want them raised
+    # rubocop:disable Metrics/AbcSize
     def s3_presigned_url
       raise Stash::Download::MerrittError, "Tenant not defined for resource_id: #{resource&.id}" if resource&.tenant.blank?
 
-      http = HTTP.use(:normalize_uri => {:normalizer => Stash::Download::NORMALIZER})
+      http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
         .timeout(connect: 30, read: 30).timeout(60).follow(max_hops: 2)
         .basic_auth(user: resource.tenant.repository.username, pass: resource.tenant.repository.password)
 
@@ -113,6 +114,7 @@ module StashEngine
       raise Stash::Download::MerrittError,
             "Merritt couldn't create presigned URL for #{merritt_presign_info_url}\nHttp status code: #{r.status.code}"
     end
+    # rubocop:enable Metrics/AbcSize
 
     # example
     # http://mrtexpress-stage.cdlib.org/dv/<version>/<ark>/<file pathname>

--- a/stash/stash_engine/lib/stash/download.rb
+++ b/stash/stash_engine/lib/stash/download.rb
@@ -12,15 +12,15 @@ module Stash
     # And now http.get will not mangle the URL into new characters.
     #
     # The change here from the default normalizer in http.rb is that this was the old value :path => uri.normalized_path
-    NORMALIZER = lambda do |uri|
+    NORMALIZER = ->(uri) do
       uri = HTTP::URI.parse uri
 
       HTTP::URI.new(
-          :scheme    => uri.normalized_scheme,
-          :authority => uri.normalized_authority,
-          :path      => uri.path,
-          :query     => uri.query,
-          :fragment  => uri.normalized_fragment
+        scheme: uri.normalized_scheme,
+        authority: uri.normalized_authority,
+        path: uri.path,
+        query: uri.query,
+        fragment: uri.normalized_fragment
       )
     end
   end

--- a/stash/stash_engine/lib/stash/download.rb
+++ b/stash/stash_engine/lib/stash/download.rb
@@ -1,0 +1,27 @@
+require 'http'
+
+module Stash
+  module Download
+    # Dir.glob(File.expand_path('download/*.rb', __dir__)).sort.each(&method(:require))
+
+    # this is pretty much the same as the built-in http.rb normalizer, but doesn't normalize the path because it was
+    # changing the already-set encoding which was the one that worked
+    #
+    # set up your HTTP client like
+    # http = HTTP.use(:normalize_uri => {:normalizer => Stash::Download::NORMALIZER})   -- rest of options after this
+    # And now http.get will not mangle the URL into new characters.
+    #
+    # The change here from the default normalizer in http.rb is that this was the old value :path => uri.normalized_path
+    NORMALIZER = lambda do |uri|
+      uri = HTTP::URI.parse uri
+
+      HTTP::URI.new(
+          :scheme    => uri.normalized_scheme,
+          :authority => uri.normalized_authority,
+          :path      => uri.path,
+          :query     => uri.query,
+          :fragment  => uri.normalized_fragment
+      )
+    end
+  end
+end

--- a/stash/stash_engine/lib/stash/download/base.rb
+++ b/stash/stash_engine/lib/stash/download/base.rb
@@ -38,7 +38,7 @@ module Stash
           # We don't want to hold dead download threads open too long for resource and network reasons.
 
           begin
-            http = HTTP.use(:normalize_uri => {:normalizer => Stash::Download::NORMALIZER})
+            http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
               .timeout(connect: 30, read: read_timeout).timeout(3.hours.to_i).follow(max_hops: 10)
               .basic_auth(user: tenant.repository.username, pass: tenant.repository.password)
             # .persistent(URI.join(url, '/').to_s)

--- a/stash/stash_engine/lib/stash/download/base.rb
+++ b/stash/stash_engine/lib/stash/download/base.rb
@@ -1,5 +1,6 @@
 require 'logger'
 require 'http'
+require 'stash/download'
 require 'zaru'
 require 'active_support'
 require 'tempfile'
@@ -37,7 +38,8 @@ module Stash
           # We don't want to hold dead download threads open too long for resource and network reasons.
 
           begin
-            http = HTTP.timeout(connect: 30, read: read_timeout).timeout(3.hours.to_i).follow(max_hops: 10)
+            http = HTTP.use(:normalize_uri => {:normalizer => Stash::Download::NORMALIZER})
+              .timeout(connect: 30, read: read_timeout).timeout(3.hours.to_i).follow(max_hops: 10)
               .basic_auth(user: tenant.repository.username, pass: tenant.repository.password)
             # .persistent(URI.join(url, '/').to_s)
             merritt_response = http.get(url)

--- a/stash/stash_engine/lib/stash/download/version_presigned.rb
+++ b/stash/stash_engine/lib/stash/download/version_presigned.rb
@@ -16,7 +16,7 @@ module Stash
         _ignored, @local_id = @resource.merritt_protodomain_and_local_id
         @domain = @tenant&.repository&.domain
 
-        @http = HTTP.use(:normalize_uri => {:normalizer => Stash::Download::NORMALIZER})
+        @http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
           .timeout(connect: 30, read: 30).timeout(30.seconds.to_i).follow(max_hops: 3)
           .basic_auth(user: @tenant&.repository&.username, pass: @tenant&.repository&.password)
       end

--- a/stash/stash_engine/lib/stash/download/version_presigned.rb
+++ b/stash/stash_engine/lib/stash/download/version_presigned.rb
@@ -1,6 +1,7 @@
 require 'http'
 require 'byebug'
 require 'zaru'
+require 'stash/download'
 
 module Stash
   module Download
@@ -15,7 +16,8 @@ module Stash
         _ignored, @local_id = @resource.merritt_protodomain_and_local_id
         @domain = @tenant&.repository&.domain
 
-        @http = HTTP.timeout(connect: 30, read: 30).timeout(30.seconds.to_i).follow(max_hops: 3)
+        @http = HTTP.use(:normalize_uri => {:normalizer => Stash::Download::NORMALIZER})
+          .timeout(connect: 30, read: 30).timeout(30.seconds.to_i).follow(max_hops: 3)
           .basic_auth(user: @tenant&.repository&.username, pass: @tenant&.repository&.password)
       end
 

--- a/stash/stash_engine/lib/stash/merritt_download/file.rb
+++ b/stash/stash_engine/lib/stash/merritt_download/file.rb
@@ -4,6 +4,7 @@ require 'http'
 require 'byebug'
 require 'digest'
 require 'fileutils'
+require 'stash/download'
 
 module Stash
   module MerrittDownload
@@ -49,7 +50,8 @@ module Stash
 
       # gets the file url and returns an HTTP.get(url) response object
       def get_url(url:, read_timeout: 30)
-        http = HTTP.timeout(connect: 30, read: read_timeout).timeout(6.hours.to_i).follow(max_hops: 10)
+        http = HTTP.use(:normalize_uri => {:normalizer => Stash::Download::NORMALIZER})
+          .timeout(connect: 30, read: read_timeout).timeout(6.hours.to_i).follow(max_hops: 10)
         http.get(url)
       end
 

--- a/stash/stash_engine/lib/stash/merritt_download/file.rb
+++ b/stash/stash_engine/lib/stash/merritt_download/file.rb
@@ -50,7 +50,7 @@ module Stash
 
       # gets the file url and returns an HTTP.get(url) response object
       def get_url(url:, read_timeout: 30)
-        http = HTTP.use(:normalize_uri => {:normalizer => Stash::Download::NORMALIZER})
+        http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
           .timeout(connect: 30, read: read_timeout).timeout(6.hours.to_i).follow(max_hops: 10)
         http.get(url)
       end

--- a/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -1,5 +1,6 @@
 require 'http'
 require 'byebug'
+require 'stash/download'
 
 module Stash
   module ZenodoReplicate
@@ -19,7 +20,8 @@ module Stash
       # rubocop:disable Metrics/AbcSize
       def self.standard_request(method, url, **args)
         resp = nil
-        http = HTTP.timeout(connect: 30, read: 60).timeout(6.hours.to_i).follow(max_hops: 10)
+        http = HTTP.use(:normalize_uri => {:normalizer => Stash::Download::NORMALIZER})
+          .timeout(connect: 30, read: 60).timeout(6.hours.to_i).follow(max_hops: 10)
 
         my_params = { access_token: APP_CONFIG[:zenodo][:access_token] }.merge(args.fetch(:params, {}))
         my_headers = { 'Content-Type': 'application/json' }.merge(args.fetch(:headers, {}))

--- a/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -20,7 +20,7 @@ module Stash
       # rubocop:disable Metrics/AbcSize
       def self.standard_request(method, url, **args)
         resp = nil
-        http = HTTP.use(:normalize_uri => {:normalizer => Stash::Download::NORMALIZER})
+        http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
           .timeout(connect: 30, read: 60).timeout(6.hours.to_i).follow(max_hops: 10)
 
         my_params = { access_token: APP_CONFIG[:zenodo][:access_token] }.merge(args.fetch(:params, {}))


### PR DESCRIPTION
This prevents http.rb from normalizing the paths in URLs by setting the normalizer.  The one in here is pretty much the same as the one built into the http.rb code but instead of changing the path it just uses the one that the user put in. `uri.path` instead of `uri.normalized_path` or something like that.

*Yes, I really wanted that path in the URL and I didn't want you to screw with it, http.rb*

I had to dig through code to find the option since I didn't really see it documented anywhere.