### PR TITLE
Fixing code that creates urls to be port-aware and handle domains with ports

### DIFF
--- a/spec/lib/stash/download/version_presigned_spec.rb
+++ b/spec/lib/stash/download/version_presigned_spec.rb
@@ -22,9 +22,22 @@ module Stash
           expect(u).to eq("https://localhost/api/assemble-version/#{ERB::Util.url_encode(@local_id)}/1?content=producer&format=zip")
         end
 
+        it 'handles ports for assemble_version_url' do
+          @vp.instance_variable_set(:@domain, 'truculent.com:2838')
+          u = @vp.assemble_version_url
+          expect(u).to eq("https://truculent.com:2838/api/assemble-version/#{ERB::Util.url_encode(@local_id)}/1?content=producer&format=zip")
+        end
+
         it 'creates correct status_url' do
           u = @vp.status_url
           expect(u).to eq("https://localhost/api/presign-obj-by-token/#{@resource.download_token.token}" \
+            "?filename=#{@vp.filename}&no_redirect=true")
+        end
+
+        it 'handles ports for status_url' do
+          @vp.instance_variable_set(:@domain, 'truculent.com:2838')
+          u = @vp.status_url
+          expect(u).to eq("https://truculent.com:2838/api/presign-obj-by-token/#{@resource.download_token.token}" \
             "?filename=#{@vp.filename}&no_redirect=true")
         end
       end

--- a/stash/stash_engine/lib/stash/download/version_presigned.rb
+++ b/stash/stash_engine/lib/stash/download/version_presigned.rb
@@ -109,16 +109,20 @@ module Stash
       end
 
       def assemble_version_url
+        d, p = @domain.split(':')
         URI::HTTPS.build(
-          host: @domain,
+          host: d,
+          port: p,
           path: ::File.join('/api', 'assemble-version', ERB::Util.url_encode(@local_id), @version.to_s),
           query: { format: 'zip', content: 'producer' }.to_query
         ).to_s
       end
 
       def status_url
+        d, p = @domain.split(':')
         URI::HTTPS.build(
-          host: @domain,
+          host: d,
+          port: p,
           path: ::File.join('/api', 'presign-obj-by-token', ERB::Util.url_encode(@resource.download_token.token)),
           query: { no_redirect: true, filename: filename }.to_query
         ).to_s


### PR DESCRIPTION
See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/778 .

Terry is doing some docker setup and it wasn't working correctly because generating a URL wasn't working if a port was included as part of the domain name.

Works both with and without ports and added tests so it tests both.