### PR TITLE
Unrevert the revert commit from months ago for counter stats from live DataCite

### DIFF
--- a/spec/data/mdc-usage.json
+++ b/spec/data/mdc-usage.json
@@ -1,125 +1,476 @@
 {
-  "data": [],
+  "data": [
+    {
+      "id": "9459a75c-a45f-49f0-8e96-94cce0d7c5fd",
+      "type": "events",
+      "attributes": {
+        "subj-id": "https://api.datacite.org/reports/bd4082c3-f1ac-4202-9cd9-fa951b8fda42",
+        "obj-id": "https://doi.org/10.5061/dryad.234",
+        "source-id": "datacite-usage",
+        "relation-type-id": "unique-dataset-requests-regular",
+        "total": 67,
+        "message-action": "create",
+        "source-token": "43ba99ae-5cf0-11e8-9c2d-fa7ae01bbebc",
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "occurred-at": "2011-02-01T00:00:00.000Z",
+        "timestamp": "2019-09-07T23:53:57.716Z"
+      }
+    },
+    {
+      "id": "50823356-0e53-4481-8f22-7521c73e1643",
+      "type": "events",
+      "attributes": {
+        "subj-id": "https://api.datacite.org/reports/bd4082c3-f1ac-4202-9cd9-fa951b8fda42",
+        "obj-id": "https://doi.org/10.5061/dryad.234",
+        "source-id": "datacite-usage",
+        "relation-type-id": "unique-dataset-investigations-regular",
+        "total": 79,
+        "message-action": "create",
+        "source-token": "43ba99ae-5cf0-11e8-9c2d-fa7ae01bbebc",
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "occurred-at": "2011-02-01T00:00:00.000Z",
+        "timestamp": "2019-09-07T23:53:58.040Z"
+      }
+    },
+    {
+      "id": "117477c5-ffb7-41f8-b9bd-0b187bd515ad",
+      "type": "events",
+      "attributes": {
+        "subj-id": "https://api.datacite.org/reports/bd4082c3-f1ac-4202-9cd9-fa951b8fda42",
+        "obj-id": "https://doi.org/10.5061/dryad.234",
+        "source-id": "datacite-usage",
+        "relation-type-id": "unique-dataset-requests-machine",
+        "total": 13,
+        "message-action": "create",
+        "source-token": "43ba99ae-5cf0-11e8-9c2d-fa7ae01bbebc",
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "occurred-at": "2011-02-01T00:00:00.000Z",
+        "timestamp": "2019-09-07T23:54:00.286Z"
+      }
+    },
+    {
+      "id": "1a3f307b-c7c5-4ff3-a001-2081fa9ebc0f",
+      "type": "events",
+      "attributes": {
+        "subj-id": "https://api.datacite.org/reports/bd4082c3-f1ac-4202-9cd9-fa951b8fda42",
+        "obj-id": "https://doi.org/10.5061/dryad.234",
+        "source-id": "datacite-usage",
+        "relation-type-id": "unique-dataset-investigations-machine",
+        "total": 13,
+        "message-action": "create",
+        "source-token": "43ba99ae-5cf0-11e8-9c2d-fa7ae01bbebc",
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "occurred-at": "2011-02-01T00:00:00.000Z",
+        "timestamp": "2019-09-07T23:54:00.317Z"
+      }
+    },
+    {
+      "id": "78cac572-06c6-4205-9f3f-4cecb022c8d2",
+      "type": "events",
+      "attributes": {
+        "subj-id": "https://api.datacite.org/reports/94c5fc89-8574-42b5-8d33-799d31ce7ed1",
+        "obj-id": "https://doi.org/10.5061/dryad.234",
+        "source-id": "datacite-usage",
+        "relation-type-id": "unique-dataset-requests-machine",
+        "total": 10,
+        "message-action": "create",
+        "source-token": "43ba99ae-5cf0-11e8-9c2d-fa7ae01bbebc",
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "occurred-at": "2011-05-01T00:00:00.000Z",
+        "timestamp": "2019-09-08T00:03:44.227Z"
+      }
+    },
+    {
+      "id": "b96924de-1bc4-4840-9ae8-aaa94b436a4a",
+      "type": "events",
+      "attributes": {
+        "subj-id": "https://api.datacite.org/reports/94c5fc89-8574-42b5-8d33-799d31ce7ed1",
+        "obj-id": "https://doi.org/10.5061/dryad.234",
+        "source-id": "datacite-usage",
+        "relation-type-id": "unique-dataset-requests-regular",
+        "total": 112,
+        "message-action": "create",
+        "source-token": "43ba99ae-5cf0-11e8-9c2d-fa7ae01bbebc",
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "occurred-at": "2011-05-01T00:00:00.000Z",
+        "timestamp": "2019-09-08T00:03:44.295Z"
+      }
+    },
+    {
+      "id": "0d302438-df59-4ac1-810a-0642270e34ee",
+      "type": "events",
+      "attributes": {
+        "subj-id": "https://api.datacite.org/reports/94c5fc89-8574-42b5-8d33-799d31ce7ed1",
+        "obj-id": "https://doi.org/10.5061/dryad.234",
+        "source-id": "datacite-usage",
+        "relation-type-id": "unique-dataset-investigations-regular",
+        "total": 127,
+        "message-action": "create",
+        "source-token": "43ba99ae-5cf0-11e8-9c2d-fa7ae01bbebc",
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "occurred-at": "2011-05-01T00:00:00.000Z",
+        "timestamp": "2019-09-08T00:03:44.316Z"
+      }
+    },
+    {
+      "id": "454f21fe-5bae-4fe4-afe4-cb5607f5ee5d",
+      "type": "events",
+      "attributes": {
+        "subj-id": "https://api.datacite.org/reports/94c5fc89-8574-42b5-8d33-799d31ce7ed1",
+        "obj-id": "https://doi.org/10.5061/dryad.234",
+        "source-id": "datacite-usage",
+        "relation-type-id": "unique-dataset-investigations-machine",
+        "total": 10,
+        "message-action": "create",
+        "source-token": "43ba99ae-5cf0-11e8-9c2d-fa7ae01bbebc",
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "occurred-at": "2011-05-01T00:00:00.000Z",
+        "timestamp": "2019-09-08T00:03:46.687Z"
+      }
+    },
+    {
+      "id": "b23e1eeb-f44a-4486-b875-800bb3b05f0f",
+      "type": "events",
+      "attributes": {
+        "subj-id": "https://api.datacite.org/reports/b0fa6cb1-a859-41d0-8722-ebd257761c6b",
+        "obj-id": "https://doi.org/10.5061/dryad.234",
+        "source-id": "datacite-usage",
+        "relation-type-id": "unique-dataset-requests-regular",
+        "total": 107,
+        "message-action": "create",
+        "source-token": "43ba99ae-5cf0-11e8-9c2d-fa7ae01bbebc",
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "occurred-at": "2011-08-01T00:00:00.000Z",
+        "timestamp": "2019-09-08T00:15:23.123Z"
+      }
+    },
+    {
+      "id": "6389b9f7-acca-42b0-8743-87485c488ca3",
+      "type": "events",
+      "attributes": {
+        "subj-id": "https://api.datacite.org/reports/b0fa6cb1-a859-41d0-8722-ebd257761c6b",
+        "obj-id": "https://doi.org/10.5061/dryad.234",
+        "source-id": "datacite-usage",
+        "relation-type-id": "unique-dataset-investigations-regular",
+        "total": 119,
+        "message-action": "create",
+        "source-token": "43ba99ae-5cf0-11e8-9c2d-fa7ae01bbebc",
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "occurred-at": "2011-08-01T00:00:00.000Z",
+        "timestamp": "2019-09-08T00:15:23.481Z"
+      }
+    }
+  ],
   "meta": {
-    "total": 19,
-    "total-pages": 0,
+    "total": 308,
+    "total-pages": 31,
     "page": 1,
     "sources": [
       {
         "id": "datacite-usage",
         "title": "DataCite Usage Stats",
-        "count": 19
+        "count": 308
       }
     ],
     "prefixes": [
       {
-        "id": "10.6071",
-        "title": "10.6071",
-        "count": 19
+        "id": "10.5061",
+        "title": "10.5061",
+        "count": 308
       }
     ],
     "citation-types": [],
     "relation-types": [
       {
-        "id": "unique-dataset-investigations-regular",
-        "title": "unique-dataset-investigations-regular",
-        "count": 172.0,
+        "id": "unique-dataset-requests-regular",
+        "title": "unique-dataset-requests-regular",
+        "count": 80,
         "year-months": [
           {
-            "id": "2018-04",
-            "title": "April 2018",
-            "sum": 16.0
+            "id": "2020-06",
+            "title": "2020-06",
+            "sum": 1
           },
           {
-            "id": "2018-05",
-            "title": "May 2018",
-            "sum": 4.0
+            "id": "2020-05",
+            "title": "2020-05",
+            "sum": 1
           },
           {
-            "id": "2018-06",
-            "title": "June 2018",
-            "sum": 18.0
+            "id": "2020-04",
+            "title": "2020-04",
+            "sum": 1
           },
           {
-            "id": "2018-07",
-            "title": "July 2018",
-            "sum": 5.0
+            "id": "2020-03",
+            "title": "2020-03",
+            "sum": 1
           },
           {
-            "id": "2018-08",
-            "title": "August 2018",
-            "sum": 16.0
+            "id": "2020-02",
+            "title": "2020-02",
+            "sum": 1
           },
           {
-            "id": "2019-02",
-            "title": "February 2019",
-            "sum": 7.0
+            "id": "2020-01",
+            "title": "2020-01",
+            "sum": 1
           },
           {
-            "id": "2019-03",
-            "title": "March 2019",
-            "sum": 12.0
+            "id": "2019-11",
+            "title": "2019-11",
+            "sum": 1
           },
           {
-            "id": "2019-04",
-            "title": "April 2019",
-            "sum": 10.0
+            "id": "2019-10",
+            "title": "2019-10",
+            "sum": 1
           },
           {
             "id": "2019-05",
-            "title": "May 2019",
-            "sum": 24.0
+            "title": "2019-05",
+            "sum": 1
           },
           {
-            "id": "2019-06",
-            "title": "June 2019",
-            "sum": 52.0
-          },
-          {
-            "id": "2019-07",
-            "title": "July 2019",
-            "sum": 8.0
+            "id": "2019-04",
+            "title": "2019-04",
+            "sum": 1
           }
         ]
       },
       {
-        "id": "unique-dataset-requests-regular",
-        "title": "unique-dataset-requests-regular",
-        "count": 6.0,
+        "id": "unique-dataset-investigations-regular",
+        "title": "unique-dataset-investigations-regular",
+        "count": 79,
         "year-months": [
           {
-            "id": "2018-04",
-            "title": "April 2018",
-            "sum": 4.0
+            "id": "2020-06",
+            "title": "2020-06",
+            "sum": 1
           },
           {
-            "id": "2019-02",
-            "title": "February 2019",
-            "sum": 1.0
+            "id": "2020-05",
+            "title": "2020-05",
+            "sum": 1
           },
           {
-            "id": "2019-07",
-            "title": "July 2019",
-            "sum": 1.0
+            "id": "2020-04",
+            "title": "2020-04",
+            "sum": 1
+          },
+          {
+            "id": "2020-03",
+            "title": "2020-03",
+            "sum": 1
+          },
+          {
+            "id": "2020-02",
+            "title": "2020-02",
+            "sum": 1
+          },
+          {
+            "id": "2020-01",
+            "title": "2020-01",
+            "sum": 1
+          },
+          {
+            "id": "2019-10",
+            "title": "2019-10",
+            "sum": 1
+          },
+          {
+            "id": "2019-09",
+            "title": "2019-09",
+            "sum": 1
+          },
+          {
+            "id": "2019-05",
+            "title": "2019-05",
+            "sum": 1
+          },
+          {
+            "id": "2019-04",
+            "title": "2019-04",
+            "sum": 1
           }
         ]
       },
       {
         "id": "unique-dataset-investigations-machine",
         "title": "unique-dataset-investigations-machine",
-        "count": 2.0,
+        "count": 78,
         "year-months": [
           {
-            "id": "2018-08",
-            "title": "August 2018",
-            "sum": 2.0
+            "id": "2020-06",
+            "title": "2020-06",
+            "sum": 1
+          },
+          {
+            "id": "2020-05",
+            "title": "2020-05",
+            "sum": 1
+          },
+          {
+            "id": "2020-04",
+            "title": "2020-04",
+            "sum": 1
+          },
+          {
+            "id": "2020-03",
+            "title": "2020-03",
+            "sum": 1
+          },
+          {
+            "id": "2020-02",
+            "title": "2020-02",
+            "sum": 1
+          },
+          {
+            "id": "2020-01",
+            "title": "2020-01",
+            "sum": 1
+          },
+          {
+            "id": "2019-12",
+            "title": "2019-12",
+            "sum": 1
+          },
+          {
+            "id": "2019-11",
+            "title": "2019-11",
+            "sum": 1
+          },
+          {
+            "id": "2019-05",
+            "title": "2019-05",
+            "sum": 1
+          },
+          {
+            "id": "2019-04",
+            "title": "2019-04",
+            "sum": 1
+          }
+        ]
+      },
+      {
+        "id": "unique-dataset-requests-machine",
+        "title": "unique-dataset-requests-machine",
+        "count": 71,
+        "year-months": [
+          {
+            "id": "2019-05",
+            "title": "2019-05",
+            "sum": 1
+          },
+          {
+            "id": "2019-04",
+            "title": "2019-04",
+            "sum": 1
+          },
+          {
+            "id": "2019-02",
+            "title": "2019-02",
+            "sum": 1
+          },
+          {
+            "id": "2019-01",
+            "title": "2019-01",
+            "sum": 1
+          },
+          {
+            "id": "2018-12",
+            "title": "2018-12",
+            "sum": 1
+          },
+          {
+            "id": "2018-11",
+            "title": "2018-11",
+            "sum": 1
+          },
+          {
+            "id": "2018-05",
+            "title": "2018-05",
+            "sum": 1
+          },
+          {
+            "id": "2018-03",
+            "title": "2018-03",
+            "sum": 1
+          },
+          {
+            "id": "2018-02",
+            "title": "2018-02",
+            "sum": 1
+          },
+          {
+            "id": "2018-01",
+            "title": "2018-01",
+            "sum": 1
+          }
+        ]
+      }
+    ],
+    "registrants": [
+      {
+        "id": "datacite.dryad.dryad",
+        "title": "datacite.dryad.dryad",
+        "count": 254,
+        "years": [
+          {
+            "id": "2020",
+            "title": "2020",
+            "sum": 18
+          },
+          {
+            "id": "2019",
+            "title": "2019",
+            "sum": 22
+          },
+          {
+            "id": "2018",
+            "title": "2018",
+            "sum": 26
+          },
+          {
+            "id": "2017",
+            "title": "2017",
+            "sum": 46
+          },
+          {
+            "id": "2016",
+            "title": "2016",
+            "sum": 40
+          },
+          {
+            "id": "2015",
+            "title": "2015",
+            "sum": 48
+          },
+          {
+            "id": "2014",
+            "title": "2014",
+            "sum": 22
+          },
+          {
+            "id": "2013",
+            "title": "2013",
+            "sum": 1
+          },
+          {
+            "id": "2012",
+            "title": "2012",
+            "sum": 4
+          },
+          {
+            "id": "2011",
+            "title": "2011",
+            "sum": 20
           }
         ]
       }
     ]
   },
   "links": {
-    "self": "https://api.datacite.org/events?mailto=scott.fisher%40ucop.edu\u0026source-id=datacite-usage\u0026doi=10.6071%2Fm3rp49\u0026page%5Bsize%5D=0\u0026rows\u0026relation-type-id=unique-dataset-investigations-regular%2Cunique-dataset-investigations-machine%2Cunique-dataset-requests-regular%2Cunique-dataset-requests-machine",
-    "next": "https://api.datacite.org/events?doi=10.6071%2Fm3rp49\u0026page%5Bnumber%5D=2\u0026page%5Bsize%5D=0\u0026relation-type-id=unique-dataset-investigations-regular%2Cunique-dataset-investigations-machine%2Cunique-dataset-requests-regular%2Cunique-dataset-requests-machine\u0026source-id=datacite-usage"
+    "self": "https://api.datacite.org/events?doi=10.5061%2Fdryad.234&page%5Bnumber%5D=1&page%5Bsize%5D=10&source-id=datacite-usage&relation-type-id=unique-dataset-investigations-regular,unique-dataset-investigations-machine,unique-dataset-requests-regular,unique-dataset-requests-machine"
   }
 }

