### PR TITLE
minor tweaks for google

### DIFF
--- a/spec/data/example.json
+++ b/spec/data/example.json
@@ -1,9 +1,10 @@
 {
+  "@id": "https://doi.org/10.15146/R3RG6G",
   "@context": "http://schema.org",
   "@type": "dataset",
   "name": "A Zebrafish Model for Studies on Esophageal Epithelial Biology",
   "description": "Mammalian esophagus exhibits a remarkable change in epithelial structure\n      during the transition from embryo to adult. However, the molecular\n      mechanisms of esophageal epithelial development are not well understood.\n      Zebrafish (Danio rerio), a common model organism for vertebrate\n      development and gene function, has not previously been characterized as a\n      model system for esophageal epithelial development. In this study, we\n      characterized a piece of non-keratinized stratified squamous epithelium\n      similar to human esophageal epithelium in the upper digestive tract of\n      developing zebrafish. Under the microscope, this piece was detectable at\n      5dpf and became stratified at 7dpf. Expression of esophageal epithelial\n      marker genes (Krt5, P63, Sox2 and Pax9) was detected by\n      immunohistochemistry and in situ hybridization. Knockdown of P63, a gene\n      known to be critical for esophageal epithelium, disrupted the development\n      of this epithelium. With this model system, we found that Pax9 knockdown\n      resulted in loss or disorganization of the squamous epithelium, as well as\n      down-regulation of the differentiation markers Krt4 and Krt5. In summary,\n      we characterized a region of stratified squamous epithelium in the\n      zebrafish upper digestive tract which can be used for functional studies\n      of candidate genes involved in esophageal epithelial biology.",
-  "url": "https://doi.org/10.15146/R3RG6G",
+  "url": "http://localhost:3000/stash/dataset/doi%253A10.15146%252FR3RG6G",
   "identifier": "https://doi.org/10.15146/R3RG6G",
   "version": 1,
   "keywords": [

--- a/stash/stash_datacite/app/models/stash_datacite/resource/schema_dataset.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/schema_dataset.rb
@@ -10,10 +10,11 @@ module StashDatacite
     # https://schema.org/Dataset
     class SchemaDataset # rubocop:disable Metrics/ClassLength
       ITEMS_TO_ADD = {
+        '@id' => :doi_url,
         'name' => :names,
         'description' => :descriptions,
-        'url' => :url,
-        'identifier' => :url,
+        'url' => :landing_url,
+        'identifier' => :doi_url,
         'version' => :version,
         'keywords' => :keywords,
         'creator' => :authors,
@@ -58,8 +59,12 @@ module StashDatacite
         @resource.descriptions.map(&:description).compact
       end
 
-      # google says URLs of the Location of a page describing the dataset
-      def url
+      def landing_url
+        target_id = CGI.escape(@resource.identifier&.to_s)
+        StashEngine::Engine.routes.url_helpers.show_url(target_id)
+      end
+
+      def doi_url
         "https://doi.org/#{@resource.try(:identifier).try(:identifier)}"
       end
 

--- a/stash/stash_engine/app/views/stash_engine/landing/show.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/landing/show.html.erb
@@ -1,3 +1,4 @@
+<% @page_title = "Data -- #{@resource.title}" %>
 <div class="c-columns">
 	<main class="t-landing__main c-columns__content">
 		<% if @user_type == 'privileged' %>


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/767

A few minor updates to make landing pages more palatable to Google:
- improve the <title> tag on landing pages
- change schema.org 'url' field to be direct link to our page instead of DOI
- add @id as the DOI