### PR TITLE
Update duplicate detection to actually merge duplicates

### DIFF
--- a/lib/tasks/affiliation_import.rake
+++ b/lib/tasks/affiliation_import.rake
@@ -78,7 +78,7 @@ namespace :affiliation_import do
                "#{levenshtein_distance(autha, authb).to_f / (autha.size > authb.size ? autha.size : authb.size)}")
           if @live_mode
             do_author_merge(authors[a], authors[b])
-            record_author_merge(resource: a.resource)
+            record_author_merge(resource: i.latest_resource)
           end
         end
       end


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/763

Some improvements to the algorithm for detecting duplicate authors, and additions to perform the merge. 

The new duplicate-matching algorithm is based on detecting names where the corresponding pieces are the same, except that one or more portions of the name have been replaced by initials, or initials have been omitted (e.g., "Mary Sue" -> "M Sue", or "P. G. Wodehouse" -> "P Wodehouse")

After testing on the stage database, I determined that I couldn't completely remove the Levenshtein distance. Due to the need to accommodate the addition/deletion of initials, authors who have the same initial for their first and last names (e.g., "Joe Jones") were matching too many other names (e.g., "Joe Jonas" would match "J. Robinson"). So there is an extra check that when the Levenshtein distance is too high, all of the initials in the name need to match.

To test this, it is easiest to manually create some authors that are duplicates. 