### PR TITLE
Put crons in the main repository and use them instead of config repo

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -4,6 +4,9 @@ require 'capistrano/setup'
 # Include default deployment tasks
 require 'capistrano/deploy'
 
+require 'capistrano/scm/git'
+install_plugin Capistrano::SCM::Git
+
 # Include tasks from other gems included in your Gemfile
 #
 # For documentation on these, see for example:

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -70,8 +70,6 @@ end
 
 namespace :deploy do
 
-  after :finished, :copy_crons_to_shared
-
   desc 'Get list of linked files for capistrano'
   task :my_linked_files do
     on roles(:app) do
@@ -114,6 +112,8 @@ namespace :deploy do
       execute "cp /apps/dryad/apps/ui/current/cron/* /apps/dryad/apps/ui/shared/cron"
     end
   end
+
+  after :finished, :copy_crons_to_shared
 
   after :restart, :clear_cache do
     on roles(:app), in: :groups, limit: 3, wait: 10 do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -101,8 +101,6 @@ namespace :deploy do
       execute "cd #{deploy_to}/current; RAILS_ENV=#{fetch(:rails_env)} bundle exec bin/delayed_job -n 3 start"
     end
 
-    after :finished, :copy_crons_to_shared
-
     desc 'copy crons to the shared directory where the schedule crons expect them'
     task :copy_crons_to_shared do
       # This was going to be a symlink into current, but we don't want to put the shared/cron directory within
@@ -110,8 +108,10 @@ namespace :deploy do
       # the backups across every version when we deploy and make us run out of disk space.
       #
       # When the crons are changed in Puppet for the new path, we can remove this copying script.
-      execute "mkdir -p /apps/dryad/apps/ui/shared/cron"
-      execute "cp /apps/dryad/apps/ui/current/cron/* /apps/dryad/apps/ui/shared/cron"
+      on roles(:app) do
+        execute "mkdir -p /apps/dryad/apps/ui/shared/cron"
+        execute "cp /apps/dryad/apps/ui/current/cron/* /apps/dryad/apps/ui/shared/cron"
+      end
     end
   end
 
@@ -168,6 +168,6 @@ namespace :deploy do
       execute "chmod 750 #{deploy_to}/shared/cron/*.sh"
     end
   end
-  
+
   before 'deploy:symlink:shared', 'deploy:my_linked_files'
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -13,9 +13,6 @@ set :branch, ENV['BRANCH'] if ENV['BRANCH']
 # Default deploy_to directory is /var/www/my_app_name
 set :deploy_to, '/apps/dryad/apps/ui'
 
-# Default value for :scm is :git
-set :scm, :git
-
 # Default value for :format is :pretty
 # set :format, :pretty
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -101,6 +101,8 @@ namespace :deploy do
       execute "cd #{deploy_to}/current; RAILS_ENV=#{fetch(:rails_env)} bundle exec bin/delayed_job -n 3 start"
     end
 
+    after :finished, :copy_crons_to_shared
+
     desc 'copy crons to the shared directory where the schedule crons expect them'
     task :copy_crons_to_shared do
       # This was going to be a symlink into current, but we don't want to put the shared/cron directory within
@@ -112,8 +114,6 @@ namespace :deploy do
       execute "cp /apps/dryad/apps/ui/current/cron/* /apps/dryad/apps/ui/shared/cron"
     end
   end
-
-  after :finished, :copy_crons_to_shared
 
   after :restart, :clear_cache do
     on roles(:app), in: :groups, limit: 3, wait: 10 do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -70,6 +70,8 @@ end
 
 namespace :deploy do
 
+  after :finished, :copy_crons_to_shared
+
   desc 'Get list of linked files for capistrano'
   task :my_linked_files do
     on roles(:app) do
@@ -91,14 +93,25 @@ namespace :deploy do
   desc 'stop delayed_job'
   task :stop_delayed_job do
     on roles(:app) do
-      execute "cd #{deploy_to}/current; bundle exec bin/delayed_job -n 3 stop"
+      execute "cd #{deploy_to}/current; RAILS_ENV=#{fetch(:rails_env)} bundle exec bin/delayed_job -n 3 stop"
     end
   end
 
   desc 'start delayed_job'
   task :start_delayed_job do
     on roles(:app) do
-      execute "cd #{deploy_to}/current; bundle exec bin/delayed_job -n 3 start"
+      execute "cd #{deploy_to}/current; RAILS_ENV=#{fetch(:rails_env)} bundle exec bin/delayed_job -n 3 start"
+    end
+
+    desc 'copy crons to the shared directory where the schedule crons expect them'
+    task :copy_crons_to_shared do
+      # This was going to be a symlink into current, but we don't want to put the shared/cron directory within
+      # current since it contains a backup directory of our database. It would then multiply
+      # the backups across every version when we deploy and make us run out of disk space.
+      #
+      # When the crons are changed in Puppet for the new path, we can remove this copying script.
+      execute "mkdir -p /apps/dryad/apps/ui/shared/cron"
+      execute "cp /apps/dryad/apps/ui/current/cron/* /apps/dryad/apps/ui/shared/cron"
     end
   end
 

