### PR TITLE
Allow zenodo (supplemental) uploads for certain journals (issns)

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -135,6 +135,8 @@ defaults: &DEFAULTS
     - 'Zimbabwe'
   funder_exemptions:
     - 'Chan Zuckerberg Initiative'
+  supplemental_info_issns: [1687-7969, 1687-7977, 1687-9309, 1687-9317, 1687-7667, 1687-7675, 1468-8115, 1468-8123,
+    1687-8159, 1687-8167, 1687-9708, 1687-9716]
   link_out:
     # LinkOut FTP information for Europe PubMed Central
     labslink:

--- a/dryad-config-example/app_config.yml
+++ b/dryad-config-example/app_config.yml
@@ -127,6 +127,8 @@ defaults: &DEFAULTS
     - 'Pakistan'
   funder_exemptions:
     - 'Happy Clown School'
+  supplemental_info_issns: [ 1687-7969, 1687-7977, 1687-9309, 1687-9317, 1687-7667, 1687-7675, 1468-8115, 1468-8123,
+    1687-8159, 1687-8167, 1687-9708, 1687-9716 ]
   link_out:
     # LinkOut FTP information for Europe PubMed Central
     labslink:

--- a/spec/features/stash_datacite/review_dataset_spec.rb
+++ b/spec/features/stash_datacite/review_dataset_spec.rb
@@ -62,16 +62,23 @@ RSpec.feature 'ReviewDataset', type: :feature do
 
   end
 
-  context :software_license do
+  context :software_uploaded do
     before(:each, js: true) do
       # Sign in and create a new dataset
       visit root_path
       click_link 'My Datasets'
       start_new_dataset
       fill_required_fields
+
+      # Sets this up as a page that can see the software/supp info upload page. There is only one identifier created for this test.
+      se_identifier = StashEngine::Identifier.all.first
+      StashEngine::InternalDatum.create(identifier_id: se_identifier.id, data_type: 'publicationISSN', value: '1687-7667')
+      se_identifier.reload
+      navigate_to_upload # so the menus refresh to show newly-allowed tab for special zenodo uploads
     end
 
-    it 'shows the software license if software uploaded', js: true do
+    it 'shows the software/supp info if uploaded', js: true do
+      # binding.remote_pry
       navigate_to_software_upload
       page.attach_file(Rails.root.join('spec', 'fixtures', 'http_responses', 'favicon.ico')) do
         page.find('#choose-the-files').click
@@ -86,16 +93,16 @@ RSpec.feature 'ReviewDataset', type: :feature do
       click_on('Proceed to Review')
       expect(page).to have_content('Supporting Information Hosted by Zenodo')
       expect(page).to have_content('favicon.ico')
-      expect(page).to have_content('Select license for files')
+      # expect(page).to have_content('Select license for files')
     end
 
-    it "doesn't show the software license if software not uploaded", js: true do
+    it "doesn't show the software info if software not uploaded", js: true do
       navigate_to_software_upload
 
       click_on('Proceed to Review')
       expect(page).not_to have_content('Supporting Information Hosted by Zenodo')
       expect(page).not_to have_content('favicon.ico')
-      expect(page).not_to have_content('Select license for files')
+      # expect(page).not_to have_content('Select license for files')
     end
 
   end

--- a/spec/features/stash_engine/ui_file_upload_spec.rb
+++ b/spec/features/stash_engine/ui_file_upload_spec.rb
@@ -40,7 +40,10 @@ RSpec.feature 'UiFileUpload', type: :feature, js: true do
       @resource = StashEngine::Resource.find(@resource_id)
       FileUtils.rm_rf(@resource.upload_dir) unless @resource_id.blank?
       FileUtils.rm_rf(@resource.software_upload_dir) unless @resource_id.blank?
+    end
 
+    it "doesn't show Zenodo upload tab if not part of special journal" do
+      expect(page).not_to have_content('Upload Supporting Information')
     end
 
     it 'uploads a file' do

--- a/spec/lib/stash/zenodo_replicate/metadata_generator_spec.rb
+++ b/spec/lib/stash/zenodo_replicate/metadata_generator_spec.rb
@@ -123,9 +123,9 @@ module Stash
           @sl = StashEngine::SoftwareLicense.create(name: 'MIT License', identifier: 'MIT', details_url: 'http://spdx.org/licenses/MIT.json')
           @resource.identifier.update(software_license_id: @sl.id)
 
-          test_doi = "#{rand.to_s[2..3]}.#{rand.to_s[2..5]}/zenodo.#{rand.to_s[2..11]}"
+          test_doi = "https://doi.org/#{rand.to_s[2..3]}.#{rand.to_s[2..5]}/zenodo.#{rand.to_s[2..11]}"
           @related_id = create(:related_identifier, related_identifier: test_doi, related_identifier_type: 'doi',
-                                                    relation_type: 'issupplementto', resource_id: @resource.id,
+                                                    relation_type: 'ispartof', resource_id: @resource.id,
                                                     verified: true, hidden: false)
           # r = StashDatacite::RelatedIdentifier.add_zenodo_relation(resource_id: @resource.id, doi: test_doi)
 
