### PR TITLE
FOS subjects in our subjects and sent to DataCite

### DIFF
--- a/config/environments/local_dev.rb
+++ b/config/environments/local_dev.rb
@@ -1,6 +1,6 @@
 Rails.application.configure do
   # this is so that we can still see output to console, otherwise it gets turned off for some reason with this environment and webrick
-  config.middleware.insert_before(Rails::Rack::Logger, Rails::Rack::LogTailer)
+  # config.middleware.insert_before(Rails::Rack::Logger, Rails::Rack::LogTailer)
   config.log_level = :debug
 
   # Settings specified here will take precedence over those in config/application.rb.

--- a/spec/models/stash-merritt/datacite_xml_factory_spec.rb
+++ b/spec/models/stash-merritt/datacite_xml_factory_spec.rb
@@ -69,7 +69,7 @@ module Datacite
         resource.save!
 
         dcs_resource = xml_factory.build_resource
-        subjs = dcs_resource.subjects.map { |item| item.value }
+        subjs = dcs_resource.subjects.map(&:value)
         expect(subjs).to include("FOS: #{subject.subject}")
       end
     end

--- a/spec/models/stash-merritt/datacite_xml_factory_spec.rb
+++ b/spec/models/stash-merritt/datacite_xml_factory_spec.rb
@@ -62,6 +62,16 @@ module Datacite
         expect(resource_type).not_to be_nil
         expect(resource_type.resource_type_general).to be(ResourceTypeGeneral::DATASET)
       end
+
+      it 'creates FOS Science subject in the way DataCite requested' do
+        subject = create(:subject, subject_scheme: 'fos')
+        resource.subjects << subject
+        resource.save!
+
+        dcs_resource = xml_factory.build_resource
+        subjs = dcs_resource.subjects.map { |item| item.value }
+        expect(subjs).to include("FOS: #{subject.subject}")
+      end
     end
   end
 end

--- a/spec/models/stash_datacite/subject_spec.rb
+++ b/spec/models/stash_datacite/subject_spec.rb
@@ -2,9 +2,9 @@ module StashDatacite
   module Resource
     describe Subject do
       it 'leaves out FOS items with .non_fos scope' do
-        items = [ create(:subject), create(:subject), create(:subject, subject_scheme: 'fos') ]
-        expect(Subject.all.length).to eq(3)
-        expect(Subject.all.non_fos.length).to eq(2)
+        items = [create(:subject), create(:subject), create(:subject, subject_scheme: 'fos')]
+        expect(Subject.all.length).to eq(items.length)
+        expect(Subject.all.non_fos.length).to eq(items.length - 1)
       end
     end
   end

--- a/spec/models/stash_datacite/subject_spec.rb
+++ b/spec/models/stash_datacite/subject_spec.rb
@@ -1,0 +1,11 @@
+module StashDatacite
+  module Resource
+    describe Subject do
+      it 'leaves out FOS items with .non_fos scope' do
+        items = [ create(:subject), create(:subject), create(:subject, subject_scheme: 'fos') ]
+        expect(Subject.all.length).to eq(3)
+        expect(Subject.all.non_fos.length).to eq(2)
+      end
+    end
+  end
+end

--- a/stash/stash-merritt/lib/datacite/mapping/datacite_xml_factory.rb
+++ b/stash/stash-merritt/lib/datacite/mapping/datacite_xml_factory.rb
@@ -148,7 +148,7 @@ module Datacite
       end
 
       def add_subjects(dcs_resource)
-        dcs_resource.subjects = se_resource.subjects.map { |s| Subject.new(value: s.subject) }
+        dcs_resource.subjects = se_resource.subjects.non_fos.map { |s| Subject.new(value: s.subject) }
       end
 
       def add_contributors(dcs_resource, datacite_3: false)

--- a/stash/stash-merritt/lib/datacite/mapping/datacite_xml_factory.rb
+++ b/stash/stash-merritt/lib/datacite/mapping/datacite_xml_factory.rb
@@ -148,7 +148,12 @@ module Datacite
       end
 
       def add_subjects(dcs_resource)
-        dcs_resource.subjects = se_resource.subjects.non_fos.map { |s| Subject.new(value: s.subject) }
+        normal_subjects = se_resource.subjects.non_fos.map { |s| Subject.new(value: s.subject) }
+        # FOS subjects are a special kind Martin is handling differently based on a prefix in the string
+        fos_subjects = se_resource.subjects.where(subject_scheme: 'fos').map do |s|
+          Subject.new(value: "FOS: #{s.subject}")
+        end
+        dcs_resource.subjects = normal_subjects + fos_subjects
       end
 
       def add_contributors(dcs_resource, datacite_3: false)