--- a/spec/features/stash_engine/landing_spec.rb
+++ b/spec/features/stash_engine/landing_spec.rb
@@ -13,6 +13,7 @@ RSpec.feature 'Landing', type: :feature, js: true do
   include Mocks::Ror
   include Mocks::Stripe
   include Mocks::Tenant
+  include Mocks::Counter
 
   before(:each) do
     # kind of crazy to mock all this, but creating identifiers and the curation activity of published triggers all sorts of stuff
@@ -22,6 +23,7 @@ RSpec.feature 'Landing', type: :feature, js: true do
     mock_datacite!
     mock_stripe!
     mock_tenant!
+    mock_counter!
 
     # below will create @identifier, @resource, @user and the basic required things for an initial version of a dataset
     create_basic_dataset!
@@ -29,6 +31,7 @@ RSpec.feature 'Landing', type: :feature, js: true do
     @resource.current_resource_state.update(resource_state: 'submitted')
     @resource.reload
     @token = create(:download_token, resource_id: @resource.id, available: Time.new + 5.minutes.to_i)
+    create(:counter_stat, identifier_id: @resource.identifier.id)
   end
 
   it 'shows popup for download assembly progress and allows it to close' do

--- a/spec/mocks/counter.rb
+++ b/spec/mocks/counter.rb
@@ -1,0 +1,39 @@
+module Mocks
+
+  module Counter
+    def mock_counter!
+      json =
+        {
+          data: [
+            { "id": '9459a75c-a45f-49f0-8e96-94cce0d7c5fd',
+              "type": 'events',
+              "attributes": {
+                "subj-id": 'https://api.datacite.org/reports/bd4082c3-f1ac-4202-9cd9-fa951b8fda42',
+                "obj-id": 'https://doi.org/10.5061/dryad.234',
+                "source-id": 'datacite-usage',
+                "relation-type-id": 'unique-dataset-requests-regular',
+                "total": 67,
+                "message-action": 'create',
+                "source-token": '43ba99ae-5cf0-11e8-9c2d-fa7ae01bbebc',
+                "license": 'https://creativecommons.org/publicdomain/zero/1.0/',
+                "occurred-at": '2011-02-01T00:00:00.000Z',
+                "timestamp": '2019-09-07T23:53:57.716Z'
+              } }
+          ],
+          "links": {
+            "self": 'https://api.datacite.org/events?doi=10.5061%2Fdryad.234&page%5Bnumber%5D=1&page%5Bsize%5D=10&source-id=datacite-usage&relation-type-id=unique-dataset-investigations-regular,unique-dataset-investigations-machine,unique-dataset-requests-regular,unique-dataset-requests-machine',
+            "next": 'https://api.datacite.org/events?doi=10.5061%2Fdryad.234&page%5Bnumber%5D=2&page%5Bsize%5D=10&relation-type-id=unique-dataset-investigations-regular%2Cunique-dataset-investigations-machine%2Cunique-dataset-requests-regular%2Cunique-dataset-requests-machine&source-id=datacite-usage'
+          }
+        }.to_json
+
+      stub_request(:get, %r{api\.datacite\.org/events})
+        .with(
+          headers: {
+            'Connection' => 'close',
+            'Host' => 'api.datacite.org'
+          }
+        )
+        .to_return(status: 200, body: json, headers: { 'Content-Type' => 'application/json' })
+    end
+  end
+end

