### PR TITLE
Disable extra rails source checking

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :exception, prepend: true
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,8 +38,9 @@ module Dash2
 
     config.active_job.queue_adapter = :delayed_job
 
-    # Temporary workaround to SSL forwarding issues -- we want to reinstate this
-    # if we can get the proper headers in Apache.
+    # Do not compare the origin of HTTP requests with the current state of the request.
+    # Our Apache config changes HTTPS to HTTP when contacting Passenger, so the origin
+    # will not be the same.
     config.action_controller.forgery_protection_origin_check = false
     
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,10 @@ module Dash2
 
     config.active_job.queue_adapter = :delayed_job
 
+    # Temporary workaround to SSL forwarding issues -- we want to reinstate this
+    # if we can get the proper headers in Apache.
+    config.action_controller.forgery_protection_origin_check = false
+    
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
Rails 5.1 introduced stricter checking of HTTP Request objects. The stricter checking is not compatible with our current Apache config, so this disables it.