--- a/stash/stash-merritt/lib/stash/merritt/builders/merritt_oaidc_builder.rb
+++ b/stash/stash-merritt/lib/stash/merritt/builders/merritt_oaidc_builder.rb
@@ -86,7 +86,7 @@ module Stash
         end
 
         def add_subjects(xml)
-          resource.subjects.each { |s| xml.send(:'dc:subject', s.subject.delete("\r").to_s) }
+          resource.subjects.non_fos.each { |s| xml.send(:'dc:subject', s.subject.delete("\r").to_s) }
         end
 
         def add_resource_type(xml)

--- a/stash/stash_api/app/models/stash_api/version/metadata/keywords.rb
+++ b/stash/stash_api/app/models/stash_api/version/metadata/keywords.rb
@@ -8,7 +8,7 @@ module StashApi
       class Keywords < MetadataItem
 
         def value
-          @resource.subjects.map(&:subject)
+          @resource.subjects.non_fos.map(&:subject)
         end
       end
     end

--- a/stash/stash_datacite/app/controllers/stash_datacite/subjects_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/subjects_controller.rb
@@ -17,14 +17,14 @@ module StashDatacite
         .split(/\s*,\s*/)
         .delete_if(&:blank?)
         .each { |s| ensure_subject(s) }
-      @subjects = resource.subjects
+      @subjects = resource.subjects.non_fos
       respond_to { |format| format.js }
     end
 
     # DELETE /subjects/1
     def delete
-      @subjects = resource.subjects
-      resource.subjects.delete(@subject)
+      @subjects = resource.subjects.non_fos
+      resource.subjects.non_fos.delete(@subject)
       respond_to do |format|
         format.js
       end
@@ -35,7 +35,7 @@ module StashDatacite
       if params[:term].blank?
         render json: nil
       else
-        @subjects = Subject.order(:subject).where('subject LIKE ?', "%#{params[:term]}%")
+        @subjects = Subject.order(:subject).non_fos.where('subject LIKE ?', "%#{params[:term]}%")
         render json: @subjects.map(&:subject)
       end
     end
@@ -50,7 +50,7 @@ module StashDatacite
 
     def ensure_subject(subject_str)
       subject = find_or_create_subject(subject_str)
-      subjects = @resource.subjects
+      subjects = @resource.subjects.non_fos
       return if subjects.exists?(subject)
 
       subjects << subject

--- a/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
@@ -110,7 +110,7 @@ module StashDatacite
       end
 
       def keyword
-        @resource.subjects.where.not(subject: [nil, '']).count > 0
+        @resource.subjects.non_fos.where.not(subject: [nil, '']).count > 0
       end
 
       def method

--- a/stash/stash_datacite/app/models/stash_datacite/resource/metadata_entry.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/metadata_entry.rb
@@ -45,7 +45,7 @@ module StashDatacite
       end
 
       def subjects
-        @subjects = @resource.subjects
+        @subjects = @resource.subjects.non_fos
       end
 
       def new_contributor

--- a/stash/stash_datacite/app/models/stash_datacite/resource/review.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/review.rb
@@ -42,7 +42,7 @@ module StashDatacite
       end
 
       def subjects
-        @subjects = @resource.subjects
+        @subjects = @resource.subjects.non_fos
       end
 
       def contributors

--- a/stash/stash_datacite/app/models/stash_datacite/resource/schema_dataset.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/schema_dataset.rb
@@ -73,9 +73,9 @@ module StashDatacite
       end
 
       def keywords
-        return [] unless @resource.subjects
+        return [] unless @resource.subjects.non_fos
 
-        @resource.subjects.map(&:subject).compact
+        @resource.subjects.non_fos.map(&:subject).compact
       end
 
       def authors

--- a/stash/stash_datacite/app/models/stash_datacite/subject.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/subject.rb
@@ -6,6 +6,6 @@ module StashDatacite
     has_and_belongs_to_many :resources, class_name: StashEngine::Resource.to_s,
                                         through: 'StashDatacite::ResourceSubject'
 
-    scope :non_fos, -> { where("subject_scheme <> 'fos'") }
+    scope :non_fos, -> { where("subject_scheme IS NULL OR subject_scheme <> 'fos'") }
   end
 end

--- a/stash/stash_datacite/app/models/stash_datacite/subject.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/subject.rb
@@ -5,5 +5,7 @@ module StashDatacite
     self.table_name = 'dcs_subjects'
     has_and_belongs_to_many :resources, class_name: StashEngine::Resource.to_s,
                                         through: 'StashDatacite::ResourceSubject'
+
+    scope :non_fos, -> { where("subject_scheme <> 'fos'") }
   end
 end

