### PR TITLE
Rename software to supporting information

### DIFF
--- a/spec/features/stash_datacite/review_dataset_spec.rb
+++ b/spec/features/stash_datacite/review_dataset_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature 'ReviewDataset', type: :feature do
       expect(page).to have_content('Upload complete')
 
       click_on('Proceed to Review')
-      expect(page).to have_content('Software Files Hosted by Zenodo')
+      expect(page).to have_content('Supporting Information Hosted by Zenodo')
       expect(page).to have_content('favicon.ico')
       expect(page).to have_content('Select license for files')
     end
@@ -93,7 +93,7 @@ RSpec.feature 'ReviewDataset', type: :feature do
       navigate_to_software_upload
 
       click_on('Proceed to Review')
-      expect(page).not_to have_content('Software Files Hosted by Zenodo')
+      expect(page).not_to have_content('Supporting Information Hosted by Zenodo')
       expect(page).not_to have_content('favicon.ico')
       expect(page).not_to have_content('Select license for files')
     end

--- a/spec/support/helpers/dataset_helper.rb
+++ b/spec/support/helpers/dataset_helper.rb
@@ -14,7 +14,7 @@ module DatasetHelper
   end
 
   def navigate_to_software_upload
-    click_link 'Upload Software'
+    click_link 'Upload Supporting Information'
     click_link 'Upload directly'
     expect(page).to have_content('Choose Files')
   end

--- a/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
@@ -32,8 +32,8 @@
 
 <% if @review.software_uploads.count > 0 %>
 	<div>
-		<h3>License and Terms of Service for Software</h3>
-		<p>Software and other files uploaded will be managed and preserved at Zenodo. Your related DOI will be linked to
+		<h3>License and Terms of Service for Supplemental Information</h3>
+		<p>Supplemental Information and other files uploaded will be managed and preserved at Zenodo. Your related DOI will be linked to
 			your dataset. Please select a license from the below dropdown list for your Zenodo deposit. For guidance,
 			check <a href="https://choosealicense.com/" target="_blank">choosealicense.org</a>.</p>
 		<div>

--- a/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
@@ -66,7 +66,7 @@
 
     <% if @review.software_uploads.count > 0 %>
       <%= image_tag('stash_engine/logo_zenodo.png', alt: 'Zenodo logo', class: 'c-review-zenodo') %>
-      <h2 class="o-heading__level2">Software Files Hosted by Zenodo</h2>
+      <h2 class="o-heading__level2">Supporting Information Hosted by Zenodo</h2>
 
       <div class="c-review-files">
         <%= render partial: "stash_engine/file_uploads/show", locals: { file_uploads:  @review.software_uploads } %>
@@ -88,7 +88,7 @@
     <%= render partial: "stash_datacite/licenses/review" %>
 
 <div class="o-dataset-nav">
-  <%= link_to 'Back to Upload Software', stash_url_helpers.up_code_resource_path(@resource), id: 'dashboard_path',
+  <%= link_to 'Back to Upload Supporting Information', stash_url_helpers.up_code_resource_path(@resource), id: 'dashboard_path',
             class: 'o-button__icon-left', role: 'button' %>
 
   <% if @data.blank? # valid data %>

--- a/stash/stash_engine/app/views/stash_engine/resources/upload.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/resources/upload.html.erb
@@ -1,4 +1,4 @@
-<%  @datatype = (params[:action] == 'upload' ? 'Data' : 'Software')
+<%  @datatype = (params[:action] == 'upload' ? 'Data' : 'Supporting Information')
   @page_title = "Upload Your #{@datatype} - Publish and Preserve your Data" %>
 <%= render partial: 'stash_engine/shared/dataset_non_user_editor', locals: {resource: @resource} %>
 <%= render partial: 'stash_engine/shared/dataset_steps_nav' %>
@@ -17,7 +17,7 @@
 <div class="o-dataset-nav">
   <% if params[:controller].end_with?('resources') && params[:action].include?('upload') %>
     <%= link_to 'Back to Describe Dataset', metadata_entry_pages_find_or_create_path(resource_id: params[:id]), class: 'o-button__icon-left', role: 'button', id: 'describe_back' %>
-    <%= link_to 'Proceed to Upload Software', up_code_resource_path(params[:id]), class: 'o-button__icon-right', role: 'button', id: 'proceed_review' %>
+    <%= link_to 'Proceed to Upload Supporting Information', up_code_resource_path(params[:id]), class: 'o-button__icon-right', role: 'button', id: 'proceed_review' %>
   <% else %>
     <%= link_to 'Back to Upload Data', stash_engine.upload_resource_path(params[:id]), class: 'o-button__icon-left', role: 'button', id: 'describe_back' %>
     <%= link_to 'Proceed to Review', review_resource_path(params[:id]), class: 'o-button__icon-right', role: 'button', id: 'proceed_review' %>

--- a/stash/stash_engine/app/views/stash_engine/shared/_dataset_steps_nav.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/shared/_dataset_steps_nav.html.erb
@@ -5,7 +5,7 @@
   <%= link_to 'Upload Data', stash_engine.upload_resource_path(@resource.id),
             class: "c-progress__tab2#{ (params[:controller].end_with?('resources') && params[:action].include?('upload') ? '--active' : '') } js-nav-out" %>
 
-  <%= link_to 'Upload Software', stash_engine.up_code_resource_path(@resource.id),
+  <%= link_to 'Upload Supporting Information', stash_engine.up_code_resource_path(@resource.id),
               class: "c-progress__tab2#{ (params[:controller].end_with?('resources') && params[:action].include?('up_') ? '--active' : '') } js-nav-out" %>
 
   <%= link_to 'Review and Submit', stash_engine.review_resource_path(@resource.id),

--- a/stash/stash_engine/lib/stash/zenodo_software/remote_access_token.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/remote_access_token.rb
@@ -3,10 +3,6 @@ require 'jwt'
 # implementation of https://gist.github.com/slint/54d197ce12757719817b242fbeff0ea3#generating-the-rat
 # testing against https://sandbox.zenodo.org/deposit/638092
 
-
-
-
-
 module Stash
   module ZenodoSoftware
     class RemoteAccessToken
@@ -19,12 +15,12 @@ module Stash
 
       def make_jwt(deposition_id:, filename:)
         payload = {
-            sub: {
-                deposit_id: deposition_id,
-                file: filename,
-                access: 'read'
-            },
-            iat: Time.now.to_i # this is what the docs at https://github.com/jwt/ruby-jwt shows
+          sub: {
+            deposit_id: deposition_id,
+            file: filename,
+            access: 'read'
+          },
+          iat: Time.now.to_i # this is what the docs at https://github.com/jwt/ruby-jwt shows
         }
         headers = { kid: @pat_token_id }
 


### PR DESCRIPTION
This is just renaming "software" to "supporting information" and it seems like Rubocop decided to change something.  I guess we're not going to merge any of this into main for a while.