--- a/spec/models/stash/event_data/citations_spec.rb
+++ b/spec/models/stash/event_data/citations_spec.rb
@@ -12,7 +12,6 @@ module Stash
             &relation-type-id=cites,describes,is-supplemented-by,references,compiles,reviews,requires,has-metadata,documents,is-source-of}x)
           .with(
             headers: {
-              'Accept' => '*/*',
               'Host' => 'api.datacite.org'
             }
           )
@@ -24,7 +23,6 @@ module Stash
             is-derived-from,is-required-by&subj-id=https://doi.org/10.6071/m3rp49}x)
           .with(
             headers: {
-              'Accept' => '*/*',
               'Host' => 'api.datacite.org'
             }
           )

--- a/spec/models/stash/event_data/usage_spec.rb
+++ b/spec/models/stash/event_data/usage_spec.rb
@@ -8,10 +8,9 @@ module Stash
         @usage = Usage.new(doi: 'doi:10.6071/m3rp49')
         WebMock.disable_net_connect!(allow_localhost: true)
 
-        stub_request(:get, 'https://api.datacite.org/events?doi=10.6071/m3rp49&mailto=scott.fisher@ucop.edu&page%5Bsize%5D=0&relation-type-id=unique-dataset-investigations-regular,unique-dataset-investigations-machine,unique-dataset-requests-regular,unique-dataset-requests-machine&rows&source-id=datacite-usage')
+        stub_request(:get, %r{api\.datacite\.org/events})
           .with(
             headers: {
-              'Accept' => '*/*',
               'Host' => 'api.datacite.org'
             }
           )
