### PR TITLE
Reset places where bundler 2 was trying to take over again

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -869,4 +869,4 @@ DEPENDENCIES
   yui-compressor
 
 BUNDLED WITH
-   2.1.4
+   1.17.3

--- a/stash/stash-notifier/Gemfile.lock
+++ b/stash/stash-notifier/Gemfile.lock
@@ -78,4 +78,4 @@ DEPENDENCIES
   rubocop (~> 0.85.1)
 
 BUNDLED WITH
-   2.1.4
+   1.17.3

--- a/stash/stash_api/Gemfile.lock
+++ b/stash/stash_api/Gemfile.lock
@@ -661,4 +661,4 @@ DEPENDENCIES
   stash_engine!
 
 BUNDLED WITH
-   2.1.4
+   1.17.3

--- a/stash/stash_datacite/Gemfile.lock
+++ b/stash/stash_datacite/Gemfile.lock
@@ -695,4 +695,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   1.17.3

--- a/stash/stash_engine/Gemfile.lock
+++ b/stash/stash_engine/Gemfile.lock
@@ -543,4 +543,4 @@ DEPENDENCIES
   zaru (~> 0.3)
 
 BUNDLED WITH
-   2.1.4
+   1.17.3


### PR DESCRIPTION
I think these crept in again because I reset my branch and these changes happened afterward.

I did a diff of my branch that finally worked with the deploys with master and these were the only changes related to the bundler problems.