### PR TITLE
Notifier dependency checking

### DIFF
--- a/documentation/external_services/README.md
+++ b/documentation/external_services/README.md
@@ -2,3 +2,12 @@ External Services
 ===================
 
 Notes and cheet sheets for services that are used by Dryad developers.
+
+
+Status Dashboard
+----------------
+
+The status of both internal and external services are monitored
+through the Status Dashboard. The primary monitoring process runs
+through the rake task `status_dashboard:check`, which calls the
+service-checking code in `stash/stash_engine/app/services/stash_engine/status_dashboard/`

--- a/stash/stash-notifier/app/dryad_notifier.rb
+++ b/stash/stash-notifier/app/dryad_notifier.rb
@@ -8,6 +8,7 @@ class DryadNotifier
     @version = version
   end
 
+  # rubocop:disable Metrics/MethodLength
   def notify
     client = HTTPClient.new
     url = "#{Config.update_base_url}/doi:#{@doi}"
@@ -26,10 +27,15 @@ class DryadNotifier
       return false
     end
     if resp.status_code != 204
-      Config.logger.error("PATCH to #{url} (merritt_id: #{@merritt_id}) returned a status code of #{resp.status_code}")
-      return false
+      if Rails.env == 'production'
+        Config.logger.error("PATCH to #{url} (merritt_id: #{@merritt_id}) returned a status code of #{resp.status_code}")
+        return false
+      else
+        Config.logger.warn("PATCH to #{url} (merritt_id: #{@merritt_id}) returned a status code of #{resp.status_code}")
+      end
     end
     true
   end
+  # rubocop:enable Metrics/MethodLength
 
 end

--- a/stash/stash-notifier/app/dryad_notifier.rb
+++ b/stash/stash-notifier/app/dryad_notifier.rb
@@ -8,7 +8,6 @@ class DryadNotifier
     @version = version
   end
 
-  # rubocop:disable Metrics/MethodLength
   def notify
     client = HTTPClient.new
     url = "#{Config.update_base_url}/doi:#{@doi}"
@@ -27,15 +26,10 @@ class DryadNotifier
       return false
     end
     if resp.status_code != 204
-      if Rails.env == 'production'
-        Config.logger.error("PATCH to #{url} (merritt_id: #{@merritt_id}) returned a status code of #{resp.status_code}")
-        return false
-      else
-        Config.logger.warn("PATCH to #{url} (merritt_id: #{@merritt_id}) returned a status code of #{resp.status_code}")
-      end
+      Config.logger.error("PATCH to #{url} (merritt_id: #{@merritt_id}) returned a status code of #{resp.status_code}")
+      return false
     end
     true
   end
-  # rubocop:enable Metrics/MethodLength
 
 end

--- a/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
+++ b/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
@@ -93,12 +93,13 @@ module StashEngine
            subject: "#{rails_env} REMINDER: Dryad Submission \"#{@resource.title}\"")
     end
 
-    def dependency_offline(dependency)
+    def dependency_offline(dependency, message)
       return unless dependency.present?
 
       @dependency = dependency
       @url = status_dashboard_url
       @submission_error_emails = APP_CONFIG['submission_error_email'] || [@helpdesk_email]
+      @message = message
       mail(to: @submission_error_emails, bcc: @bcc_emails,
            subject: "#{rails_env} dependency offline: #{dependency.name}")
     end

--- a/stash/stash_engine/app/services/stash_engine/status_dashboard/dependency_checker_service.rb
+++ b/stash/stash_engine/app/services/stash_engine/status_dashboard/dependency_checker_service.rb
@@ -23,12 +23,12 @@ module StashEngine
 
         was_already_offline = @dependency.status != 1
         @dependency.update(status: online, error_message: message)
-        report_outage if !online && !was_already_offline
+        report_outage(message) if !online && !was_already_offline
         true
       end
 
-      def report_outage
-        UserMailer.dependency_offline(@dependency).deliver_now
+      def report_outage(message)
+        UserMailer.dependency_offline(@dependency, message).deliver_now
       end
 
       def extract_last_log_date(log)
@@ -39,7 +39,7 @@ module StashEngine
 
       def read_end_of_file(log)
         f = File.new(log)
-        f.seek(-512, IO::SEEK_END) # to 512 bytes before end of file
+        f.seek(-1024, IO::SEEK_END) # to 1024 bytes before end of file
         f.read.strip.split("\n") # this reads just end of file, strips whitespace and converts to array of lines
       end
 

