### PR TITLE
Allow more flexible base URLs for Merritt Repo and handle timeouts

### DIFF
--- a/documentation/dryad_install.md
+++ b/documentation/dryad_install.md
@@ -201,12 +201,12 @@ API for identifier assignment and submission to repositories.
 Dryad uses CDL's EZID service for identifier assignment and stores datasets in the [Merritt](https://merritt.cdlib.org/) repository.
 The Stash::Repo implementation is provided by the [stash-merritt](https://github.com/CDLUC3/stash-merritt) gem, which is included in the application [Gemfile](../../Gemfile)
 and declared by the `repository:` key in [`app_config.yml`](https://github.com/CDL-Drayd/dryad-config-example/blob/development/config/app_config.yml).
-EZID and Merritt/SWORD must be configured for each tenant in the apporpriate `tenants/*.yml` file, e.g.
+EZID and Merritt/SWORD must be configured for each tenant in the appropriate `tenants/*.yml` file, e.g.
 
 ```yaml
 repository: # change me: you'll probably have to change all the following indented values and only if using Merritt repo
     type: merritt
-    domain: merritt-repo-dev-example.cdlib.org
+    domain: http://merritt-repo-dev-example.cdlib.org
     endpoint: "http://uc3-mrtsword-dev.cdlib.org:39001/mrtsword/collection/my_collection_id"
     username: "submitter_username"
     password: "submitter_password"

--- a/dryad-config-example/tenants/dataone.yml
+++ b/dryad-config-example/tenants/dataone.yml
@@ -7,7 +7,7 @@
 default: &default
   enabled: true
   repository:
-    domain: merritt.repository.domain.here
+    domain: http://merritt.repository.domain.here
     endpoint: "http://merritt.repository.domain.here/mrtsword/collection/demo_open_context"
     username: "submitter.username"
     password: "submitter.password"

--- a/dryad-config-example/tenants/dryad.yml
+++ b/dryad-config-example/tenants/dryad.yml
@@ -7,7 +7,7 @@
 default: &default
   enabled: true
   repository:
-    domain: merritt.repository.domain.here
+    domain: http://merritt.repository.domain.here
     endpoint: "http://merritt.repository.domain.here/mrtsword/collection/demo_open_context"
     username: "submitter.username"
     password: "submitter.password"

--- a/dryad-config-example/tenants/localhost.yml
+++ b/dryad-config-example/tenants/localhost.yml
@@ -12,7 +12,8 @@
 default: &default
   enabled: true
   repository:
-    domain: http://localhost
+    # making this localhost.com some it WebMock picks up invalid requests outside my local machine
+    domain: http://localhost.com
     endpoint: "http://localhost:39001/sword/collection/stash"
     username: "stash_submitter"
     password: "correct​horse​battery​staple"

--- a/dryad-config-example/tenants/localhost.yml
+++ b/dryad-config-example/tenants/localhost.yml
@@ -12,7 +12,7 @@
 default: &default
   enabled: true
   repository:
-    domain: localhost
+    domain: http://localhost
     endpoint: "http://localhost:39001/sword/collection/stash"
     username: "stash_submitter"
     password: "correct​horse​battery​staple"

--- a/dryad-config-example/tenants/ucop.yml
+++ b/dryad-config-example/tenants/ucop.yml
@@ -7,7 +7,7 @@
 default: &default
   enabled: true
   repository:
-    domain: merritt.repository.domain.here
+    domain: http://merritt.repository.domain.here
     endpoint: "http://merritt.repository.domain.here/mrtsword/collection/dash_cdl"
     username: "submitter.username"
     password: "submitter.password"

--- a/spec/data/tenant-example.yml
+++ b/spec/data/tenant-example.yml
@@ -2,7 +2,7 @@ default: &default
   enabled: true
   repository:
     type: exemplum
-    domain: repo-dev.example.edu
+    domain: http://repo-dev.example.edu
     endpoint: "http://repo-dev.example.edu:39001/sword/collection/stash"
     username: "stash_submitter"
     password: "correct​horse​battery​staple"
@@ -32,7 +32,7 @@ stage:
   #Add any items that need to override the defaults here
   repository:
     type: exemplum
-    domain: repo-stage.example.edu
+    domain: http://repo-stage.example.edu
     endpoint: "http://repo-stg.example.edu:39001/sword/collection/stash"
     username: "stash_submitter"
     password: "correct​horse​battery​staple"
@@ -42,7 +42,7 @@ production:
   #Add any items that need to override the defaults here
   repository:
     type: exemplum
-    domain: repo.example.edu
+    domain: http://repo.example.edu
     endpoint: "http://repo-prd.example.edu:39001/sword/collection/stash"
     username: "stash_submitter"
     password: "correct​horse​battery​staple"

--- a/spec/features/stash_engine/landing_spec.rb
+++ b/spec/features/stash_engine/landing_spec.rb
@@ -41,4 +41,29 @@ RSpec.feature 'Landing', type: :feature, js: true do
     click_on 'cancel_dialog'
     expect(page).not_to have_text('Preparing Download')
   end
+
+  it "shows popup telling people of problems if download assembly times out but status doesn't" do
+    res = @identifier.resources.first
+    res.update(meta_view: true, file_view: true, publication_date: Time.new)
+    create(:curation_activity, status: 'curation', user_id: @user.id, resource_id: res.id)
+    stub_404_status # the status of the token (not found)
+    stub_408_assemble # the status for assembly
+    visit stash_url_helpers.landing_show_path(id: @identifier.to_s)
+    click_on 'Download dataset'
+    expect(page).to have_text('There was a problem assembling your download request')
+    click_on 'cancel_dialog'
+    expect(page).not_to have_text('There was a problem assembling your download request')
+  end
+
+  it "shows popup telling people of problems if token status times out" do
+    res = @identifier.resources.first
+    res.update(meta_view: true, file_view: true, publication_date: Time.new)
+    create(:curation_activity, status: 'curation', user_id: @user.id, resource_id: res.id)
+    stub_408_status # the status for assembly
+    visit stash_url_helpers.landing_show_path(id: @identifier.to_s)
+    click_on 'Download dataset'
+    expect(page).to have_text('There was a problem assembling your download request')
+    click_on 'cancel_dialog'
+    expect(page).not_to have_text('There was a problem assembling your download request')
+  end
 end

--- a/spec/features/stash_engine/landing_spec.rb
+++ b/spec/features/stash_engine/landing_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature 'Landing', type: :feature, js: true do
     expect(page).not_to have_text('There was a problem assembling your download request')
   end
 
-  it "shows popup telling people of problems if token status times out" do
+  it 'shows popup telling people of problems if token status times out' do
     res = @identifier.resources.first
     res.update(meta_view: true, file_view: true, publication_date: Time.new)
     create(:curation_activity, status: 'curation', user_id: @user.id, resource_id: res.id)

--- a/spec/lib/stash/download/version_presigned_spec.rb
+++ b/spec/lib/stash/download/version_presigned_spec.rb
@@ -93,7 +93,7 @@ module Stash
 
         it 'returns a 408 status code if Merritt gives us one' do
           stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zip})
-              .to_return(status: 408, body: 'Not found', headers: {})
+            .to_return(status: 408, body: 'Not found', headers: {})
 
           expect(@vp.assemble[:status]).to eq(408)
         end
@@ -201,7 +201,7 @@ module Stash
 
         it 'returns 408 when Merritt is timing out on the assemble call for a token' do
           stub_request(:get, %r{/api/presign-obj-by-token/.+})
-              .to_return(status: 404, body:
+            .to_return(status: 404, body:
                   { status: 404 }.to_json, headers: { 'Content-Type' => 'application/json' })
           @vp = VersionPresigned.new(resource: @resource)
           expect(@vp).to receive(:assemble).and_raise(HTTP::TimeoutError)

--- a/spec/lib/stash/download/version_presigned_spec.rb
+++ b/spec/lib/stash/download/version_presigned_spec.rb
@@ -23,7 +23,7 @@ module Stash
         end
 
         it 'handles ports for assemble_version_url' do
-          @vp.instance_variable_set(:@domain, 'truculent.com:2838')
+          @vp.instance_variable_set(:@domain, 'https://truculent.com:2838')
           u = @vp.assemble_version_url
           expect(u).to eq("https://truculent.com:2838/api/assemble-version/#{ERB::Util.url_encode(@local_id)}/1?content=producer&format=zip")
         end
@@ -35,7 +35,7 @@ module Stash
         end
 
         it 'handles ports for status_url' do
-          @vp.instance_variable_set(:@domain, 'truculent.com:2838')
+          @vp.instance_variable_set(:@domain, 'https://truculent.com:2838')
           u = @vp.status_url
           expect(u).to eq("https://truculent.com:2838/api/presign-obj-by-token/#{@resource.download_token.token}" \
             "?filename=#{@vp.filename}&no_redirect=true")

--- a/spec/lib/stash/download/version_presigned_spec.rb
+++ b/spec/lib/stash/download/version_presigned_spec.rb
@@ -19,7 +19,7 @@ module Stash
       describe 'urls for Merritt service' do
         it 'creates correct assemble_version_url' do
           u = @vp.assemble_version_url
-          expect(u).to eq("http://localhost/api/assemble-version/#{ERB::Util.url_encode(@local_id)}/1?content=producer&format=zip")
+          expect(u).to eq("http://localhost.com/api/assemble-version/#{ERB::Util.url_encode(@local_id)}/1?content=producer&format=zip")
         end
 
         it 'handles ports for assemble_version_url' do
@@ -30,7 +30,7 @@ module Stash
 
         it 'creates correct status_url' do
           u = @vp.status_url
-          expect(u).to eq("http://localhost/api/presign-obj-by-token/#{@resource.download_token.token}" \
+          expect(u).to eq("http://localhost.com/api/presign-obj-by-token/#{@resource.download_token.token}" \
             "?filename=#{@vp.filename}&no_redirect=true")
         end
 

--- a/spec/lib/stash/download/version_presigned_spec.rb
+++ b/spec/lib/stash/download/version_presigned_spec.rb
@@ -22,9 +22,22 @@ module Stash
           expect(u).to eq("https://localhost/api/assemble-version/#{ERB::Util.url_encode(@local_id)}/1?content=producer&format=zip")
         end
 
+        it 'handles ports for assemble_version_url' do
+          @vp.instance_variable_set(:@domain, 'truculent.com:2838')
+          u = @vp.assemble_version_url
+          expect(u).to eq("https://truculent.com:2838/api/assemble-version/#{ERB::Util.url_encode(@local_id)}/1?content=producer&format=zip")
+        end
+
         it 'creates correct status_url' do
           u = @vp.status_url
           expect(u).to eq("https://localhost/api/presign-obj-by-token/#{@resource.download_token.token}" \
+            "?filename=#{@vp.filename}&no_redirect=true")
+        end
+
+        it 'handles ports for status_url' do
+          @vp.instance_variable_set(:@domain, 'truculent.com:2838')
+          u = @vp.status_url
+          expect(u).to eq("https://truculent.com:2838/api/presign-obj-by-token/#{@resource.download_token.token}" \
             "?filename=#{@vp.filename}&no_redirect=true")
         end
       end

--- a/spec/lib/stash/download/version_presigned_spec.rb
+++ b/spec/lib/stash/download/version_presigned_spec.rb
@@ -19,7 +19,7 @@ module Stash
       describe 'urls for Merritt service' do
         it 'creates correct assemble_version_url' do
           u = @vp.assemble_version_url
-          expect(u).to eq("https://localhost/api/assemble-version/#{ERB::Util.url_encode(@local_id)}/1?content=producer&format=zip")
+          expect(u).to eq("http://localhost/api/assemble-version/#{ERB::Util.url_encode(@local_id)}/1?content=producer&format=zip")
         end
 
         it 'handles ports for assemble_version_url' do
@@ -30,7 +30,7 @@ module Stash
 
         it 'creates correct status_url' do
           u = @vp.status_url
-          expect(u).to eq("https://localhost/api/presign-obj-by-token/#{@resource.download_token.token}" \
+          expect(u).to eq("http://localhost/api/presign-obj-by-token/#{@resource.download_token.token}" \
             "?filename=#{@vp.filename}&no_redirect=true")
         end
 

--- a/spec/responses/stash_engine/download_helpers.rb
+++ b/spec/responses/stash_engine/download_helpers.rb
@@ -59,18 +59,18 @@ module DownloadHelpers
 
   def stub_408_assemble
     stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zip})
-        .to_return(status: 408, body:
+      .to_return(status: 408, body:
             {  status: 408,
                message: 'Timed out' }.to_json,
-                   headers: { 'Content-Type' => 'application/json' })
+                 headers: { 'Content-Type' => 'application/json' })
   end
 
   def stub_408_status
     stub_request(:get, %r{/api/presign-obj-by-token/#{@token.token}.+})
-        .to_return(status: 408, body:
+      .to_return(status: 408, body:
             {  status: 408,
                message: 'Timed out' }.to_json,
-                   headers: { 'Content-Type' => 'application/json' })
+                 headers: { 'Content-Type' => 'application/json' })
   end
 
 end

--- a/spec/responses/stash_engine/download_helpers.rb
+++ b/spec/responses/stash_engine/download_helpers.rb
@@ -57,4 +57,20 @@ module DownloadHelpers
       .to_return(status: 404, body: 'Internal server error', headers: {})
   end
 
+  def stub_408_assemble
+    stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zip})
+        .to_return(status: 408, body:
+            {  status: 408,
+               message: 'Timed out' }.to_json,
+                   headers: { 'Content-Type' => 'application/json' })
+  end
+
+  def stub_408_status
+    stub_request(:get, %r{/api/presign-obj-by-token/#{@token.token}.+})
+        .to_return(status: 408, body:
+            {  status: 408,
+               message: 'Timed out' }.to_json,
+                   headers: { 'Content-Type' => 'application/json' })
+  end
+
 end

--- a/stash/stash-merritt/lib/stash/merritt/repository.rb
+++ b/stash/stash-merritt/lib/stash/merritt/repository.rb
@@ -20,7 +20,7 @@ module Stash
       def download_uri_for(resource:, record_identifier:)
         merritt_host = merritt_host_for(resource)
         ark = ark_from(record_identifier)
-        "http://#{merritt_host}/d/#{ERB::Util.url_encode(ark)}"
+        "#{merritt_host}/d/#{ERB::Util.url_encode(ark)}"
       end
 
       def update_uri_for(resource:, record_identifier:) # rubocop:disable Lint/UnusedMethodArgument

--- a/stash/stash-merritt/spec/db/stash/merritt/repository_spec.rb
+++ b/stash/stash-merritt/spec/db/stash/merritt/repository_spec.rb
@@ -33,7 +33,7 @@ module Stash
         )
 
         repo_config = OpenStruct.new(
-          domain: 'merritt.cdlib.org',
+          domain: 'http://merritt.cdlib.org',
           endpoint: 'http://uc3-mrtsword-prd.cdlib.org:39001/mrtsword/collection/dataone_dash'
         )
 

--- a/stash/stash_engine/app/views/stash_engine/downloads/_download_timeout_message.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/downloads/_download_timeout_message.html.erb
@@ -1,0 +1,13 @@
+<div class="o-admin-dialog">
+  <p>There was a problem assembling your download request.</p>
+
+  <p>The server may be overloaded or having problems.</p>
+
+  <p>You may wish to try again later or download individual files from the list on the page.</p>
+
+  <p>The Dryad team has been notified of this problem.</p>
+
+  <p>
+    <%= button_tag 'Close', type: 'button', id: 'cancel_dialog' %>
+  </p>
+</div>

--- a/stash/stash_engine/app/views/stash_engine/downloads/download_timeout.js.erb
+++ b/stash/stash_engine/app/views/stash_engine/downloads/download_timeout.js.erb
@@ -1,0 +1,20 @@
+$('.js-download').prop('disabled', false);
+
+$('#popup_dialog').html("<%= escape_javascript(render partial: 'download_timeout_message') %>");
+
+$(function() {
+    $("#popup_dialog").dialog({
+        autoOpen: true,
+        height: 'auto',
+        width: '500px',
+        modal: true,
+        title: 'This download cannot be assembled right now'
+    });
+
+    $("#cancel_dialog").click(function (e) {
+        e.preventDefault();
+        $('#popup_dialog').dialog('close');
+    });
+});
+
+

--- a/stash/stash_engine/lib/stash/download/version_presigned.rb
+++ b/stash/stash_engine/lib/stash/download/version_presigned.rb
@@ -109,16 +109,20 @@ module Stash
       end
 
       def assemble_version_url
+        d, p = @domain.split(':')
         URI::HTTPS.build(
-          host: @domain,
+          host: d,
+          port: p,
           path: ::File.join('/api', 'assemble-version', ERB::Util.url_encode(@local_id), @version.to_s),
           query: { format: 'zip', content: 'producer' }.to_query
         ).to_s
       end
 
       def status_url
+        d, p = @domain.split(':')
         URI::HTTPS.build(
-          host: @domain,
+          host: d,
+          port: p,
           path: ::File.join('/api', 'presign-obj-by-token', ERB::Util.url_encode(@resource.download_token.token)),
           query: { no_redirect: true, filename: filename }.to_query
         ).to_s

--- a/stash/stash_engine/lib/stash/download/version_presigned.rb
+++ b/stash/stash_engine/lib/stash/download/version_presigned.rb
@@ -109,23 +109,15 @@ module Stash
       end
 
       def assemble_version_url
-        d, p = @domain.split(':')
-        URI::HTTPS.build(
-          host: d,
-          port: p,
-          path: ::File.join('/api', 'assemble-version', ERB::Util.url_encode(@local_id), @version.to_s),
-          query: { format: 'zip', content: 'producer' }.to_query
-        ).to_s
+        path = ::File.join('/api', 'assemble-version', ERB::Util.url_encode(@local_id), @version.to_s).to_s
+        query = { format: 'zip', content: 'producer' }.to_query
+        "#{@domain}#{path}?#{query}"
       end
 
       def status_url
-        d, p = @domain.split(':')
-        URI::HTTPS.build(
-          host: d,
-          port: p,
-          path: ::File.join('/api', 'presign-obj-by-token', ERB::Util.url_encode(@resource.download_token.token)),
-          query: { no_redirect: true, filename: filename }.to_query
-        ).to_s
+        path = ::File.join('/api', 'presign-obj-by-token', ERB::Util.url_encode(@resource.download_token.token)).to_s
+        query = { no_redirect: true, filename: filename }.to_query
+        "#{@domain}#{path}?#{query}"
       end
 
       def filename

--- a/stash/stash_engine/spec/data/tenant-example.yml
+++ b/stash/stash_engine/spec/data/tenant-example.yml
@@ -2,7 +2,7 @@ default: &default
   enabled: true
   repository:
     type: exemplum
-    domain: repo-dev.example.edu
+    domain: http://repo-dev.example.edu
     endpoint: "http://repo-dev.example.edu:39001/sword/collection/stash"
     username: "stash_submitter"
     password: "correct​horse​battery​staple"

--- a/stash/stash_engine/spec/unit/models/tenant_spec.rb
+++ b/stash/stash_engine/spec/unit/models/tenant_spec.rb
@@ -36,7 +36,7 @@ module StashEngine
       expect(tenant.stash_logo_after_tenant).to eq(true)
       repo = tenant.repository
       expect(repo.type).to eq('exemplum')
-      expect(repo.domain).to eq('repo-dev.example.edu')
+      expect(repo.domain).to eq('http://repo-dev.example.edu')
       expect(repo.endpoint).to eq('http://repo-dev.example.edu:39001/sword/collection/stash')
       expect(repo.username).to eq('stash_submitter')
       expect(repo.password).to eq('correct​horse​battery​staple')


### PR DESCRIPTION
This changes the config repo so that the domain is really port+domain+(possibly protocol).

It also handles timeouts from Merritt (they return a 408 to us as part of their status hash).

I'll have Terry test this out with his docker containers, but tried to mock something up.

Displays a message that our download isn't working right now and lets them know to try files or to try again later on timeouts.

Also corresponding PR at https://github.com/cdlib/dryad-config