### PR TITLE
ROR affiliation updates

### DIFF
--- a/lib/tasks/affiliation_import.rake
+++ b/lib/tasks/affiliation_import.rake
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+require 'csv'
+
+namespace :affiliation_import do
+
+  ROOT = Rails.root.join('tmp', 'Results').freeze
+
+  desc 'Process all of the TSV files'
+  task process_ror_tsv: :environment do
+    start_time = Time.now
+    p "Loading Journal, Author and Affiliation info from TSV files in tmp/Results"
+
+    crosswalk = CSV.read("#{ROOT}/Crosswalk.csv", headers: true)
+
+    entries = []
+    dois_to_skip = []
+    Dir.entries(ROOT).each do |f|
+      next unless f.end_with?('.tsv')
+
+      qualified_file_name = "#{ROOT}/#{f}"
+      entries += read_tsv_file(file_name: qualified_file_name).select do |row|
+        row['selected']&.downcase == 'true' && row['tokenIndex'] == '1'
+      end
+    end
+    p "Found #{entries.length} entries to process."
+
+    curr_doi = ''
+    entries.map do |entry|
+      next if dois_to_skip.include?(entry['DOI'])
+      matched = crosswalk.select { |cw| cw['ArticleDOI']&.gsub('doi:', '') == entry['DOI']&.gsub('doi:', '') }.first
+      next unless entry['DOI'].present? && matched.present?
+
+      identifier = StashEngine::Identifier.where("stash_engine_identifiers.identifier like ?", "%#{matched['PackageDOI'].gsub('doi:', '')}").first
+      dois_to_skip << entry['DOI'] unless identifier.present?
+      p "****** NO MATCH FOR: (#{entry['DOI']}) #{entry['title']}" unless identifier.present?
+      next unless identifier.present?
+
+      p "Matched: #{entry['title']} -- Journal DOI: #{entry['DOI']} => Dataset DOI: #{identifier.to_s}" unless curr_doi == entry['DOI']
+      curr_doi = entry['DOI']
+      handle_journal_name(identifier: identifier, hash: entry)
+      handle_journal_doi(identifier: identifier, hash: entry)
+
+      next unless identifier.latest_resource.present?
+      handle_author(resource: identifier.latest_resource, hash: entry)
+    end
+    p "DONE! Elapsed time: #{(Time.now - start_time).strftime('%H:%M:%S')}"
+  end
+
+  def handle_author(resource:, hash:)
+    return nil unless resource.present? && hash['family'].present?
+    author = StashEngine::Author.where('stash_engine_authors.resource_id = ? AND LOWER(stash_engine_authors.author_last_name) = ? AND LOWER(stash_engine_authors.author_first_name) = ?',
+      resource.id, hash['family'], hash['given']).first
+    author = StashEngine::Author.new(resource_id: resource.id, author_last_name: hash['family'], author_first_name: hash['given']) unless author.present?
+    p "    Assigning author: #{author.author_last_name}, #{author.author_first_name}"
+    author.save
+    handle_affiliation(author: author, hash: hash)
+  end
+
+  def handle_affiliation(author:, hash:)
+    return nil unless author.present? && hash['organizationLookupName'].present?
+    affiliation = StashDatacite::Affiliation.where('dcs_affiliations.ror_id = ? OR dcs_affiliations.long_name = ?',
+      hash['ROR'], hash['organizationLookupName']).first
+    affiliation = StashDatacite::Affiliation.find_or_initialize_by(long_name: hash['organizationLookupName'], ror_id: hash['ROR'])
+    p "    Assigning affiliation: #{affiliation.long_name} --> #{affiliation.ror_id}"
+    affiliation.authors << author
+    affiliation.save
+  end
+
+  def handle_journal_name(identifier:, hash:)
+    return nil unless identifier.present? && hash['journal'].present?
+    datum = StashEngine::InternalDatum.find_or_initialize_by(identifier_id: identifier.id, data_type: 'publicationName')
+    datum.value = hash['journal']
+    p "    Assigning Journal: '#{datum.value}'" if datum.value&.include?('�')
+    datum.save
+  end
+
+  def handle_journal_doi(identifier:, hash:)
+    return nil unless identifier.present? && hash['DOI'].present?
+    datum = StashEngine::InternalDatum.find_or_initialize_by(identifier_id: identifier.id, data_type: 'publicationDOI')
+    datum.value = hash['DOI']
+    p "    Assigning Journal DOI: '#{datum.value}'"
+    datum.save if hash['DOI']
+  end
+
+  def read_tsv_file(file_name:)
+    params = {
+      col_sep: "\t",
+      headers: true,
+      encoding: "utf-8"
+    }
+    return nil unless File.exists?(file_name)
+    CSV.read(file_name, params.merge({ quote_char: '^' }))
+
+  rescue CSV::MalformedCSVError
+    begin
+      CSV.read(file_name, params.merge({ quote_char: '|' }))
+
+    rescue CSV::MalformedCSVError
+      begin
+        CSV.read(file_name, params.merge({ quote_char: '~' }))
+
+      rescue CSV::MalformedCSVError
+        CSV.read(file_name, params.merge({ quote_char: '@' }))
+      end
+    end
+  end
+
+end

