### PR TITLE
Hide display for disliked items

### DIFF
--- a/spec/mocks/submission_job.rb
+++ b/spec/mocks/submission_job.rb
@@ -8,12 +8,8 @@ module Mocks
     def mock_submission_job!
       allow_any_instance_of(Stash::Merritt::Repository).to receive(:download_uri_for).and_return(mint_id)
       allow_any_instance_of(Stash::Merritt::Repository).to receive(:update_uri_for).and_return(mint_id)
-      Stash::Merritt::SubmissionJob.prepend(Mocks::SubmissionJob::MonkeyPatch) # a way to override this method
-    end
-
-    module MonkeyPatch
-      def do_submit!
-        sleep 30 # to simulate submission happening, this should be in background thread, so enjoy!
+      allow_any_instance_of(Stash::Merritt::SubmissionJob).to receive(:'do_submit!') do
+        sleep 30
         Stash::Repo::SubmissionResult.success(resource_id: resource_id, request_desc: description, message: 'Success')
       end
     end

--- a/spec/responses/stash_datacite/related_identifiers_controller_spec.rb
+++ b/spec/responses/stash_datacite/related_identifiers_controller_spec.rb
@@ -1,4 +1,3 @@
-
 # We have no real way to test this directly in the UI since setting a related identifier to hidden can't be done in the
 # UI and testing the UI runs in a different process/database which is difficult to manipulate manually.
 module StashDatacite
@@ -6,8 +5,8 @@ module StashDatacite
 
     before(:each) do
       user = StashEngine::User.create(
-          email: 'lmuckenhaupt@example.edu',
-          tenant_id: 'dataone'
+        email: 'lmuckenhaupt@example.edu',
+        tenant_id: 'dataone'
       )
       @resource = create(:resource, user_id: user.id)
       @related_identifier = create(:related_identifier, resource_id: @resource.id, work_type: 'article')

--- a/spec/responses/stash_datacite/related_identifiers_controller_spec.rb
+++ b/spec/responses/stash_datacite/related_identifiers_controller_spec.rb
@@ -1,0 +1,38 @@
+
+# We have no real way to test this directly in the UI since setting a related identifier to hidden can't be done in the
+# UI and testing the UI runs in a different process/database which is difficult to manipulate manually.
+module StashDatacite
+  RSpec.describe AffiliationsController, type: :request do
+
+    before(:each) do
+      user = StashEngine::User.create(
+          email: 'lmuckenhaupt@example.edu',
+          tenant_id: 'dataone'
+      )
+      @resource = create(:resource, user_id: user.id)
+      @related_identifier = create(:related_identifier, resource_id: @resource.id, work_type: 'article')
+    end
+
+    describe 'non-hidden related IDs' do
+      it 'renders a non-hidden related work' do
+        response_code = get "/stash_datacite/related_identifiers/show.js?resource_id=#{@resource.id}", xhr: true
+        expect(response_code).to eq(200)
+
+        body = response.body
+        expect(body).to include('Article')
+        expect(body).to include(@related_identifier.related_identifier)
+      end
+
+      it 'hides a hidden related work' do
+        @related_identifier.update(hidden: true)
+        response_code = get "/stash_datacite/related_identifiers/show.js?resource_id=#{@resource.id}", xhr: true
+        expect(response_code).to eq(200)
+
+        body = response.body
+        expect(body).not_to include('Article')
+        expect(body).not_to include(@related_identifier.related_identifier)
+      end
+
+    end
+  end
+end

--- a/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_landing_related_works.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_landing_related_works.html.erb
@@ -1,5 +1,5 @@
-<% @resource.related_identifiers.select(:work_type).distinct.order(:work_type).each do |wt| %>
-  <% my_ids = @resource.related_identifiers.where(work_type: wt.work_type) %>
+<% @resource.related_identifiers.select(:work_type).where(hidden: false).distinct.order(:work_type).each do |wt| %>
+  <% my_ids = @resource.related_identifiers.where(work_type: wt.work_type).where(hidden: false) %>
   <h3 class="o-heading__level3-related-works"><%= (my_ids.count > 1 ? wt.work_type_friendly_plural : wt.work_type_friendly) %></h3>
   <ul class="o-list-related">
     <% my_ids.each do |r| %>

--- a/stash/stash_datacite/db/migrate/20200922172911_add_hidden_to_stash_datacite_related_identifier.rb
+++ b/stash/stash_datacite/db/migrate/20200922172911_add_hidden_to_stash_datacite_related_identifier.rb
@@ -1,0 +1,5 @@
+class AddHiddenToStashDataciteRelatedIdentifier < ActiveRecord::Migration[5.2]
+  def change
+    add_column :dcs_related_identifiers, :hidden, :boolean, default: false
+  end
+end

--- a/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
@@ -83,7 +83,7 @@ module Stash
       end
 
       def related_identifiers
-        related = @resource.related_identifiers.map do |ri|
+        related = @resource.related_identifiers.where(verified: true).where(hidden: false).map do |ri|
           { relation: ri.relation_type_friendly&.camelize(:lower), identifier: ri.related_identifier }
         end
 


### PR DESCRIPTION
As part of cleanup Daniella wanted to hide many icky related works, but not delete the data completely.  This allows items that are disliked to have `hidden: true` set and they will no longer display on the landing page for the dataset.

Right now this hidden display will be set manually based on our related identifier cleanup.

Added some "requests" tests and just requesting that javascript for that part of the page.

Not sending the bad items (validation or no display) to zenodo since they won't take badly formatted things and also don't want a backdoor to displaying them through their UI when it's replicated.