### PR TITLE
Add note about system user

### DIFF
--- a/documentation/dryad_install.md
+++ b/documentation/dryad_install.md
@@ -172,6 +172,15 @@ source ../dryad-config/sample_data/sample_record.sql;
 
 To configure where the search enterface draws its data from, modify the dryad app config/blacklight.yml to change the endpoint for the development server.  When running locally, the default server is development.
 
+## Creating the System user
+
+Go into Rails console, and create the default user.
+
+```
+bundle exec rails console
+u=StashEngine::User.create(first_name: 'Dryad', last_name: 'System', id: 0)
+```
+
 ## Testing basic functionality
 
 ### Explore the datasets


### PR DESCRIPTION
Some of our automated tasks assign objects to user 0. In the past, we didn't actually have a user associated with this ID, but as of Rails 5.1, this user is required to be present for the associated objects to validate.

I'm adding a note to the install instructions about creating this user, though I'm not sure this is the best way to handle the requirement. Perhaps we should put this in a rake task that is run when a new database is set up?