--- a/stash/stash_engine/db/migrate/20200805213525_add_fos_to_subjects.rb
+++ b/stash/stash_engine/db/migrate/20200805213525_add_fos_to_subjects.rb
@@ -1,69 +1,69 @@
 class AddFosToSubjects < ActiveRecord::Migration[5.0]
 
   SUBJECT_LIST = [
-      'Natural sciences',
-      'Mathematics',
-      'Computer and information sciences',
-      'Physical sciences',
-      'Chemical sciences',
-      'Earth and related environmental sciences',
-      'Biological sciences',
-      'Other natural sciences',
-      'Engineering and technology',
-      'Civil engineering',
-      'Electrical engineering, electronic engineering, information engineering',
-      'Mechanical engineering',
-      'Chemical engineering',
-      'Materials engineering',
-      'Medical engineering',
-      'Environmental engineering',
-      'Environmental biotechnology',
-      'Industrial biotechnology',
-      'Nano-technology',
-      'Other engineering and technologies',
-      'Medical and health sciences',
-      'Basic medicine',
-      'Clinical medicine',
-      'Health sciences',
-      'Medical biotechnology',
-      'Other medical sciences',
-      'Agricultural sciences',
-      'Agriculture, forestry, and fisheries',
-      'Animal and dairy science',
-      'Veterinary science',
-      'Agricultural biotechnology',
-      'Other agricultural sciences',
-      'Social sciences',
-      'Psychology',
-      'Economics and business',
-      'Educational sciences',
-      'Sociology',
-      'Law',
-      'Political science',
-      'Social and economic geography',
-      'Media and communications',
-      'Other social sciences',
-      'Humanities',
-      'History and archaeology',
-      'Languages and literature',
-      'Philosophy, ethics and religion',
-      'Arts (arts, history of arts, performing arts, music)',
-      'Other humanities'
-  ]
+    'Natural sciences',
+    'Mathematics',
+    'Computer and information sciences',
+    'Physical sciences',
+    'Chemical sciences',
+    'Earth and related environmental sciences',
+    'Biological sciences',
+    'Other natural sciences',
+    'Engineering and technology',
+    'Civil engineering',
+    'Electrical engineering, electronic engineering, information engineering',
+    'Mechanical engineering',
+    'Chemical engineering',
+    'Materials engineering',
+    'Medical engineering',
+    'Environmental engineering',
+    'Environmental biotechnology',
+    'Industrial biotechnology',
+    'Nano-technology',
+    'Other engineering and technologies',
+    'Medical and health sciences',
+    'Basic medicine',
+    'Clinical medicine',
+    'Health sciences',
+    'Medical biotechnology',
+    'Other medical sciences',
+    'Agricultural sciences',
+    'Agriculture, forestry, and fisheries',
+    'Animal and dairy science',
+    'Veterinary science',
+    'Agricultural biotechnology',
+    'Other agricultural sciences',
+    'Social sciences',
+    'Psychology',
+    'Economics and business',
+    'Educational sciences',
+    'Sociology',
+    'Law',
+    'Political science',
+    'Social and economic geography',
+    'Media and communications',
+    'Other social sciences',
+    'Humanities',
+    'History and archaeology',
+    'Languages and literature',
+    'Philosophy, ethics and religion',
+    'Arts (arts, history of arts, performing arts, music)',
+    'Other humanities'
+  ].freeze
 
   # this up will insert the needed values if needed, but otherwise leave the existing ones alone
   def up
     # it can have unexpected consequences to use ActiveRecord models directly in a migration, so using SQL,
     # btw, no values have an apostrophe or other weird characters in them and a controlled list
-    results = ActiveRecord::Base.connection.instance_variable_get('@connection').
-        query("SELECT * FROM dcs_subjects WHERE subject_scheme = 'fos'", as: :hash)
+    results = ActiveRecord::Base.connection.instance_variable_get('@connection')
+      .query("SELECT * FROM dcs_subjects WHERE subject_scheme = 'fos'", as: :hash)
     existing_subjects = results.map { |i| i['subject'] } # can't use a symbol here for more compact notation
 
     need_insertion = SUBJECT_LIST - existing_subjects
     return if need_insertion.empty?
 
     t = Time.now.strftime('%Y-%m-%d %H:%M:%S')
-    insertion_list = need_insertion.map { |i| "('#{i}', 'fos', '#{t}', '#{t}')"}
+    insertion_list = need_insertion.map { |i| "('#{i}', 'fos', '#{t}', '#{t}')" }
 
     execute <<-SQL
       INSERT INTO dcs_subjects (subject, subject_scheme, created_at, updated_at)

