### PR TITLE
Double encode hash sign if present in a filename

### DIFF
--- a/spec/models/stash_engine/file_upload_spec.rb
+++ b/spec/models/stash_engine/file_upload_spec.rb
@@ -255,6 +255,13 @@ module StashEngine
           'https://merritt.example.com/api/presign-file/ark%3A%2F12345%2F38568/1/producer%2Ffoo.bar?no_redirect=true'
         )
       end
+
+      it 'doubly-encodes any # signs in filenames because otherwise they prematurely cut off in Merritt' do
+        @upload.upload_file_name = '#1 in the world'
+        expect(@upload.merritt_presign_info_url).to eq(
+          'https://merritt.example.com/api/presign-file/ark%3A%2F12345%2F38568/1/producer%2F%25231%20in%20the%20world?no_redirect=true'
+        )
+      end
     end
 
     describe :s3_presigned_url do

--- a/stash/stash_engine/app/models/stash_engine/file_upload.rb
+++ b/stash/stash_engine/app/models/stash_engine/file_upload.rb
@@ -93,9 +93,14 @@ module StashEngine
 
     # the Merritt URL to query in order to get the information on the presigned URL
     def merritt_presign_info_url
+      raise "Filename may not be blank when creating presigned URL" if upload_file_name.blank?
+
+      # The gsub below ensures and number signs get double-encoded because otherwise Merritt cuts them off early.
+      # We can remove the workaround if it changes in Merritt at some point in the future.
+
       domain, local_id = resource.merritt_protodomain_and_local_id
       "#{domain}/api/presign-file/#{local_id}/#{resource.stash_version.merritt_version}/" \
-          "producer%2F#{ERB::Util.url_encode(upload_file_name)}?no_redirect=true"
+          "producer%2F#{ERB::Util.url_encode(upload_file_name.gsub('#', '%23'))}?no_redirect=true"
     end
 
     # this will do the http request to Merritt to get the presigned URL, putting here instead of other classes since it gets

--- a/stash/stash_engine/app/models/stash_engine/file_upload.rb
+++ b/stash/stash_engine/app/models/stash_engine/file_upload.rb
@@ -93,7 +93,7 @@ module StashEngine
 
     # the Merritt URL to query in order to get the information on the presigned URL
     def merritt_presign_info_url
-      raise "Filename may not be blank when creating presigned URL" if upload_file_name.blank?
+      raise 'Filename may not be blank when creating presigned URL' if upload_file_name.blank?
 
       # The gsub below ensures and number signs get double-encoded because otherwise Merritt cuts them off early.
       # We can remove the workaround if it changes in Merritt at some point in the future.


### PR DESCRIPTION
This is related to https://github.com/CDLUC3/mrt-doc/issues/426 .

It seems like the Merritt folks will consider fixing in the future as they begin to release further APIs and can take a more consistent approach. This is a #wontfix from them for now.  Our workaround should allow our users that have number signs in their filenames to still download.

You can test on dev (or wherever by uploading a file with a number sign in it and see that it downloads).  Example: https://dryad-dev.cdlib.org/stash/dataset/doi:10.5072/FK25H7MF7Q