### PR TITLE
Ui cleanup tweaks, see #878

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,8 +62,8 @@ gem 'http'
 # Development and testing
 
 group :development, :local_dev do
-  gem 'colorize', '~> 0.8'
-  gem 'web-console', '~> 2.0'
+  gem 'colorize'
+  gem 'web-console'
   # gem 'httplog', not needed always, but good for troubleshooting HTTP requests to outside http services from the app
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,7 @@ GEM
     benchmark_methods (0.7)
     bibtex-ruby (5.1.4)
       latex-decode (~> 0.0)
+    bindex (0.8.1)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     blacklight (6.23.0)
@@ -801,11 +802,11 @@ GEM
     unicode_utils (1.4.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    web-console (2.3.0)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
+    web-console (3.7.0)
+      actionview (>= 5.0)
+      activemodel (>= 5.0)
+      bindex (>= 0.4.0)
+      railties (>= 5.0)
     webdrivers (4.4.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -840,7 +841,7 @@ DEPENDENCIES
   capybara
   capybara-screenshot
   coffee-rails (~> 4.1)
-  colorize (~> 0.8)
+  colorize
   database_cleaner
   diffy
   down
@@ -883,7 +884,7 @@ DEPENDENCIES
   therubyracer
   turbolinks
   uglifier (~> 3.0.4)
-  web-console (~> 2.0)
+  web-console
   webdrivers
   webmock
   yui-compressor

--- a/config/environments/local_dev.rb
+++ b/config/environments/local_dev.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :sendmail
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
   # config.active_storage.service = :local     
@@ -70,6 +70,6 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  Rails.application.default_url_options = { host: 'localhost:3000' }
+  Rails.application.default_url_options = { host: 'localhost', port: 3000 }
 
 end

--- a/spec/models/stash_datacite/metadata_entry_spec.rb
+++ b/spec/models/stash_datacite/metadata_entry_spec.rb
@@ -52,7 +52,7 @@ module StashDatacite
           @metadata_entry = MetadataEntry.new(resource, tenant)
           publisher = metadata_entry.instance_variable_get(:@publisher)
           expect(publisher).to be_a(Publisher)
-          expect(publisher.publisher).to eq('DataONE')
+          expect(publisher.publisher).to eq('Dryad')
           expect(publisher.resource_id).to eq(resource.id)
         end
       end

--- a/stash/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser.rb
@@ -165,7 +165,7 @@ module StashApi
       publisher = StashDatacite::Publisher.where(resource_id: @resource.id).first
       return if publisher
 
-      StashDatacite::Publisher.create(publisher: @resource.tenant.short_name, resource_id: @resource.id) if @resource.tenant
+      StashDatacite::Publisher.create(publisher: 'Dryad', resource_id: @resource.id) if @resource.tenant
     end
 
     def ensure_resource_type

--- a/stash/stash_datacite/app/controllers/stash_datacite/landing_mixin.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/landing_mixin.rb
@@ -38,26 +38,21 @@ module StashDatacite
         review.authors,
         review.title_str,
         review.resource_type,
-        version_string_for(resource, review),
         identifier_string_for(resource, review),
-        review.publisher,
         resource.publication_date&.strftime('%Y')
       )
     end
 
-    # rubocop:disable Metrics/ParameterLists
-    def citation(authors, title, resource_type, version, identifier, publisher, publication_year)
+    def citation(authors, title, resource_type, identifier, publication_year)
       citation = []
       citation << h("#{author_citation_format(authors)} (#{publication_year})")
       citation << h(title)
-      citation << h(version == 'v1' ? '' : version)
-      citation << h(publisher.try(:publisher))
+      citation << 'Dryad'
       citation << h(resource_type.try(:resource_type_general_friendly))
       id_str = "https://doi.org/#{identifier}"
       citation << "<a href=\"#{id_str}\">#{h(id_str)}</a>"
       citation.reject(&:blank?).join(', ').html_safe
     end
-    # rubocop:enable Metrics/ParameterLists
 
     def author_citation_format(authors)
       return '' if authors.blank?

--- a/stash/stash_datacite/app/helpers/stash_datacite/resources_helper.rb
+++ b/stash/stash_datacite/app/helpers/stash_datacite/resources_helper.rb
@@ -1,11 +1,10 @@
 module StashDatacite
   module ResourcesHelper
-    def citation(authors, title, resource_type, version, identifier, publisher, publication_year) # rubocop:disable Metrics/ParameterLists
+    def citation(authors, title, resource_type, identifier, publication_year)
       [
         "#{author_citation_format(authors)} (#{publication_year})",
         escape_title(title),
-        escape_version(version),
-        escape_publisher(publisher),
+        'Dryad',
         escape_resource_type(resource_type),
         doi_link(identifier)
       ].reject(&:blank?).join(', ').html_safe

--- a/stash/stash_datacite/app/models/stash_datacite/resource/metadata_entry.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/metadata_entry.rb
@@ -3,9 +3,9 @@
 module StashDatacite
   module Resource
     class MetadataEntry
-      def initialize(resource, tenant)
+      def initialize(resource, _tenant)
         @resource = resource
-        create_publisher(tenant)
+        create_publisher
         ensure_license
         @resource.fill_blank_author!
       end
@@ -108,9 +108,9 @@ module StashDatacite
         @resource.rights.create(rights: license[:name], rights_uri: license[:uri])
       end
 
-      def create_publisher(tenant)
+      def create_publisher
         publisher = Publisher.where(resource_id: @resource.id).first
-        @publisher = publisher.present? ? publisher : Publisher.create(publisher: tenant&.short_name, resource_id: @resource.id)
+        @publisher = publisher.present? ? publisher : Publisher.create(publisher: 'Dryad', resource_id: @resource.id)
       end
     end
   end

--- a/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
@@ -12,9 +12,8 @@
 
     <section class="o-section">
     <%= render partial: "stash_datacite/shared/citations", locals: { authors: @review.authors, title: @review.title_str,
-                         resource_type: @review.resource_type, version: "v#{@resource.version_number}",
+                         resource_type: @review.resource_type,
                          identifier: @resource.identifier.nil? ? nil : "#{@review.identifier.identifier}",
-                         publisher: @review.publisher,
                          publication_year: (@resource.publication_date.present? ? @resource.publication_date.year : @resource.updated_at.year) } %>
     </section>
 

--- a/stash/stash_datacite/app/views/stash_datacite/resources/_show.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/resources/_show.html.erb
@@ -11,9 +11,7 @@
   <%= render partial: "stash_datacite/shared/citations",
              locals: { authors: review.authors, title: review.title_str,
                        resource_type: review.resource_type,
-                       version: resource.stash_version.nil? ? 'v0' : "v#{review.version.version }",
                        identifier: resource.identifier.nil? ? 'DOI' : "#{review.identifier.identifier }",
-                       publisher: review.publisher,
                        publication_year: (resource.publication_date.present? ? resource.publication_date.year : resource.updated_at.year) } %>
   </section>
   <%= render partial: "stash_datacite/descriptions/show", locals: { abstract: review.abstract,

--- a/stash/stash_datacite/app/views/stash_datacite/shared/_citations.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/shared/_citations.html.erb
@@ -1,2 +1,2 @@
 <h2 class="o-heading__level2">Citation</h2>
-<p><%= citation(authors, title, resource_type, version, identifier, publisher, publication_year) %></p>
+<p><%= citation(authors, title, resource_type, identifier, publication_year) %></p>

--- a/stash/stash_engine/app/models/stash_engine/tenant.rb
+++ b/stash/stash_engine/app/models/stash_engine/tenant.rb
@@ -98,7 +98,12 @@ module StashEngine
     end
 
     def full_url(path)
-      URI::HTTPS.build(host: Rails.application.default_url_options[:host], path: path).to_s
+      d = Rails.application.default_url_options
+      if d[:port].blank?
+        URI::HTTPS.build(host: d[:host], path: path).to_s
+      else
+        URI::HTTPS.build(host: d[:host], port: d[:port], path: path).to_s
+      end
     end
 
   end

--- a/stash/stash_engine/app/views/stash_engine/shared/_footer.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/shared/_footer.html.erb
@@ -11,5 +11,5 @@
       <a href="#" class="js-nav-out"><i class="fa fa-envelope-square fa-2x"></i> Subscribe to our mailing list</a>
     </div>
   </div>
-  <p>Copyright (c) 2019 Dryad</p>
+  <p>Copyright (c) <%= Time.new.year %> Dryad</p>
 </footer>

--- a/stash/stash_engine/app/views/stash_engine/shared/_footer.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/shared/_footer.html.erb
@@ -8,7 +8,6 @@
     <div class="c-footer__social-group">
       <a href="https://twitter.com/datadryad" class="js-nav-out"><i class="fa fa-twitter-square fa-2x"></i> Follow us on Twitter</a>
       <a href="https://blog.datadryad.org/" class="js-nav-out"><i class="fa fa-rss-square fa-2x"></i> Check out our Blog</a>
-      <a href="#" class="js-nav-out"><i class="fa fa-envelope-square fa-2x"></i> Subscribe to our mailing list</a>
     </div>
   </div>
   <p>Copyright (c) <%= Time.new.year %> Dryad</p>


### PR DESCRIPTION
https://github.com/CDL-Dryad/dryad-product-roadmap/issues/878

Things in this PR.

- Unlocked and updated web-console and colorize version locks in Gemfile because at least web-console was erroring with Rails 5.2 and our installed gems when trying to display error messages in development mode.
- Added localhost and port for local-dev copy of configuration environment.
- DataCite publisher always set to Dryad as well as display of Publisher always showing Dryad (and updated tests, and places it's set).
- Removing version and publisher from calls to create citation because publisher is always Dryad and version is never shown in citation now.
- Footer copyright year always shows current year.
- Subscribe to mailing list removed since we didn't have any link for that.

After we release this code then I put in a separate ticket for updating all publishers to Dryad and re-submitting all metadata to DataCite/EZID at that point.

BTW, this is the record from a newly submitted record in EZID for DataCite metadata showing Dryad (even though submitted as UCOP tenant) https://ezid.cdlib.org/id/doi:10.5072/FK2TD9WW48 .