### PR TITLE
Mangled the tenants and didn't even seem needed for the test

### DIFF
--- a/spec/models/stash_api/dataset_parser_spec.rb
+++ b/spec/models/stash_api/dataset_parser_spec.rb
@@ -10,14 +10,6 @@ module StashApi
       mock_ror!
       allow(Stash::Doi::IdGen).to receive(:mint_id).and_return('doi:10.5072/dryad.12345678')
 
-      @tenants = StashEngine.tenants
-      StashEngine.tenants = begin
-        tenants = HashWithIndifferentAccess.new
-        tenant_hash = YAML.load_file('spec/data/tenant-example.yml')['test']
-        tenants['exemplia'] = HashWithIndifferentAccess.new(tenant_hash)
-        tenants
-      end
-
       @user = StashEngine::User.create(
         first_name: 'Lisa',
         last_name: 'Muckenhaupt',


### PR DESCRIPTION
I removed this and it fixed test failures in my other tests and also didn't seem needed to begin with since the tests for the dataset_parser_spec still work fine.

I re-setup rspec bisect and had to change it to shell mode and let it run tests for a while to find which class was destroying things.