--- a/lib/tasks/affiliation_import.rake
+++ b/lib/tasks/affiliation_import.rake
@@ -4,6 +4,8 @@ require 'csv'
 # rubocop:disable Metrics/CyclomaticComplexity
 # rubocop:disable Metrics/MethodLength
 # rubocop:disable Lint/UselessAssignment
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/PerceivedComplexity
 namespace :affiliation_import do
 
   ROOT = Rails.root.join('/tmp').freeze
@@ -126,3 +128,5 @@ end
 # rubocop:enable Metrics/CyclomaticComplexity
 # rubocop:enable Metrics/MethodLength
 # rubocop:enable Lint/UselessAssignment
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/PerceivedComplexity

--- a/lib/tasks/affiliation_import.rake
+++ b/lib/tasks/affiliation_import.rake
@@ -79,7 +79,7 @@ namespace :affiliation_import do
     end
 
     if author.blank?
-      puts "    WARNING! AUTHOR NOT FOUND!! #{author.author_last_name}, #{author.author_first_name}"
+      puts "    WARNING! AUTHOR NOT FOUND!! #{last}, #{first}"
       if @live_mode
         # author = StashEngine::Author.new(resource_id: resource.id, author_last_name: last, author_first_name: first)
         # author.save
@@ -93,6 +93,11 @@ namespace :affiliation_import do
 
     if author.affiliations.present? && author.affiliations.size > 1
       puts "    WARNING! Skipping author with multiple affiliations. author_id=#{author.id}"
+      return
+    end
+
+    if author.resource.blank? || author.resource.publication_date.blank?
+      puts "    WARNING! Skipping author with blank publication date. author_id=#{author.id}"
       return
     end
 

--- a/lib/tasks/affiliation_import.rake
+++ b/lib/tasks/affiliation_import.rake
@@ -63,7 +63,7 @@ namespace :affiliation_import do
     parts = name.split(' ')
     first = parts[0]
     last = parts[1..-1].join(' ')
-    puts "searching authors for resource #{resource.id}, first[#{first}], last[#{last}]"
+    puts "  searching authors for resource #{resource.id}, first[#{first}], last[#{last}]"
     author = StashEngine::Author.where('stash_engine_authors.resource_id = ? ' \
                                        'AND LOWER(stash_engine_authors.author_last_name) = ? ' \
                                        'AND LOWER(stash_engine_authors.author_first_name) = ?', resource.id, last, first).first
@@ -72,14 +72,14 @@ namespace :affiliation_import do
       # try split at second space, see if we find an author that way
       first = parts[0..1].join(' ')
       last = parts[2..-1].join(' ')
-      puts "searching authors for resource #{resource.id}, first[#{first}], last[#{last}]"
+      puts "  searching authors for resource #{resource.id}, first[#{first}], last[#{last}]"
       author = StashEngine::Author.where('stash_engine_authors.resource_id = ? ' \
                                          'AND LOWER(stash_engine_authors.author_last_name) = ? ' \
                                          'AND LOWER(stash_engine_authors.author_first_name) = ?', resource.id, last, first).first
     end
 
     if author.blank?
-      puts "  WARNING! AUTHOR NOT FOUND!! #{author.author_last_name}, #{author.author_first_name}"
+      puts "    WARNING! AUTHOR NOT FOUND!! #{author.author_last_name}, #{author.author_first_name}"
       if @live_mode
         # author = StashEngine::Author.new(resource_id: resource.id, author_last_name: last, author_first_name: first)
         # author.save
