### PR TITLE
Fix for someone deleting and then adding and then deleting files

### DIFF
--- a/stash/stash_engine/app/models/stash_engine/file_upload.rb
+++ b/stash/stash_engine/app/models/stash_engine/file_upload.rb
@@ -131,27 +131,21 @@ module StashEngine
           "/#{CGI.unescape(ark)}/#{ERB::Util.url_encode(upload_file_name).gsub('%252F', '%2F')}"
     end
 
-    # This will get rid of a file, either immediately, when not submitted yet, or mark it for deletion when it's submitted to Merritt.
-    # We also need to refresh the file list for this resource and check for other files with this same name to be deleted since
-    # users find ways to do multiple deletions in the UI (multiple windows or perhaps uploading two files with the same name).
     def smart_destroy!
-      files_with_name = FileUpload.where(resource_id: resource_id).where(upload_file_name: upload_file_name)
+      # see if it's on the file system and destroy it if it's there
+      cfp = calc_file_path
+      ::File.delete(cfp) if !cfp.blank? && ::File.exist?(cfp)
 
-      # destroy any files for this version and and not yet sent to Merritt, shouldn't have nil, but if so, it's newly created
-      files_with_name.where(file_state: ['created', nil]).each do |fl|
-        ::File.delete(fl.calc_file_path) if !fl.calc_file_path.blank? && ::File.exist?(fl.calc_file_path)
-        fl.destroy
+      if in_previous_version?
+        # destroy any others of this filename in this resource
+        self.class.where(resource_id: resource_id, upload_file_name: upload_file_name).where("id <> ?", id).destroy_all
+        # and mark to remove from merritt
+        update(file_state: 'deleted')
+      else
+        # remove all of this filename for this resource from the database
+        self.class.where(resource_id: resource_id, upload_file_name: upload_file_name).destroy_all
       end
 
-      # leave only one delete directive for this filename for this resource (ie the first listed file), if there is already
-      # a delete directive then it must've been copied at one point from the last resource, so keep one
-      files_with_name.where(file_state: %w[deleted copied]).each_with_index do |f, idx|
-        if idx == 0
-          f.update(file_state: 'deleted')
-        else
-          f.destroy
-        end
-      end
       resource.reload
     end
 