@@ -27,11 +26,11 @@ module Stash
 
       describe :counts do
         it 'calculates unique investigations count' do
-          expect(@usage.unique_dataset_investigations_count).to eq(174)
+          expect(@usage.unique_dataset_investigations_count).to eq(348)
         end
 
         it 'calculates unique requests count' do
-          expect(@usage.unique_dataset_requests_count).to eq(6)
+          expect(@usage.unique_dataset_requests_count).to eq(309)
         end
       end
     end

--- a/stash/stash_engine/app/models/stash_engine/counter_stat.rb
+++ b/stash/stash_engine/app/models/stash_engine/counter_stat.rb
@@ -3,22 +3,22 @@ module StashEngine
     belongs_to :identifier, class_name: 'StashEngine::Identifier'
 
     # this class wraps around some database accessors to cache them so we don't query the same stats more than once
-    # per day because that is the max time that we update stats
+    # per week
 
-    # all these "check" methods may be obsolete if we do scripts for population of everything ahead.  See note
-    # above update_if_necessary for details of our fun with datacite.
+    # all these "check" methods may be obsolete if we do scripts for population of everything ahead
+    # and then we could just pull from database
     def check_unique_investigation_count
-      # update_if_necessary
+      update_if_necessary
       unique_investigation_count
     end
 
     def check_unique_request_count