--- a/config/deploy/development.rb
+++ b/config/deploy/development.rb
@@ -76,23 +76,7 @@ role %i[app web], fetch(:server_hosts), user: 'dryad'
 #   }
 
 namespace :deploy do
-
   before :starting, :stop_delayed_job
   after :finished, :start_delayed_job
-
-  #desc 'update local engines to get around requiring version number changes in development'
-  #task :update_local_engines do
-  #  on roles(:app) do
-  #    my_branch = capture("cat #{deploy_to}/current/branch_info")
-  #
-  #    %w(stash_datacite stash_engine stash_discovery).each do |engine|
-  #      execute "cd #{deploy_to}/#{engine}; git checkout #{my_branch}; git reset --hard origin/#{my_branch}; git pull"
-  #    end
-
-      # execute "cd #{deploy_to}/stash_datacite; git checkout #{my_branch}; git reset --hard origin/#{my_branch}; git pull"
-      # execute "cd #{deploy_to}/stash_engine; git checkout #{my_branch}; git reset --hard origin/#{my_branch}; git pull"
-  #  end
-  #end
-
-  #after :published, :update_local_engines
+  after :finished, :copy_crons_to_shared
 end

--- a/config/deploy/prod1.rb
+++ b/config/deploy/prod1.rb
@@ -78,4 +78,5 @@ role %i[app web], fetch(:server_hosts), user: 'dryad'
 
 namespace :deploy do
   before :start, :setup_cron
+  after :finished, :copy_crons_to_shared
 end

--- a/config/deploy/prod2.rb
+++ b/config/deploy/prod2.rb
@@ -13,6 +13,7 @@ set :passenger_pool, '12'
 namespace :deploy do
   before :starting, :stop_delayed_job
   after :finished, :start_delayed_job
+  after :finished, :copy_crons_to_shared
 end
 
 #set :bundle_env_variables, { 'RAILS_ENV' => 'stage' }

--- a/config/deploy/stage1.rb
+++ b/config/deploy/stage1.rb
@@ -78,4 +78,5 @@ role %i[app web], fetch(:server_hosts), user: 'dryad'
 
 namespace :deploy do
   before :start, :setup_cron
+  after :finished, :copy_crons_to_shared
 end

--- a/config/deploy/stage2.rb
+++ b/config/deploy/stage2.rb
@@ -13,6 +13,7 @@ set :passenger_pool, '6'
 namespace :deploy do
   before :starting, :stop_delayed_job
   after :finished, :start_delayed_job
+  after :finished, :copy_crons_to_shared
 end
 
 #set :bundle_env_variables, { 'RAILS_ENV' => 'stage' }

--- a/cron/README.md
+++ b/cron/README.md
@@ -1,0 +1,38 @@
+# Dryad Cron Jobs
+
+Most of the Dryad Cron jobs are executed via the shell scripts in this directory.
+
+The files deploy with the code (in `apps/ui/current`), but the scheduled crons point to
+`/apps/dryad/apps/ui/shared/cron`, so we should re-symlink this directory after
+a successful deploy until we can get the crontab changed in puppet.
+
+## Frequencies:
+
+Cron jobs run on one of the following schedules:
+- every_1.sh <-- Every minute for checking the OAI feed for publications
+- every_5.sh <-- Every 5 minutes
+- daily.sh <-- Every day at 12:00
+- weekly.sh <-- Every Sunday at 21:00
+- monthly.sh <- On the 20th at 19:00
+
+Cron MUST pass in the environment as an argument when executing the scripts! For example: `/apps/dryad/apps/ui/shared/cron/daily.sh development`
+
+
+## Adding a new Cron task:
+
+Add your task as a new line to one of these shell scripts and then redeploy the app via Capistrano. If you need to incorporate a new frequency (e.g. every 30 minutes) you will need to add the new shell script and then coordinate with the team who manages puppet to have the corresponding line added to the crontab.
+
+## Cron tasks:
+
+example crontab
+
+```shell
+# Run jobs every 5 minutes
+*/5 * * * * /apps/dryad/apps/ui/shared/cron/every_5.sh stage >> /apps/dryad/apps/ui/shared/cron/logs/cron.log 2>&1
+
+# Run the jobs at noon each day
+00 12 * * * /apps/dryad/apps/ui/shared/cron/daily.sh stage >> /apps/dryad/apps/ui/shared/cron/logs/cron.log 2>&1
+
+# Run the jobs every Sunday at 21:00
+00 21 * * 0 /apps/dryad/apps/ui/shared/cron/weekly.sh stage >> /apps/dryad/apps/ui/shared/cron/logs/cron.log 2>&1
+```