@@ -150,7 +150,7 @@ module Stash
 
         it 'adds isSupplementTo to the Zenodo software to reference the Dryad dataset' do
           ids = @mg.related_identifiers.map { |i| i[:identifier] }
-          expect(ids).to include(@resource.identifier.identifier)
+          expect(ids).to include(StashDatacite::RelatedIdentifier.standardize_doi(@resource.identifier.identifier))
         end
       end
     end

--- a/spec/lib/stash/zenodo_software/copier_spec.rb
+++ b/spec/lib/stash/zenodo_software/copier_spec.rb
@@ -27,6 +27,7 @@ module Stash
         my_path = @file.calc_file_path[0..-(File.basename(@file.calc_file_path).length + 1)]
         FileUtils.mkdir_p(my_path)
         FileUtils.touch(@file.calc_file_path)
+        WebMock.disable_net_connect!(allow_localhost: true)
       end
 
       after(:each) do

--- a/spec/lib/stash/zenodo_software/copier_spec.rb
+++ b/spec/lib/stash/zenodo_software/copier_spec.rb
@@ -219,7 +219,7 @@ module Stash
             stub_get_existing_ds(deposition_id: @zc2.deposition_id)
             allow(@zsc).to receive(:publish_dataset).and_return(nil)
             @zsc.add_to_zenodo
-            expect(@resource.related_identifiers.map(&:related_identifier).first).to eq("10.5072/zenodo.#{@zc.deposition_id}")
+            expect(@resource.related_identifiers.map(&:related_identifier).first).to eq("https://doi.org/10.5072/zenodo.#{@zc.deposition_id}")
           end
         end
 

--- a/spec/models/stash_datacite/related_identifier_spec.rb
+++ b/spec/models/stash_datacite/related_identifier_spec.rb
@@ -90,10 +90,10 @@ module StashDatacite
         test_doi = "#{rand.to_s[2..6]}/zenodo#{rand.to_s[2.11]}"
         r = StashDatacite::RelatedIdentifier.add_zenodo_relation(resource_id: @resource.id, doi: test_doi)
         expect(r.related_identifier).to eq(test_doi)
-        expect(r.relation_type).to eq('issupplementto')
+        expect(r.relation_type).to eq('ispartof')
       end
 
-      it "doesn't add the zenodo issupplement doi multiple times" do
+      it "doesn't add the zenodo doi multiple times" do
         test_doi = "#{rand.to_s[2..6]}/zenodo#{rand.to_s[2.11]}"
         StashDatacite::RelatedIdentifier.add_zenodo_relation(resource_id: @resource.id, doi: test_doi)
         StashDatacite::RelatedIdentifier.add_zenodo_relation(resource_id: @resource.id, doi: test_doi)

--- a/spec/support/helpers/dataset_helper.rb
+++ b/spec/support/helpers/dataset_helper.rb
@@ -14,6 +14,12 @@ module DatasetHelper
   end
 
   def navigate_to_software_upload
+    # Sets this up as a page that can see the software/supp info upload page.
+    se_identifier = StashEngine::Identifier.all.first
+    StashEngine::InternalDatum.create(identifier_id: se_identifier.id, data_type: 'publicationISSN', value: '1687-7667')
+    se_identifier.reload
+    navigate_to_upload # so the menus refresh to show newly-allowed tab for special zenodo uploads
+
     click_link 'Upload Supporting Information'
     click_link 'Upload directly'
     expect(page).to have_content('Choose Files')

--- a/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
@@ -130,13 +130,18 @@ module StashDatacite
     end
 
     def self.add_zenodo_relation(resource_id:, doi:)
+      doi = standardize_doi(doi)
       existing_item = where(resource_id: resource_id).where(related_identifier_type: 'doi')
-        .where(relation_type: 'issupplementto').where('related_identifier LIKE "%zenodo%"').last
+        .where(related_identifier: doi).last
       if existing_item.nil?
