### PR TITLE
No longer disallow DataONE individual file downloads.

### DIFF
--- a/stash/stash_engine/app/views/stash_engine/landing/_sidebar.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/landing/_sidebar.html.erb
@@ -6,13 +6,10 @@
   <%= button_to "Download Data Publication (PDF)", data_paper_path(params[:id]), class: 'o-download__docs', method: 'get' %>
 </div>
 
-<% # don't show the files to download at all for DataONE--not working in Merritt, they just need to download the full dataset version %>
-<% unless resource.tenant_id == 'dataone' %>
-  <% if may_download %>
-    <%= render partial: 'stash_engine/landing/files', locals: {dataset_identifier: @id, resource: @resource} %>
-  <% else %>
-    <%= render partial: 'stash_engine/landing/files_embargoed', locals: {resource: @resource} %>
-  <% end %>
+<% if may_download %>
+  <%= render partial: 'stash_engine/landing/files', locals: {dataset_identifier: @id, resource: @resource} %>
+<% else %>
+  <%= render partial: 'stash_engine/landing/files_embargoed', locals: {resource: @resource} %>
 <% end %>
 
 <div class="c-sidebox">


### PR DESCRIPTION
This removes the file download block for DataONE.