### PR TITLE
Update API docs on API accounts without ORCIDs

### DIFF
--- a/documentation/apis/adding_api_accounts.md
+++ b/documentation/apis/adding_api_accounts.md
@@ -7,11 +7,12 @@ Dryad so they have a user record and you will want to find their user
 record in the database.
 
 In special cases where the API account will not be attached to a
-single person, we must still create a new user. This can be created
-(e.g. in Rails console) without a specific ORCID, but ensure it does
-have a valid email address so it can receive notifications about the
-datasets. Ensure the account users realize that they will still need
-"normal" ORCID-based accounts to access the Dryad web interface.
+single person, we must still create a new user account. This can be
+created (e.g. in Rails console) without a specific ORCID, but ensure
+it does have a valid email address so it can receive notifications
+about the datasets. Ensure the people who will access the API account
+users understand that they will still need "normal" ORCID-based
+accounts to access the Dryad web interface.
 
 To create an API account:
 1. Log into Dryad with a user that has the superuser role (set the

--- a/documentation/apis/adding_api_accounts.md
+++ b/documentation/apis/adding_api_accounts.md
@@ -10,7 +10,8 @@ In special cases where the API account will not be attached to a
 single person, we must still create a new user. This can be created
 (e.g. in Rails console) without a specific ORCID, but ensure it does
 have a valid email address so it can receive notifications about the
-datasets.
+datasets. Ensure the account users realize that they will still need
+"normal" ORCID-based accounts to access the Dryad web interface.
 
 To create an API account:
 1. Log into Dryad with a user that has the superuser role (set the

--- a/documentation/apis/adding_api_accounts.md
+++ b/documentation/apis/adding_api_accounts.md
@@ -1,9 +1,16 @@
 Adding a New API Account
 ========================
 
-The user requesting the account must have previously logged in to
+Each API account must be associated with a user account. In most
+cases, the user requesting the account will have previously logged in to
 Dryad so they have a user record and you will want to find their user
 record in the database.
+
+In special cases where the API account will not be attached to a
+single person, we must still create a new user. This can be created
+(e.g. in Rails console) without a specific ORCID, but ensure it does
+have a valid email address so it can receive notifications about the
+datasets.
 
 To create an API account:
 1. Log into Dryad with a user that has the superuser role (set the

--- a/documentation/apis/submission.md
+++ b/documentation/apis/submission.md
@@ -3,14 +3,21 @@ The Dryad API now enables submission.  For authentication, it uses an OAuth2 cli
 
 This document gives practical information for working with the API in order to submit a dataset and [fuller API documentation is available](https://datadryad.org/api/v2/docs/index.html).
 
-## Log in to Dryad and request a an application id and secret
+## Obtain a Dryad API account
 
-Before you can submit from the API, you need to log in to Dryad at
-least once to create a user record and (if applicable) associate it
-with your associated campus/organization. 
+Before you can submit from the API, you must have an account for the
+API. It is easiest if you first create an account through the Dryad
+web interface. Dryad staff can then add API capabilities to this
+account. Log in to Dryad at least once to create a user record and (if
+applicable) associate it with your associated campus/organization.
 
-Once you have logged in, please
-[contact us](mailto:help@datadryad.org) to request API access. In your
+In some cases, an API account will be needed that is not attached to a
+single user. In this case, the account will not be associated with an
+ORCID, which means that the API account will not be able to log in to
+the Dryad web interface. We will still need an email address to
+receive notifications associated with the account.
+
+Please [contact us](mailto:help@datadryad.org) to request API access. In your
 request, please specify whether you are associated with an institution
 or journal that is a Dryad member. Dryad developers will then [grant
 you the necessary permissions](adding_api_accounts.md).


### PR DESCRIPTION
Institutions often use role-based accounts for accessing APIs. Updating our API documentation to indicate how this will work within our existing system.