--- a/stash/stash_engine/db/migrate/20200805213525_add_fos_to_subjects.rb
+++ b/stash/stash_engine/db/migrate/20200805213525_add_fos_to_subjects.rb
@@ -1,5 +1,3 @@
-require 'byebug'
-
 class AddFosToSubjects < ActiveRecord::Migration[5.0]
 
   SUBJECT_LIST = [
@@ -53,9 +51,10 @@ class AddFosToSubjects < ActiveRecord::Migration[5.0]
       'Other humanities'
   ]
 
+  # this up will insert the needed values if needed, but otherwise leave the existing ones alone
   def up
     # it can have unexpected consequences to use ActiveRecord models directly in a migration, so using SQL,
-    # btw, no values have an apostrophe or other weird characters in them
+    # btw, no values have an apostrophe or other weird characters in them and a controlled list
     results = ActiveRecord::Base.connection.instance_variable_get('@connection').
         query("SELECT * FROM dcs_subjects WHERE subject_scheme = 'fos'", as: :hash)
     existing_subjects = results.map { |i| i['subject'] } # can't use a symbol here for more compact notation

--- a/stash/stash_engine/db/migrate/20200805213525_add_fos_to_subjects.rb
+++ b/stash/stash_engine/db/migrate/20200805213525_add_fos_to_subjects.rb
@@ -1,0 +1,78 @@
+require 'byebug'
+
+class AddFosToSubjects < ActiveRecord::Migration[5.0]
+
+  SUBJECT_LIST = [
+      'Natural sciences',
+      'Mathematics',
+      'Computer and information sciences',
+      'Physical sciences',
+      'Chemical sciences',
+      'Earth and related environmental sciences',
+      'Biological sciences',
+      'Other natural sciences',
+      'Engineering and technology',
+      'Civil engineering',
+      'Electrical engineering, electronic engineering, information engineering',
+      'Mechanical engineering',
+      'Chemical engineering',
+      'Materials engineering',
+      'Medical engineering',
+      'Environmental engineering',
+      'Environmental biotechnology',
+      'Industrial biotechnology',
+      'Nano-technology',
+      'Other engineering and technologies',
+      'Medical and health sciences',
+      'Basic medicine',
+      'Clinical medicine',
+      'Health sciences',
+      'Medical biotechnology',
+      'Other medical sciences',
+      'Agricultural sciences',
+      'Agriculture, forestry, and fisheries',
+      'Animal and dairy science',
+      'Veterinary science',
+      'Agricultural biotechnology',
+      'Other agricultural sciences',
+      'Social sciences',
+      'Psychology',
+      'Economics and business',
+      'Educational sciences',
+      'Sociology',
+      'Law',
+      'Political science',
+      'Social and economic geography',
+      'Media and communications',
+      'Other social sciences',
+      'Humanities',
+      'History and archaeology',
+      'Languages and literature',
+      'Philosophy, ethics and religion',
+      'Arts (arts, history of arts, performing arts, music)',
+      'Other humanities'
+  ]
+
+  def up
+    # it can have unexpected consequences to use ActiveRecord models directly in a migration, so using SQL,
+    # btw, no values have an apostrophe or other weird characters in them
+    results = ActiveRecord::Base.connection.instance_variable_get('@connection').
+        query("SELECT * FROM dcs_subjects WHERE subject_scheme = 'fos'", as: :hash)
+    existing_subjects = results.map { |i| i['subject'] } # can't use a symbol here for more compact notation
+
+    need_insertion = SUBJECT_LIST - existing_subjects
+    return if need_insertion.empty?
+
+    t = Time.now.strftime('%Y-%m-%d %H:%M:%S')
+    insertion_list = need_insertion.map { |i| "('#{i}', 'fos', '#{t}', '#{t}')"}
+
+    execute <<-SQL
+      INSERT INTO dcs_subjects (subject, subject_scheme, created_at, updated_at)
+      VALUES #{insertion_list.join(', ')}
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, 'Not removing subjects from FOS subjects from database. They may be used by data.'
+  end
+end

--- a/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
@@ -72,7 +72,7 @@ module Stash
       end
 
       def keywords
-        @resource.subjects&.map(&:subject)
+        @resource.subjects.non_fos&.map(&:subject)
       end
 
       def notes


### PR DESCRIPTION
These are the changes for https://github.com/CDL-Dryad/dryad-product-roadmap/issues/776 .

This basically creates a migration to be sure the FOS vocabulary is added to our database with the FOS terms and the subject scheme 'fos'.

It changes the places where we don't want to expose that with the ActiveRecord scope "non_fos."

Current tests pass and added tests to check that FOS subjects are excluded by the scope and that when sending these special subjects they are prefixed as Martin says in that ticket/chat.