-      # update_if_necessary
+      update_if_necessary
       unique_request_count
     end
 
     def check_citation_count
-      # update_if_necessary
+      update_if_necessary
       citation_count
     end
 
@@ -40,25 +40,24 @@ module StashEngine
     # or how about this one? doi:10.7272/Q6Z60KZD
     # or this one has machine hits, I think.  doi:10.6086/D1H59V
     #
-    # but unfortunately, we can really only display stats against production
-    #
-    # We are no longer using this until we have everything working with DataCite correctly.
-    # Also we are probably moving to a script to populate citations and data ahead since they want them as part of instant reporting.
-    # Will leave in for now, but can probably be removed if that is the permanent way we do things.
+    # but unfortunately, we can really only display stats against production, because that is where stats are submitted
     def update_if_necessary
       # we should have a counter stat already if it got to this class
       # only update stats if it's a later calendar week than this record was updated
       return unless new_record? || updated_at.nil? || calendar_week(Time.new) > calendar_week(updated_at)
 
       # do no update the usage data until we can successfully get all of our reports in to DataCite in order to pull them back
-      # update_usage!
-      # update_citation_count!
+      update_usage!
+      update_citation_count!
       self.updated_at = Time.new.utc # seem to need this for some reason, since not always updating automatically
       save!
     end
 
     def update_usage!
       usage = Stash::EventData::Usage.new(doi: identifier.identifier)