--- a/stash/stash_engine/app/services/stash_engine/status_dashboard/notifier_service.rb
+++ b/stash/stash_engine/app/services/stash_engine/status_dashboard/notifier_service.rb
@@ -17,6 +17,9 @@ module StashEngine
 
         last_run_date = extract_last_log_date(LOG_FILE)
         log_err = extract_log_err(LOG_FILE)
+        # A failure to process the notifier's PATCH call is not a failure in the notifier itself
+        log_err = nil if log_err.match(/PATCH to http/)
+
         online = last_run_date.present? && last_run_date >= (Time.now - 15.minutes) && !log_err
         msg = ''
         msg += "The Notifier service last updated its log at '#{last_run_date}'. " unless online

--- a/stash/stash_engine/app/services/stash_engine/status_dashboard/notifier_service.rb
+++ b/stash/stash_engine/app/services/stash_engine/status_dashboard/notifier_service.rb
@@ -19,7 +19,7 @@ module StashEngine
         log_err = extract_log_err(LOG_FILE)
         online = last_run_date.present? && last_run_date >= (Time.now - 15.minutes) && !log_err
         msg = ''
-        msg += "The Notifier service has not updated its log since '#{last_run_date}'. " unless online
+        msg += "The Notifier service last update its log at '#{last_run_date}'. " unless online
         msg += "Notifier log has error: #{log_err}" if log_err.present?
         record_status(online: online, message: msg)
         online

--- a/stash/stash_engine/app/services/stash_engine/status_dashboard/notifier_service.rb
+++ b/stash/stash_engine/app/services/stash_engine/status_dashboard/notifier_service.rb
@@ -9,20 +9,25 @@ module StashEngine
 
       LOG_FILE = '/dryad/apps/ui/shared/cron/logs/stash-notifier.log'
 
+      # rubocop:disable Metrics/CyclomaticComplexity
       def ping_dependency
         super
         record_status(online: false, message: "No log file found at '#{LOG_FILE}'.") unless File.exist?(LOG_FILE)
         return false unless File.exist?(LOG_FILE)
 
         last_run_date = extract_last_log_date(LOG_FILE)
-        online = last_run_date.present? && last_run_date >= (Time.now - 15.minutes)
-        msg = "The Notifier service has not updated its log since '#{last_run_date}'." unless online
+        log_err = extract_log_err(LOG_FILE)
+        online = last_run_date.present? && last_run_date >= (Time.now - 15.minutes) && !log_err
+        msg = ''
+        msg += "The Notifier service has not updated its log since '#{last_run_date}'. " unless online
+        msg += "Notifier log has error: #{log_err}" if log_err.present?
         record_status(online: online, message: msg)
         online
       rescue StandardError => e
         record_status(online: false, message: e.to_s)
         false
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
 
     end
 

--- a/stash/stash_engine/app/services/stash_engine/status_dashboard/notifier_service.rb
+++ b/stash/stash_engine/app/services/stash_engine/status_dashboard/notifier_service.rb
@@ -19,7 +19,7 @@ module StashEngine
         log_err = extract_log_err(LOG_FILE)
         online = last_run_date.present? && last_run_date >= (Time.now - 15.minutes) && !log_err
         msg = ''
-        msg += "The Notifier service last update its log at '#{last_run_date}'. " unless online
+        msg += "The Notifier service last updated its log at '#{last_run_date}'. " unless online
         msg += "Notifier log has error: #{log_err}" if log_err.present?
         record_status(online: online, message: msg)
         online

--- a/stash/stash_engine/app/views/stash_engine/user_mailer/dependency_offline.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/user_mailer/dependency_offline.html.erb
@@ -1,6 +1,8 @@
 <p>The <%= @dependency.name %> dependency is offline!</p>
 
+<% if @message %>
 <p>Its error message is: <%= @message %></p>
+<% end %>
 
 For more information please visit the <a href="<%= @url %>">status dashboard page</a>
 

--- a/stash/stash_engine/app/views/stash_engine/user_mailer/dependency_offline.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/user_mailer/dependency_offline.html.erb
@@ -1,5 +1,7 @@
 <p>The <%= @dependency.name %> dependency is offline!</p>
 
+<p>Its error message is: <%= @message %></p>
+
 For more information please visit the <a href="<%= @url %>">status dashboard page</a>
 
 <p><%= @dependency.documentation.html_safe %></p>


### PR DESCRIPTION
Improving the dependency checker for stash-notifier. 

- Check several lines at the end of the log file, not just the last one.
- Check for error messages as well as outdated timestamps.
- Include any error messages in the emails that go out to developers.