--- a/cron/counter.sh
+++ b/cron/counter.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+: ${RAILS_ENV:?"Need to set RAILS_ENV (e.g. development, stage, production)"}
+
+echo ""
+dt=`date '+%m/%d/%Y_%H:%M:%S'`
+echo "Starting counter run at $dt"
+
+# may have some environment problems, maybe needs to be run as interactive shell or see /apps/dryad/apps/ui/unbloat.sh for setting environment
+# maybe /usr/bin/bash -l -c <script> will run with correct environment set
+
+# this is for flexility but right now only used in production for real purposes
+source "${RAILS_ENV}_counter.sh"
+
+# --------------------------------------
+# combining daily logs from both servers
+# --------------------------------------
+echo "Combining logs from all servers"
+export LOG_DIRECTORY="/apps/dryad/apps/ui/current/log"
+cd /apps/dryad/apps/ui/current
+# note for the combine_files to work, this server must have its public key added to the other SCP_HOSTS authorized keys so it can scp in to get files
+bundle exec rails counter:combine_files
+
+# ---------------------------------------
+# set up python and run counter-processor (maybe twice)
+# ---------------------------------------
+echo "Running counter-processor"
+export PATH=$HOME/opt/bin:$PATH
+export PYTHONPATH=$HOME/opt/bin/python-3.6.9
+python --version
+cd /apps/dryad/apps/counter/counter-processor
+# may need to to run the following lines to get dependencies (like bundler) before the first time the processor is run
+# pip install -r requirements.txt
+YEST_MONTH="`date --date='1 day ago' '+%Y-%m'`"
+WEEK_AGO_MONTH="`date --date='8 days ago' '+%Y-%m'`"
+
+# note there are additional configurations in the counter-processor config diretory and these just override or set thing there
+UPLOAD_TO_HUB=False \
+YEAR_MONTH=$WEEK_AGO_MONTH \
+OUTPUT_FILE="$COUNTER_JSON_STORAGE/$WEEK_AGO_MONTH" \
+LOG_NAME_PATTERN="/apps/dryad/apps/ui/current/log/counter_(yyyy-mm-dd).log_combined" \
+python -u main.py
+
+if [ "$YEST_MONTH" != "$WEEK_AGO_MONTH" ]; then
+    # We have another month to partially process
+    # note there are additional configurations in the counter-processor config diretory and these just override or set thing there
+    UPLOAD_TO_HUB=False \
+    YEAR_MONTH=$YEST_MONTH \
+    OUTPUT_FILE="$COUNTER_JSON_STORAGE/$YEST_MONTH" \
+    LOG_NAME_PATTERN="/apps/dryad/apps/ui/current/log/counter_(yyyy-mm-dd).log_combined" \
+    python -u main.py
+fi
+
+cd /apps/dryad/apps/ui/current
+
+# There is a "monthly" task which re-uploads all stats to datacite from our output json files
+
+# This was from when we weren't getting stats back from DataCite because of problems
+# --------------------------------------
+# clear out cached stats in our database
+# --------------------------------------
+# echo "Clearing cached stats from database"
+# bundle exec rails counter:clear_cache
+
+# This was from when we weren't getting stats back from DataCite because of problems
+# -----------------------------------------
+# repopulate all stats back into our tables
+# -----------------------------------------
+# echo "Repopulating stats into database cache"
+# JSON_DIRECTORY="$COUNTER_JSON_STORAGE" bundle exec rails counter:cop_manual
+
+# -----------------------------------------------
+# remove old logs that are past our deletion time
+# -----------------------------------------------
+echo "Remove old logs past their deletion time"
+bundle exec rails counter:remove_old_logs

--- a/cron/daily.sh
+++ b/cron/daily.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+: ${1:?"Need to pass in environment (e.g. development, stage, production)"}
+
+PATH=$PATH:/apps/dryad/local/bin
+
+cd /apps/dryad/apps/ui/current/
+
+bundle exec rails download_tracking:cleanup RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/download_tracking.log 2>&1
+bundle exec rails identifiers:publish_datasets RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/publish_datasets.log 2>&1
+bundle exec rails identifiers:peer_review_reminder RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/peer_review_reminder.log 2>&1
+bundle exec rails identifiers:in_progess_reminder RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/in_progess_reminder.log 2>&1
+bundle exec rails identifiers:update_missing_search_words RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/update_search_words.log 2>&1
+bundle exec rails dev_ops:retry_zenodo_errors RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/retry_zenodo_errors.log 2>&1