@@ -179,6 +173,18 @@ module StashEngine
       # remove some extra characters that Zaru does not remove by default
       # replace spaces with underscores
       sanitized.gsub(/,|;|'|"|\u007F/, '').strip.gsub(/\s+/, '_')
+    end
+
+    # We need to know state from last resource version if any.  It may have both deleted and created last time, which really
+    # means created last time.
+    def in_previous_version?
+      prev_res = resource.previous_resource
+      return false if prev_res.nil?
+
+      prev_file = FileUpload.where(resource_id: prev_res.id, upload_file_name: upload_file_name).order(id: :desc).first
+      return false if prev_file.nil? || prev_file.file_state == 'deleted'
+
+      true # otherwise it existed last version because file state is created, copied or nil (nil is assumed to be copied)
     end
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/file_upload.rb
+++ b/stash/stash_engine/app/models/stash_engine/file_upload.rb
@@ -138,7 +138,7 @@ module StashEngine
 
       if in_previous_version?
         # destroy any others of this filename in this resource
-        self.class.where(resource_id: resource_id, upload_file_name: upload_file_name).where("id <> ?", id).destroy_all
+        self.class.where(resource_id: resource_id, upload_file_name: upload_file_name).where('id <> ?', id).destroy_all
         # and mark to remove from merritt
         update(file_state: 'deleted')
       else

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -492,7 +492,7 @@ module StashEngine
     private :increment_version!
 
     def previous_resource
-      StashEngine::Resource.where(identifier_id: identifier_id).where("id < ?", id).order(id: :desc).first
+      StashEngine::Resource.where(identifier_id: identifier_id).where('id < ?', id).order(id: :desc).first
     end
 
     # ------------------------------------------------------------

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -491,6 +491,10 @@ module StashEngine
     end
     private :increment_version!
 
+    def previous_resource
+      StashEngine::Resource.where(identifier_id: identifier_id).where("id < ?", id).order(id: :desc).first
+    end
+
     # ------------------------------------------------------------
     # Ownership
 

--- a/stash/stash_engine/spec/db/stash_engine/file_upload_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/file_upload_spec.rb
@@ -325,8 +325,8 @@ module StashEngine
     describe '#in_previous_version' do
       before(:each) do
         @files = [
-            create(:file_upload, upload_file_name: 'noggin1.jpg', file_state: 'created', resource_id: @resource.id),
-            create(:file_upload, upload_file_name: 'noggin3.jpg', file_state: 'created', resource_id: @resource.id)
+          create(:file_upload, upload_file_name: 'noggin1.jpg', file_state: 'created', resource_id: @resource.id),
+          create(:file_upload, upload_file_name: 'noggin3.jpg', file_state: 'created', resource_id: @resource.id)
         ]
 
         @resource2 = Resource.create(user_id: user.id, tenant_id: 'ucop')
@@ -334,9 +334,9 @@ module StashEngine
         FileUtils.mkdir_p('tmp')
         @testfile = FileUtils.touch('tmp/noggin2.jpg').first # touch returns an array
         @files2 = [
-            create(:file_upload, upload_file_name: 'noggin1.jpg', file_state: 'copied', resource_id: @resource2.id),
-            create(:file_upload, upload_file_name: 'noggin2.jpg', file_state: 'created', resource_id: @resource2.id),
-            create(:file_upload, upload_file_name: 'noggin3.jpg', file_state: 'deleted', resource_id: @resource2.id)
+          create(:file_upload, upload_file_name: 'noggin1.jpg', file_state: 'copied', resource_id: @resource2.id),
+          create(:file_upload, upload_file_name: 'noggin2.jpg', file_state: 'created', resource_id: @resource2.id),
+          create(:file_upload, upload_file_name: 'noggin3.jpg', file_state: 'deleted', resource_id: @resource2.id)
         ]
 
         # I tried just modifying one instance but it doesn't work from the internal method if I do that.

--- a/stash/stash_engine/spec/db/stash_engine/file_upload_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/file_upload_spec.rb
@@ -117,10 +117,9 @@ module StashEngine
 
       before(:each) do
         @files = [
-            create(:file_upload, upload_file_name: 'noggin1.jpg', file_state: 'created', resource_id: @resource.id),
-            create(:file_upload, upload_file_name: 'noggin3.jpg', file_state: 'created', resource_id: @resource.id)
+          create(:file_upload, upload_file_name: 'noggin1.jpg', file_state: 'created', resource_id: @resource.id),
+          create(:file_upload, upload_file_name: 'noggin3.jpg', file_state: 'created', resource_id: @resource.id)
         ]
-
 
         @resource2 = Resource.create(user_id: user.id, tenant_id: 'ucop')
         @resource2.ensure_identifier('10.123/456')

--- a/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
@@ -1399,5 +1399,29 @@ module StashEngine
         @resource.send_to_zenodo
       end
     end
+
+    describe '#previous_resource' do
+      before(:each) do
+        @identifier2 = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI')
+        @identifier = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI')
+
+        @resource1 = Resource.create(user_id: user.id, identifier_id: @identifier.id)
+        @other_resource1 = Resource.create(user_id: user.id, identifier_id: @identifier2.id)
+        @resource2 = Resource.create(user_id: user.id, identifier_id: @identifier.id)
+        @resource3 = Resource.create(user_id: user.id, identifier_id: @identifier.id)
+      end
+
+      it 'has no previous resource for version 1' do
+        expect(@resource1.previous_resource).to be_nil
+      end
+
+      it 'shows version 1 is previous resource for version 2' do
+        expect(@resource2.previous_resource).to eq(@resource1)
+      end
+
+      it 'shows version 2 as previous resource for version 3' do
+        expect(@resource3.previous_resource).to eq(@resource2)
+      end
+    end
   end
 end

--- a/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
+++ b/stash/stash_engine/spec/db/stash_engine/resource_spec.rb
@@ -1402,7 +1402,7 @@ module StashEngine
 
     describe '#previous_resource' do
       before(:each) do
-        @identifier2 = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI')
+        @identifier2 = Identifier.create(identifier: 'cat/frog', identifier_type: 'DOI')
         @identifier = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI')
 
         @resource1 = Resource.create(user_id: user.id, identifier_id: @identifier.id)


### PR DESCRIPTION
This is a fix for https://github.com/CDL-Dryad/dryad-product-roadmap/issues/787 .

It doesn't rely on any of the current version's state but looks back at the previous version (if it exists) and figures out if a deletion is just a deletion from the file system and from the database or if a deletion means sending a removal request to Merritt instead.