+      # only update if usage going up, otherwise something is wrong and don't update
+      return if usage.unique_dataset_investigations_count < unique_investigation_count
+
       self.unique_investigation_count = usage.unique_dataset_investigations_count
       self.unique_request_count = usage.unique_dataset_requests_count
     end

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -67,7 +67,7 @@ module StashEngine
     # https://stackoverflow.com/questions/3808782/rails-best-practice-how-to-create-dependent-has-one-relations
     def counter_stat
       super || build_counter_stat(citation_count: 0, unique_investigation_count: 0, unique_request_count: 0,
-                                  created_at: Time.new.utc - 1.day, updated_at: Time.new.utc - 1.day)
+                                  created_at: Time.new.utc - 7.days, updated_at: Time.new.utc - 7.days)
     end
 
     # gets citations for this identifier w/ citation class

--- a/stash/stash_engine/lib/stash/event_data.rb
+++ b/stash/stash_engine/lib/stash/event_data.rb
@@ -1,9 +1,14 @@
 # EventData is the DataCite API for getting stats about citations and usage.
 # They currently do not have totals so we need to get large swaths of data and add it up on the client side instead
 # of doing it a database where it is probably easier and more efficient.
+require 'http'
+require 'cgi'
 
 module Stash
   module EventData
+
+    class QueryFailure < RuntimeError; end
+
     Dir.glob(File.expand_path('event_data/*.rb', __dir__)).sort.each(&method(:require))
 
     TIME_BETWEEN_RETRIES = 1