--- a/cron/every_1.sh
+++ b/cron/every_1.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+: ${1:?"Need to pass in environment (e.g. development, stage, production)"}
+
+PATH=$PATH:/apps/dryad/local/bin
+
+cd /apps/dryad/apps/ui/current/
+
+STASH_ENV=$1 NOTIFIER_OUTPUT=stdout /dryad/apps/stash-notifier/main.rb >> /dryad/apps/ui/shared/cron/logs/stash-notifier.log 2>&1

--- a/cron/every_30.sh
+++ b/cron/every_30.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+: ${1:?"Need to pass in environment (e.g. development, stage, production)"}
+
+PATH=$PATH:/apps/dryad/local/bin
+
+cd /apps/dryad/apps/ui/current/
+
+# Opting not to record output in logs since it would display the command in clear text
+bundle exec rails dev_ops:backup RAILS_ENV=$1

--- a/cron/every_5.sh
+++ b/cron/every_5.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+: ${1:?"Need to pass in environment (e.g. development, stage, production)"}
+
+PATH=$PATH:/apps/dryad/local/bin
+
+cd /apps/dryad/apps/ui/current/
+
+bundle exec rails status_dashboard:check RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/status_dashboard_check.log 2>&1
+

--- a/cron/monthly.sh
+++ b/cron/monthly.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+: ${1:?"Need to pass in environment (e.g. development, stage, production)"}
+
+export RAILS_ENV="$1"
+
+PATH=$PATH:/apps/dryad/local/bin
+
+cd /apps/dryad/apps/ui/current/
+
+# gets the token from our config by way of rake task and sets variable for last line and also variable for report dir
+tok=`bundle exec rails dev_ops:get_counter_token RAILS_ENV=$1`
+# set env for last line of output
+export TOKEN=`echo "$tok" | tail -n1`
+export REPORT_DIR="/apps/dryad-prd-shared/json-reports"
+
+# force submission for last month (and will submit other missing months)
+export FORCE_SUBMISSION="`date --date="$(date +%Y-%m-15) - 1 month" "+%Y-%m"`"
+
+# run the script with the above settings, this is just a ruby script (no rails)
+/apps/dryad/apps/ui/current/stash/script/counter-uploader/main.rb >> /apps/dryad/apps/ui/shared/cron/logs/counter-uploader.log 2>&1

--- a/cron/production_counter.sh
+++ b/cron/production_counter.sh
@@ -1,0 +1,3 @@
+# specifics for environment that get sourced into the counter.sh
+export SCP_HOSTS="uc3-dryaduix2-prd-2c.cdlib.org"
+COUNTER_JSON_STORAGE="/apps/dryad-prd-shared/json-reports"

--- a/cron/stage_counter.sh
+++ b/cron/stage_counter.sh
@@ -1,0 +1,3 @@
+# specifics for environment that get sourced into the counter.sh
+export SCP_HOSTS="uc3-dryaduix2-stg-2c.cdlib.org"
+COUNTER_JSON_STORAGE="/apps/dryad-stg-shared/json-reports"

--- a/cron/weekly.sh
+++ b/cron/weekly.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+: ${1:?"Need to pass in environment (e.g. development, stage, production)"}
+
+export RAILS_ENV="$1"
+
+PATH=$PATH:/apps/dryad/local/bin
+
+cd /apps/dryad/apps/ui/current/
+
+bundle exec rails link_out:publish >> /apps/dryad/apps/ui/shared/cron/logs/link_out_publish.log 2>&1
+bundle exec rails publication_updater:crossref >> /apps/dryad/apps/ui/shared/cron/logs/publication_updater_crossref.log 2>&1
+
+# putting this in background since I don't want to delay the counter processor starting
+bundle exec rails counter:populate_citations >> /apps/dryad/apps/ui/shared/cron/logs/citation_populator.log 2>&1 &
+
+# the MDC/counter processor only runs in the production environment to send stats to the datacite hub, no need to run in other environments
+if [ "$RAILS_ENV" == "production" ] || [ "$RAILS_ENV" == "stage" ]
+then
+    cd /apps/dryad/apps/ui/shared/cron
+    ./counter.sh >> /apps/dryad/apps/ui/shared/cron/logs/counter.log 2>&1
+fi


### PR DESCRIPTION
I looked at all for sensitive information and think we're good.

I needed to modify the deploy tasks since the crons from from the shared directory.  So just copy the latest from the main app over the ones there.  If we like we can get Ashley to change the puppet to use it from current instead and then can remove this task.

This should end our reliance on the config repo and allow us to update that code like the rest.