### PR TITLE
Modifies the relationships for the new related identifier world and Zenodo

### DIFF
--- a/spec/lib/stash/zenodo_replicate/metadata_generator_spec.rb
+++ b/spec/lib/stash/zenodo_replicate/metadata_generator_spec.rb
@@ -123,9 +123,9 @@ module Stash
           @sl = StashEngine::SoftwareLicense.create(name: 'MIT License', identifier: 'MIT', details_url: 'http://spdx.org/licenses/MIT.json')
           @resource.identifier.update(software_license_id: @sl.id)
 
-          test_doi = "#{rand.to_s[2..3]}.#{rand.to_s[2..5]}/zenodo.#{rand.to_s[2..11]}"
+          test_doi = "https://doi.org/#{rand.to_s[2..3]}.#{rand.to_s[2..5]}/zenodo.#{rand.to_s[2..11]}"
           @related_id = create(:related_identifier, related_identifier: test_doi, related_identifier_type: 'doi',
-                                                    relation_type: 'issupplementto', resource_id: @resource.id,
+                                                    relation_type: 'ispartof', resource_id: @resource.id,
                                                     verified: true, hidden: false)
           # r = StashDatacite::RelatedIdentifier.add_zenodo_relation(resource_id: @resource.id, doi: test_doi)
 
@@ -150,7 +150,7 @@ module Stash
 
         it 'adds isSupplementTo to the Zenodo software to reference the Dryad dataset' do
           ids = @mg.related_identifiers.map { |i| i[:identifier] }
-          expect(ids).to include(@resource.identifier.identifier)
+          expect(ids).to include(StashDatacite::RelatedIdentifier.standardize_doi(@resource.identifier.identifier))
         end
       end
     end

--- a/spec/lib/stash/zenodo_software/copier_spec.rb
+++ b/spec/lib/stash/zenodo_software/copier_spec.rb
@@ -219,7 +219,7 @@ module Stash
             stub_get_existing_ds(deposition_id: @zc2.deposition_id)
             allow(@zsc).to receive(:publish_dataset).and_return(nil)
             @zsc.add_to_zenodo
-            expect(@resource.related_identifiers.map(&:related_identifier).first).to eq("10.5072/zenodo.#{@zc.deposition_id}")
+            expect(@resource.related_identifiers.map(&:related_identifier).first).to eq("https://doi.org/10.5072/zenodo.#{@zc.deposition_id}")
           end
         end
 

--- a/spec/models/stash_datacite/related_identifier_spec.rb
+++ b/spec/models/stash_datacite/related_identifier_spec.rb
@@ -90,10 +90,10 @@ module StashDatacite
         test_doi = "#{rand.to_s[2..6]}/zenodo#{rand.to_s[2.11]}"
         r = StashDatacite::RelatedIdentifier.add_zenodo_relation(resource_id: @resource.id, doi: test_doi)
         expect(r.related_identifier).to eq(test_doi)
-        expect(r.relation_type).to eq('issupplementto')
+        expect(r.relation_type).to eq('ispartof')
       end
 
-      it "doesn't add the zenodo issupplement doi multiple times" do
+      it "doesn't add the zenodo doi multiple times" do
         test_doi = "#{rand.to_s[2..6]}/zenodo#{rand.to_s[2.11]}"
         StashDatacite::RelatedIdentifier.add_zenodo_relation(resource_id: @resource.id, doi: test_doi)
         StashDatacite::RelatedIdentifier.add_zenodo_relation(resource_id: @resource.id, doi: test_doi)

--- a/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
@@ -130,9 +130,9 @@ module StashDatacite
     end
 
     def self.add_zenodo_relation(resource_id:, doi:)
-      doi = self.standardize_doi(doi)
+      doi = standardize_doi(doi)
       existing_item = where(resource_id: resource_id).where(related_identifier_type: 'doi')
-                          .where(related_identifier: doi).last
+        .where(related_identifier: doi).last
       if existing_item.nil?
         create(related_identifier: doi,
                related_identifier_type: 'doi',

--- a/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
@@ -130,13 +130,18 @@ module StashDatacite
     end
 
     def self.add_zenodo_relation(resource_id:, doi:)
+      doi = self.standardize_doi(doi)
       existing_item = where(resource_id: resource_id).where(related_identifier_type: 'doi')
-        .where(relation_type: 'issupplementto').where('related_identifier LIKE "%zenodo%"').last
+                          .where(related_identifier: doi).last
       if existing_item.nil?
-        create(related_identifier: doi, related_identifier_type: 'doi', relation_type: 'issupplementto',
+        create(related_identifier: doi,
+               related_identifier_type: 'doi',
+               relation_type: 'ispartof',
+               work_type: 'supplemental_information',
+               verified: true,
                resource_id: resource_id)
       else
-        existing_item.update(related_identifier: doi)
+        existing_item.update(related_identifier: doi, relation_type: 'ispartof', work_type: 'supplemental_information', verified: true)
       end
     end
 

--- a/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
@@ -102,13 +102,14 @@ module Stash
         end
 
         # this relation is for myself and created in Dryad, so doesn't make sense to send to zenodo
-        related.delete_if { |i| i[:relation] == 'ispartof' && i[:identifier].include?('/zenodo.') && @software_upload }
+        related.delete_if { |i| i[:relation] == 'isPartOf' && i[:identifier].include?('/zenodo.') && @software_upload }
 
         # though this says software, it's hijacked for supplemental information for now because that is what we needed first
         # This is adding the link back from zenodo to our datasets
         if @software_upload
-          related.push(relation: 'issupplementto',
-                       identifier: StashDatacite::RelatedIdentifier.standardize_doi(@resource.identifier.identifier))
+          related.push(relation: 'isSupplementTo',
+                       identifier: StashDatacite::RelatedIdentifier.standardize_doi(@resource.identifier.identifier),
+                       scheme: 'doi')
         end
         related ||= []
         related

--- a/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
@@ -101,10 +101,15 @@ module Stash
           { relation: ri.relation_type_friendly&.camelize(:lower), identifier: ri.related_identifier }
         end
 
-        # this relation is for myself and created in Dryad, so doesn't make sense here
-        related.delete_if { |i| i[:relation] == 'isSupplementTo' && i[:identifier].include?('/zenodo.') && @software_upload }
+        # this relation is for myself and created in Dryad, so doesn't make sense to send to zenodo
+        related.delete_if { |i| i[:relation] == 'ispartof' && i[:identifier].include?('/zenodo.') && @software_upload }
 
-        related.push(relation: 'isSupplementTo', identifier: @resource.identifier.identifier) if @software_upload
+        # though this says software, it's hijacked for supplemental information for now because that is what we needed first
+        # This is adding the link back from zenodo to our datasets
+        if @software_upload
+          related.push(relation: 'issupplementto',
+                       identifier: StashDatacite::RelatedIdentifier.standardize_doi(@resource.identifier.identifier))
+        end
         related ||= []
         related
       end


### PR DESCRIPTION
https://github.com/CDL-Dryad/dryad-product-roadmap/issues/907

This adds a relationship of  "is part of" for supplemental information since that is the relationship D. said to use for this type.

Sets the relationship in our database so it appears under the correct category in the review page and shows it is verified.

Modifications to what we send to zenodo to take into account changes.

Test fixes for 1) longer dois (full DOI URL) and 2) relationship changes.