@@ -14,23 +19,37 @@ module Stash
     # These methods are mixed in to citations and usage classes
     protected
 
-    def generic_query(params:)
-      hash = { 'mailto' => @email } # this was for crossref, but doesn't hurt for DataCite so they can contact us if there are problems
-      response = make_reliable { RestClient.get @base_url, params: hash.merge(params) }
-      JSON.parse(response.body)
+    def generic_query(url:, params: {})
+      http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
+        .timeout(connect: 60, read: 60).timeout(60).follow(max_hops: 10)
+
+      # get any pre-existing hash off query-part of url
+      uri_obj = URI.parse(url)
+      existing_params = CGI.parse(uri_obj.query || '')
+      existing_params.each { |key, val| existing_params[key] = val.first } # because CGI makes every value into an array
+
+      uri_begin = "#{uri_obj.scheme}://#{uri_obj.host}:#{uri_obj.port}#{uri_obj.path}"
+
+      hash = { 'mailto' => @email }.merge(existing_params)
+      r = make_reliable { http.get uri_begin, params: hash.merge(params) }
+
+      resp = r.parse if r.headers['content-type'].start_with?('application/json') && r.code != 204 # 204 is no-content
+      resp = resp.with_indifferent_access if resp.class == Hash
+      resp
     end
 
     def make_reliable
-      retries = 5
-      begin
-        yield
-      rescue RestClient::InternalServerError => e
-        raise e if retries < 1
+      resp = nil
+      4.downto(0) do |my_retry|
+        resp = yield
+        return resp if resp.status.success?
+      rescue HTTP::Error, JSON::ParserError => e
+        raise QueryFailure, "Error from HTTP #{resp&.uri}\nOriginal error: #{e}\n#{e.backtrace.join("\n")}" if my_retry < 1
 
-        retries -= 1
         sleep TIME_BETWEEN_RETRIES
-        retry
       end
+      # if it has tried 5 times without success, then raise error
+      raise QueryFailure, "Error from HTTP #{resp&.uri} -- got status code #{resp&.status&.code}"
     end
   end
 end

--- a/stash/stash_engine/lib/stash/event_data/citations.rb
+++ b/stash/stash_engine/lib/stash/event_data/citations.rb
@@ -1,4 +1,4 @@
-require 'rest-client'
+require 'http'
 require 'json'
 require 'cgi'
 
@@ -29,10 +29,12 @@ module Stash
       # response.headers -- includes :content_type=>"application/json;charset=UTF-8"
       def results
         params = { 'page[size]': 10_000 }
-        result1 = generic_query(params: params.merge('obj-id': "#{DATACITE_URL}#{@doi}", 'relation-type-id': OTHERS_CITING_ME.join(',')))
+        result1 = generic_query(url: @base_url,
+                                params: params.merge('obj-id': "#{DATACITE_URL}#{@doi}", 'relation-type-id': OTHERS_CITING_ME.join(',')))
         array1 = result1['data'].map { |i| i['attributes']['subj-id'] }
 