@@ -92,7 +92,7 @@ namespace :affiliation_import do
     return nil unless author.present? && org_name.present?
 
     if author.affiliations.present? && author.affiliations.size > 1
-      puts "   WARNING! Skipping author with multiple affiliations. author_id=#{author.id}"
+      puts "    WARNING! Skipping author with multiple affiliations. author_id=#{author.id}"
       return
     end
 
@@ -103,7 +103,7 @@ namespace :affiliation_import do
     end
 
     if author.affiliations.present? && ror.blank?
-      puts "   WARNING! Author already has affiliation, and input file has no ROR. author_id=#{author.id}"
+      puts "    WARNING! Author already has affiliation, and input file has no ROR. author_id=#{author.id}"
       return
     end
 

--- a/lib/tasks/affiliation_import.rake
+++ b/lib/tasks/affiliation_import.rake
@@ -1,8 +1,9 @@
-# -*- coding: utf-8 -*-
 require 'csv'
 
-
-
+# rubocop:disable Metrics/BlockLength
+# rubocop:disable Metrics/CyclomaticComplexity
+# rubocop:disable Metrics/MethodLength
+# rubocop:disable Lint/UselessAssignment
 namespace :affiliation_import do
 
   ROOT = Rails.root.join('/tmp').freeze
@@ -22,9 +23,9 @@ namespace :affiliation_import do
     else
       puts "Environment variable AFFILIATION_MODE is #{ENV['AFFILIATION_MODE']}, entering test mode."
     end
-    
+
     puts 'Loading affiliation info from CSV files in /tmp/dryad_affiliations*'
-    
+
     Dir.entries(ROOT).each do |f|
       next unless f.start_with?('dryad_affiliations')
       qualified_file_name = "#{ROOT}/#{f}"
@@ -32,17 +33,17 @@ namespace :affiliation_import do
       process_file(file_name: qualified_file_name)
     end
 
-    puts "DONE! Elapsed time: #{Time.at(Time.now - start_time).utc.strftime("%H:%M:%S")}"
+    puts "DONE! Elapsed time: #{Time.at(Time.now - start_time).utc.strftime('%H:%M:%S')}"
   end
 
   def process_file(file_name:)
     CSV.foreach(file_name) do |entry|
-      #puts "<< #{entry} >>"
+      # puts "<< #{entry} >>"
       next if entry[0] == 'DOI' && entry[1] == 'person' # header row
 
       doi, person, organization, ror_original, ror, identifier_date, supplement_to, \
       publication_date, title, type, update_date, organization_date = entry
-      
+
       next if @dois_to_skip.include?(doi)
       next unless doi.present?
       identifier = StashEngine::Identifier.where(identifier: doi).first
@@ -50,57 +51,73 @@ namespace :affiliation_import do
       puts "****** NO DATASET FOUND WITH ID: #{doi} -- #{title}" unless identifier.present?
       next unless identifier.present?
       next unless identifier.latest_resource.present?
-      puts "Processing #{identifier.to_s} #{title}"
+      puts "Processing #{identifier} #{title}"
       handle_author(resource: identifier.latest_resource, name: person, ror: ror, org_name: organization)
     end
   end
 
   def handle_author(resource:, name:, ror:, org_name:)
     return nil unless resource.present? && name.present?
-    
+
     # start with the assuption that the firstname lastname split is at the first space
     parts = name.split(' ')
     first = parts[0]
     last = parts[1..-1].join(' ')
     puts "searching authors for resource #{resource.id}, first[#{first}], last[#{last}]"
-    author = StashEngine::Author.where('stash_engine_authors.resource_id = ? AND LOWER(stash_engine_authors.author_last_name) = ? AND LOWER(stash_engine_authors.author_first_name) = ?', resource.id, last, first).first
+    author = StashEngine::Author.where('stash_engine_authors.resource_id = ? ' \
+                                       'AND LOWER(stash_engine_authors.author_last_name) = ? ' \
+                                       'AND LOWER(stash_engine_authors.author_first_name) = ?', resource.id, last, first).first
 
     if author.nil? && parts.size > 2
       # try split at second space, see if we find an author that way
       first = parts[0..1].join(' ')
       last = parts[2..-1].join(' ')
       puts "searching authors for resource #{resource.id}, first[#{first}], last[#{last}]"
