### PR TITLE
To fix the text/html errors

### DIFF
--- a/spec/factories/stash_datacite/related_identifiers.rb
+++ b/spec/factories/stash_datacite/related_identifiers.rb
@@ -7,10 +7,9 @@ FactoryBot.define do
     related_identifier      { Faker::Number.number(digits: 8) }
     related_identifier_type { %w[doi ean13 eissn handle isbn issn istc lissn lsid pmid purl upc url urn].sample }
     relation_type           do
-      %w[iscitedby cites issupplementto issupplementedby iscontinuedby continues isnewversionof
-         ispreviousversionof ispartof haspart isreferencedby references isdocumentedby documents
-         iscompiledby compiles isvariantformof isorginalformof isidenticalto hasmetadata ismetadatafor
-         reviews isreviewedby isderivedfrom issourceof].sample
+      %w[iscitedby cites issupplementto issupplementedby iscontinuedby continues isnewversionof ispreviousversionof ispartof
+         haspart isreferencedby references isdocumentedby documents iscompiledby compiles isvariantformof isoriginalformof
+         isidenticalto hasmetadata ismetadatafor reviews isreviewedby isderivedfrom issourceof].sample
     end
 
     trait :publication_doi do

--- a/spec/lib/stash_datacite/indexing_resource_spec.rb
+++ b/spec/lib/stash_datacite/indexing_resource_spec.rb
@@ -140,7 +140,7 @@ module Stash
 
       describe '#issued_date' do
         it 'returns a correct issued date' do
-          expect(@ir.issued_date[0..9]).to eql(Time.now.strftime('%Y-%m-%d'))
+          expect(@ir.issued_date[0..9]).to eql(Time.now.utc.strftime('%Y-%m-%d'))
         end
       end
 

--- a/stash/stash_engine/lib/stash/download/version_presigned.rb
+++ b/stash/stash_engine/lib/stash/download/version_presigned.rb
@@ -6,7 +6,7 @@ require 'stash/download'
 module Stash
   module Download
 
-    class MerrittException < Exception; end
+    class MerrittException < RuntimeError; end
 
     class VersionPresigned
 

--- a/stash/stash_engine/lib/stash/download/version_presigned.rb
+++ b/stash/stash_engine/lib/stash/download/version_presigned.rb
@@ -6,7 +6,7 @@ require 'stash/download'
 module Stash
   module Download
 
-    class MerrittException < RuntimeError; end
+    class MerrittException < Exception; end
 
     class VersionPresigned
 


### PR DESCRIPTION
Merritt is returning text/html instead of json sometimes through the API requests.  IDK what type of errors.  This converts it to a standard 404 status for API use and also raises exceptions for 500 internal server errors from Merritt since we probably would like to know if Merritt is flakey.

Also added a couple of testing fixes from some tests that got moved over.  Compare times in UTC and also only generate factories for the datacite metadata we support in our database through the enum (because otherwise it causes test errors).