-        result2 = generic_query(params: params.merge('subj-id': "#{DATACITE_URL}#{@doi}", 'relation-type-id': ME_CLAIMING_CITATION.join(',')))
+        result2 = generic_query(url: @base_url,
+                                params: params.merge('subj-id': "#{DATACITE_URL}#{@doi}", 'relation-type-id': ME_CLAIMING_CITATION.join(',')))
         array2 = result2['data'].map { |i| i['attributes']['obj-id'] }
 
         (array1 | array2) # returns the union of two sets, which deduplicates identical items, even if in the same original array

--- a/stash/stash_engine/lib/stash/event_data/usage.rb
+++ b/stash/stash_engine/lib/stash/event_data/usage.rb
@@ -1,6 +1,8 @@
-require 'rest-client'
 require 'json'
 require 'cgi'
+
+# some fun datasets to test: doi:10.5061/dryad.234, 10.7272/Q6BG2KWF, 10.5061/dryad.1k84r, 10.5061/dryad.m93f6, 10.7272/Q6H41PB7,
+# 10.5061/dryad.2343k, 10.5061/dryad.070jc, 10.5061/dryad.8j60q, 10.5061/dryad.kd00n, 10.5061/dryad.6rd6f
 
 module Stash
   module EventData
@@ -25,7 +27,7 @@ module Stash
       end
 
       def self.ping
-        RestClient.get HEARTBEAT_URL
+        HTTP.get(HEARTBEAT_URL)
       end
 
       # types of stats
@@ -44,8 +46,8 @@ module Stash
 
       def unique_dataset_investigations_count
         stats.inject(0) do |sum, item|
-          if UNIQUE_INVESTIGATIONS.include?(item['id'])
-            sum + item['count'].to_i
+          if UNIQUE_INVESTIGATIONS.include?(item[:attributes]['relation-type-id'])
+            sum + item[:attributes][:total]
           else
             sum
           end
@@ -54,8 +56,8 @@ module Stash
 
       def unique_dataset_requests_count
         stats.inject(0) do |sum, item|
-          if UNIQUE_REQUESTS.include?(item['id'])
-            sum + item['count'].to_i
+          if UNIQUE_REQUESTS.include?(item[:attributes]['relation-type-id'])
+            sum + item[:attributes][:total]
           else
             sum
           end
@@ -63,14 +65,27 @@ module Stash
       end
 
       def query
-        query_result = generic_query(params:
-          { 'source-id' => 'datacite-usage', 'doi' => @doi, 'page[size]' => 0, 'rows' => nil,
+        data_results = []
+
+        query_result = generic_query(url: @base_url, params:
+          { 'source-id' => 'datacite-usage', 'doi' => @doi, 'page[size]' => 500,
             'relation-type-id' => (UNIQUE_INVESTIGATIONS + UNIQUE_REQUESTS).join(',') })
-        query_result['meta']['relation-types'] || []
-      rescue RestClient::ExceptionWithResponse => e
+
+        data_results.concat(query_result[:data])
+
+        # if this doesn't contain full set of results, then keep going to the next page and adding them
+        while query_result[:links][:next].present?
+          query_result = generic_query(url: query_result[:links][:next])
+          data_results.concat(query_result[:data])
+        end
+
+        # it looks like we actually want ['data']['attributes'] -- relation-type-id gives type,
+        # total -- number, occurred-at is month
+        data_results || []
+      rescue Stash::EventData::QueryFailure => e
         logger.error('DataCite event-data error')
         logger.error("#{Time.new.utc} Could not get response from DataCite event data source-id=datacite-usage&doi=#{CGI.escape(@doi)}")
-        logger.error("#{Time.new.utc} #{e}")
+        logger.error("#{Time.new.utc} #{e}\n#{e.backtrace.join("\n")}")
         []
       end
     end


### PR DESCRIPTION
This was a PR that I worked on in August but then Daniella said she didn't want it going live yet, so had to do a revert patch to take it out.  Now I'm doing a revert on the revert.

To test that it pulls from DataCite and not out of our database you can go to a record like /stash/dataset/doi:10.5061/dryad.3bc76 (against development).  Then find the identifier_Id (1460) in the database.  Then open the stash_engine_counter_stats table and delete the cache record for this identifier_id.  Then refresh the page and it should pull the stats back again from DataCite and add a cache record to the database table again and display the stats on the page.