### PR TITLE
Update schema.org for DataONE

### DIFF
--- a/spec/data/example.json
+++ b/spec/data/example.json
@@ -1,11 +1,12 @@
 {
   "@id": "https://doi.org/10.15146/R3RG6G",
   "@context": "http://schema.org",
-  "@type": "dataset",
+  "@type": "Dataset",
   "name": "A Zebrafish Model for Studies on Esophageal Epithelial Biology",
   "description": "Mammalian esophagus exhibits a remarkable change in epithelial structure\n      during the transition from embryo to adult. However, the molecular\n      mechanisms of esophageal epithelial development are not well understood.\n      Zebrafish (Danio rerio), a common model organism for vertebrate\n      development and gene function, has not previously been characterized as a\n      model system for esophageal epithelial development. In this study, we\n      characterized a piece of non-keratinized stratified squamous epithelium\n      similar to human esophageal epithelium in the upper digestive tract of\n      developing zebrafish. Under the microscope, this piece was detectable at\n      5dpf and became stratified at 7dpf. Expression of esophageal epithelial\n      marker genes (Krt5, P63, Sox2 and Pax9) was detected by\n      immunohistochemistry and in situ hybridization. Knockdown of P63, a gene\n      known to be critical for esophageal epithelium, disrupted the development\n      of this epithelium. With this model system, we found that Pax9 knockdown\n      resulted in loss or disorganization of the squamous epithelium, as well as\n      down-regulation of the differentiation markers Krt4 and Krt5. In summary,\n      we characterized a region of stratified squamous epithelium in the\n      zebrafish upper digestive tract which can be used for functional studies\n      of candidate genes involved in esophageal epithelial biology.",
   "url": "http://localhost:3000/stash/dataset/doi%253A10.15146%252FR3RG6G",
   "identifier": "https://doi.org/10.15146/R3RG6G",
+  "isAccessibleForFree": true,
   "version": 1,
   "keywords": [
     "Zebrafish",
@@ -28,6 +29,8 @@
     "encodingFormat": "application/zip",
     "contentUrl": "http://localhost:3000/api/v2/datasets/doi%253A10.15146%252FR3RG6G/download"
   },
+  "provider": {"@id": "https://datadryad.org"},
+  "publisher": {"@id": "https://datadryad.org", "@type": "Organization", "legalName": "Dryad Digital Repository", "name": "Dryad", "url": "https://datadryad.org"},
   "temporalCoverage": [
     "2016",
     "2015-12-02",

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -46,6 +46,17 @@ module StashEngine
 
     end
 
+    describe :title do
+      it 'gets the correct clean_title' do
+        test_title = 'some test title'
+        resource = create(:resource, title: test_title)
+        expect(resource.clean_title).to eq(test_title)
+
+        resource = create(:resource, title: "Data from: #{test_title}")
+        expect(resource.clean_title).to eq(test_title)
+      end
+    end
+
     describe :tenant do
       it 'returns the resource tenant' do
         tenant = instance_double(Tenant)

--- a/stash/stash_datacite/app/models/stash_datacite/resource/schema_dataset.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/schema_dataset.rb
@@ -16,13 +16,16 @@ module StashDatacite
         'url' => :landing_url,
         'identifier' => :doi_url,
         'version' => :version,
+        'isAccessibleForFree' => :true_val,
         'keywords' => :keywords,
         'creator' => :authors,
         'distribution' => :distribution,
         'temporalCoverage' => :temporal_coverages,
         'spatialCoverage' => :spatial_coverages,
         'citation' => :citation,
-        'license' => :license
+        'license' => :license,
+        'publisher' => :publisher,
+        'provider' => :provider
       }.freeze
 
       def initialize(resource:)
@@ -30,7 +33,7 @@ module StashDatacite
       end
 
       def generate
-        structure = { '@context' => 'http://schema.org', '@type' => 'dataset' }
+        structure = { '@context' => 'http://schema.org', '@type' => 'Dataset' }
         ITEMS_TO_ADD.each_pair do |k, v|
           item = to_item(send(v))
           structure[k] = item if item
@@ -39,6 +42,26 @@ module StashDatacite
       end
 
       private
+
+      def true_val
+        true
+      end
+
+      def publisher
+        {
+          '@id': 'https://datadryad.org',
+          '@type': 'Organization',
+          'legalName': 'Dryad Digital Repository',
+          'name': 'Dryad',
+          'url': 'https://datadryad.org'
+        }.compact
+      end
+
+      def provider
+        {
+          '@id': 'https://datadryad.org'
+        }.compact
+      end
 
       def to_item(value)
         return unless value
@@ -50,7 +73,7 @@ module StashDatacite
       def names
         return [] if @resource.title.blank?
 
-        [@resource.title]
+        [@resource.clean_title]
       end
 
       def descriptions

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -634,6 +634,14 @@ module StashEngine
     end
 
     # -----------------------------------------------------------
+    # Title
+
+    # Title without "Data from:"
+    def clean_title
+      title.delete_prefix('Data from:').strip
+    end
+
+    # -----------------------------------------------------------
     # SOLR actions for this resource
 
     def submit_to_solr

--- a/stash/stash_engine/app/views/stash_engine/landing/show.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/landing/show.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = "Data -- #{@resource.title}" %>
+<% @page_title = "Data -- #{@resource.clean_title}" %>
 <div class="c-columns">
 	<main class="t-landing__main c-columns__content">
 		<% if @user_type == 'privileged' %>


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/807

Adds some fields requested by DataONE. Also removes the "Data from:" in landing page titles, so listings in search engines are cleaner.