-        create(related_identifier: doi, related_identifier_type: 'doi', relation_type: 'issupplementto',
+        create(related_identifier: doi,
+               related_identifier_type: 'doi',
+               relation_type: 'ispartof',
+               work_type: 'supplemental_information',
+               verified: true,
                resource_id: resource_id)
       else
-        existing_item.update(related_identifier: doi)
+        existing_item.update(related_identifier: doi, relation_type: 'ispartof', work_type: 'supplemental_information', verified: true)
       end
     end
 

--- a/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
@@ -87,8 +87,13 @@
     <%= render partial: "stash_datacite/licenses/review" %>
 
 <div class="o-dataset-nav">
-  <%= link_to 'Back to Upload Supporting Information', stash_url_helpers.up_code_resource_path(@resource), id: 'dashboard_path',
+  <% if @resource.identifier.allow_supplemental_info? %>
+    <%= link_to 'Back to Upload Supporting Information', stash_url_helpers.up_code_resource_path(@resource), id: 'dashboard_path',
             class: 'o-button__icon-left', role: 'button' %>
+  <% else %>
+    <%= link_to 'Back to Upload Data', stash_engine.upload_resource_path(params[:id]), class: 'o-button__icon-left',
+                role: 'button' %>
+  <% end %>
 
   <% if @data.blank? # valid data %>
     <%= form_tag stash_datacite.resources_submission_path do -%>

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -480,6 +480,15 @@ module StashEngine
         .order(id: :desc).limit(1).first
     end
 
+    def allow_supplemental_info?
+      @allow_supplemental_info ||=
+        begin
+          my_internal = StashEngine::InternalDatum.where(identifier_id: id, data_type: 'publicationISSN').first
+          my_issn = my_internal&.value
+          APP_CONFIG.supplemental_info_issns.include?(my_issn)
+        end
+    end
+
     private
 
     def abstracts

--- a/stash/stash_engine/app/views/stash_engine/resources/upload.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/resources/upload.html.erb
@@ -16,9 +16,15 @@
 
 <div class="o-dataset-nav">
   <% if params[:controller].end_with?('resources') && params[:action].include?('upload') %>
+    <!-- standard upload page -->
     <%= link_to 'Back to Describe Dataset', metadata_entry_pages_find_or_create_path(resource_id: params[:id]), class: 'o-button__icon-left', role: 'button', id: 'describe_back' %>
-    <%= link_to 'Proceed to Upload Supporting Information', up_code_resource_path(params[:id]), class: 'o-button__icon-right', role: 'button', id: 'proceed_review' %>
+    <% if @resource.identifier.allow_supplemental_info? %>
+      <%= link_to 'Proceed to Upload Supporting Information', up_code_resource_path(params[:id]), class: 'o-button__icon-right', role: 'button', id: 'proceed_review' %>
+    <% else %>
+      <%= link_to 'Proceed to Review', review_resource_path(params[:id]), class: 'o-button__icon-right', role: 'button', id: 'proceed_review' %>
+    <% end %>
   <% else %>
+    <!-- software/supplemental zenodo upload page, should only get here if you can upload to zenodo -->
     <%= link_to 'Back to Upload Data', stash_engine.upload_resource_path(params[:id]), class: 'o-button__icon-left', role: 'button', id: 'describe_back' %>
     <%= link_to 'Proceed to Review', review_resource_path(params[:id]), class: 'o-button__icon-right', role: 'button', id: 'proceed_review' %>
   <% end %>

--- a/stash/stash_engine/app/views/stash_engine/shared/_dataset_steps_nav.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/shared/_dataset_steps_nav.html.erb
@@ -5,8 +5,10 @@
   <%= link_to 'Upload Data', stash_engine.upload_resource_path(@resource.id),
             class: "c-progress__tab2#{ (params[:controller].end_with?('resources') && params[:action].include?('upload') ? '--active' : '') } js-nav-out" %>
 
-  <%= link_to 'Upload Supporting Information', stash_engine.up_code_resource_path(@resource.id),
+  <% if @resource.identifier.allow_supplemental_info? %>
+    <%= link_to 'Upload Supporting Information', stash_engine.up_code_resource_path(@resource.id),
               class: "c-progress__tab2#{ (params[:controller].end_with?('resources') && params[:action].include?('up_') ? '--active' : '') } js-nav-out" %>
+  <% end %>
 
   <%= link_to 'Review and Submit', stash_engine.review_resource_path(@resource.id),
             class: "c-progress__tab3#{ (params[:controller].end_with?('resources') && params[:action] == 'review' ? '--active' : '') } js-nav-out" %>

--- a/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
@@ -101,10 +101,16 @@ module Stash
           { relation: ri.relation_type_friendly&.camelize(:lower), identifier: ri.related_identifier }
         end
 
-        # this relation is for myself and created in Dryad, so doesn't make sense here
-        related.delete_if { |i| i[:relation] == 'isSupplementTo' && i[:identifier].include?('/zenodo.') && @software_upload }
+        # this relation is for myself and created in Dryad, so doesn't make sense to send to zenodo
+        related.delete_if { |i| i[:relation] == 'isPartOf' && i[:identifier].include?('/zenodo.') && @software_upload }
 
-        related.push(relation: 'isSupplementTo', identifier: @resource.identifier.identifier) if @software_upload
+        # though this says software, it's hijacked for supplemental information for now because that is what we needed first
+        # This is adding the link back from zenodo to our datasets
+        if @software_upload
+          related.push(relation: 'isSupplementTo',
+                       identifier: StashDatacite::RelatedIdentifier.standardize_doi(@resource.identifier.identifier),
+                       scheme: 'doi')
+        end
         related ||= []
         related
       end


### PR DESCRIPTION
https://github.com/CDL-Dryad/dryad-product-roadmap/issues/826

To test manually, I think the only one that currently is in the list is "International Journal of Agronomy."

The selected journals should see the extra tab "Upload Supporting Information" as well as have the page-to-page navigation allow going to it with next/prev buttons on bottom of the screen.  Without that journal, navigation should only be 3 pages.

Also has config for journal ISSNs and test updates for the new special structure.

Note: I'm also including the previous pull request in this one (so merge it first if you want to see just the changes for this one).  That PR includes some testing fixed I don't want to have to re-create again just for this PR.