-      author = StashEngine::Author.where('stash_engine_authors.resource_id = ? AND LOWER(stash_engine_authors.author_last_name) = ? AND LOWER(stash_engine_authors.author_first_name) = ?', resource.id, last, first).first
+      author = StashEngine::Author.where('stash_engine_authors.resource_id = ? ' \
+                                         'AND LOWER(stash_engine_authors.author_last_name) = ? ' \
+                                         'AND LOWER(stash_engine_authors.author_first_name) = ?', resource.id, last, first).first
     end
-    
+
     if author.blank?
-      puts "    Creating new author: #{author.author_last_name}, #{author.author_first_name}"
+      puts "  WARNING! AUTHOR NOT FOUND!! #{author.author_last_name}, #{author.author_first_name}"
       if @live_mode
-        author = StashEngine::Author.new(resource_id: resource.id, author_last_name: last, author_first_name: first)
-        author.save
+        # author = StashEngine::Author.new(resource_id: resource.id, author_last_name: last, author_first_name: first)
+        # author.save
       end
     end
     handle_affiliation(author: author, ror: ror, org_name: org_name)
   end
 
   def handle_affiliation(author:, ror:, org_name:)
-    # what does brian's code do?
-    # - find an existing affiliation (twice?)
-    # - add it to the author
-    # what do I want my code to do?
-    # - If there is a difference between the ror and the existing item
-    #   ROR, and the item is pre-launch, update it
-    # - If there is no ror in the item, add it (either by ror or by the long_name)
-
     return nil unless author.present? && org_name.present?
-    affiliation = StashDatacite::Affiliation.where('dcs_affiliations.ror_id = ? OR dcs_affiliations.long_name = ?',
-      ror, org_name).first
 
-    puts "    Assigning affiliation: #{affiliation.long_name} --> #{affiliation.ror_id}"
-    if @live_mode
-      affiliation = StashDatacite::Affiliation.find_or_initialize_by(long_name: org_name, ror_id: ror)
-      affiliation.authors << author
-      affiliation.save
+    if author.affiliations.present? && author.affiliations.size > 1
+      puts "   WARNING! Skipping author with multiple affiliations. author_id=#{author.id}"
+      return
     end
+
+    dryad_v2_launch_date = Date.parse('2019-9-17')
+    if author.resource.publication_date >= dryad_v2_launch_date
+      puts "    skipping post-lauch item; assuming its affiliations are correct resource_id=#{author.resource}"
+      return
+    end
+
+    if author.affiliations.present? && ror.blank?
+      puts "   WARNING! Author already has affiliation, and input file has no ROR. author_id=#{author.id}"
+      return
+    end
+
+    # If we have gotten through all of the above checks, we can safely replace any
+    # existing affiliation with a "better" affiliation from the input file
+    target_affiliation = StashDatacite::Affiliation.find_or_initialize_by(long_name: org_name, ror_id: ror)
+    puts "    Assigning affiliation: #{target_affiliation.long_name} --> #{target_affiliation.ror_id}"
+
+    return unless @live_mode
+    author.affiliation = target_affiliation
+    author.save
   end
 end
+# rubocop:enable Metrics/BlockLength
+# rubocop:enable Metrics/CyclomaticComplexity
+# rubocop:enable Metrics/MethodLength
+# rubocop:enable Lint/UselessAssignment


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/753

These are one-off scripts that will likely only be used once on the production server, but they are saved here for future reference. Since they are only intended to be run once, they are somewhat messy, with a large amount of text to stdout, and no explicit testing framework. 

These scripts include:
- clean_ror_names -- Reset the `long_name` of each affiliation in the database to match the name we receive from the ROR API. This normally is not necessary, but I'm leaving this script in place in case we need it in the future.
- detect_duplicate_authors -- Analyzes all datasets in the database to detect instances where a resource has duplicate author entries. This does not make changes to the database; it will be expanded in the future.
- process_ror_csv -- The main script for updating affiliations. Requires an input file with a specific format. Since this was the subject of a large amount of testing before being run on an actual database, it uses an environment variable (`AFFILIATION_MODE`) to determine whether it is allowed to make database changes.