### PR TITLE
Removes the select license and always sets it to CC-BY-4.0

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -135,6 +135,8 @@ defaults: &DEFAULTS
     - 'Zimbabwe'
   funder_exemptions:
     - 'Chan Zuckerberg Initiative'
+  supplemental_info_issns: [1687-7969, 1687-7977, 1687-9309, 1687-9317, 1687-7667, 1687-7675, 1468-8115, 1468-8123,
+    1687-8159, 1687-8167, 1687-9708, 1687-9716]
   link_out:
     # LinkOut FTP information for Europe PubMed Central
     labslink:

--- a/dryad-config-example/app_config.yml
+++ b/dryad-config-example/app_config.yml
@@ -127,6 +127,8 @@ defaults: &DEFAULTS
     - 'Pakistan'
   funder_exemptions:
     - 'Happy Clown School'
+  supplemental_info_issns: [ 1687-7969, 1687-7977, 1687-9309, 1687-9317, 1687-7667, 1687-7675, 1468-8115, 1468-8123,
+    1687-8159, 1687-8167, 1687-9708, 1687-9716 ]
   link_out:
     # LinkOut FTP information for Europe PubMed Central
     labslink:

--- a/spec/features/stash_datacite/review_dataset_spec.rb
+++ b/spec/features/stash_datacite/review_dataset_spec.rb
@@ -121,7 +121,5 @@ RSpec.feature 'ReviewDataset', type: :feature do
       v = find("#software_license", :visible => false).value
       expect(v).to eq('CC-BY-4.0')
     end
-
   end
-
 end

--- a/spec/features/stash_datacite/review_dataset_spec.rb
+++ b/spec/features/stash_datacite/review_dataset_spec.rb
@@ -62,16 +62,23 @@ RSpec.feature 'ReviewDataset', type: :feature do
 
   end
 
-  context :software_license do
+  context :software_uploaded do
     before(:each, js: true) do
       # Sign in and create a new dataset
       visit root_path
       click_link 'My Datasets'
       start_new_dataset
       fill_required_fields
+
+      # Sets this up as a page that can see the software/supp info upload page. There is only one identifier created for this test.
+      se_identifier = StashEngine::Identifier.all.first
+      StashEngine::InternalDatum.create(identifier_id: se_identifier.id, data_type: 'publicationISSN', value: '1687-7667')
+      se_identifier.reload
+      navigate_to_upload # so the menus refresh to show newly-allowed tab for special zenodo uploads
     end
 
-    it 'shows the software license if software uploaded', js: true do
+    it 'shows the software/supp info if uploaded', js: true do
+      # binding.remote_pry
       navigate_to_software_upload
       page.attach_file(Rails.root.join('spec', 'fixtures', 'http_responses', 'favicon.ico')) do
         page.find('#choose-the-files').click
@@ -86,16 +93,16 @@ RSpec.feature 'ReviewDataset', type: :feature do
       click_on('Proceed to Review')
       expect(page).to have_content('Supporting Information Hosted by Zenodo')
       expect(page).to have_content('favicon.ico')
-      expect(page).to have_content('Select license for files')
+      # expect(page).to have_content('Select license for files')
     end
 
-    it "doesn't show the software license if software not uploaded", js: true do
+    it "doesn't show the software info if software not uploaded", js: true do
       navigate_to_software_upload
 
       click_on('Proceed to Review')
       expect(page).not_to have_content('Supporting Information Hosted by Zenodo')
       expect(page).not_to have_content('favicon.ico')
-      expect(page).not_to have_content('Select license for files')
+      # expect(page).not_to have_content('Select license for files')
     end
 
   end

--- a/spec/features/stash_datacite/review_dataset_spec.rb
+++ b/spec/features/stash_datacite/review_dataset_spec.rb
@@ -117,8 +117,8 @@ RSpec.feature 'ReviewDataset', type: :feature do
       expect(page).to have_content('Upload complete')
 
       click_on('Proceed to Review')
-      #type hidden -- software_license 'CC-BY-4.0'
-      v = find("#software_license", :visible => false).value
+      # type hidden -- software_license 'CC-BY-4.0'
+      v = find('#software_license', visible: false).value
       expect(v).to eq('CC-BY-4.0')
     end
   end

--- a/spec/features/stash_datacite/review_dataset_spec.rb
+++ b/spec/features/stash_datacite/review_dataset_spec.rb
@@ -78,7 +78,6 @@ RSpec.feature 'ReviewDataset', type: :feature do
     end
 
     it 'shows the software/supp info if uploaded', js: true do
-      # binding.remote_pry
       navigate_to_software_upload
       page.attach_file(Rails.root.join('spec', 'fixtures', 'http_responses', 'favicon.ico')) do
         page.find('#choose-the-files').click
@@ -103,6 +102,24 @@ RSpec.feature 'ReviewDataset', type: :feature do
       expect(page).not_to have_content('Supporting Information Hosted by Zenodo')
       expect(page).not_to have_content('favicon.ico')
       # expect(page).not_to have_content('Select license for files')
+    end
+
+    it 'sets CC-BY-4.0 License for not-dataset', js: true do
+      navigate_to_software_upload
+      page.attach_file(Rails.root.join('spec', 'fixtures', 'http_responses', 'favicon.ico')) do
+        page.find('#choose-the-files').click
+      end
+      expect(page).to have_content('favicon.ico')
+      check('confirm_to_upload')
+      click_on('upload_all')
+
+      # it shows upload complete
+      expect(page).to have_content('Upload complete')
+
+      click_on('Proceed to Review')
+      #type hidden -- software_license 'CC-BY-4.0'
+      v = find("#software_license", :visible => false).value
+      expect(v).to eq('CC-BY-4.0')
     end
 
   end

--- a/spec/features/stash_engine/ui_file_upload_spec.rb
+++ b/spec/features/stash_engine/ui_file_upload_spec.rb
@@ -40,7 +40,10 @@ RSpec.feature 'UiFileUpload', type: :feature, js: true do
       @resource = StashEngine::Resource.find(@resource_id)
       FileUtils.rm_rf(@resource.upload_dir) unless @resource_id.blank?
       FileUtils.rm_rf(@resource.software_upload_dir) unless @resource_id.blank?
+    end
 
+    it "doesn't show Zenodo upload tab if not part of special journal" do
+      expect(page).not_to have_content('Upload Supporting Information')
     end
 
     it 'uploads a file' do

--- a/spec/lib/stash/zenodo_replicate/metadata_generator_spec.rb
+++ b/spec/lib/stash/zenodo_replicate/metadata_generator_spec.rb
@@ -123,9 +123,9 @@ module Stash
           @sl = StashEngine::SoftwareLicense.create(name: 'MIT License', identifier: 'MIT', details_url: 'http://spdx.org/licenses/MIT.json')
           @resource.identifier.update(software_license_id: @sl.id)
 
-          test_doi = "#{rand.to_s[2..3]}.#{rand.to_s[2..5]}/zenodo.#{rand.to_s[2..11]}"
+          test_doi = "https://doi.org/#{rand.to_s[2..3]}.#{rand.to_s[2..5]}/zenodo.#{rand.to_s[2..11]}"
           @related_id = create(:related_identifier, related_identifier: test_doi, related_identifier_type: 'doi',
-                                                    relation_type: 'issupplementto', resource_id: @resource.id,
+                                                    relation_type: 'ispartof', resource_id: @resource.id,
                                                     verified: true, hidden: false)
           # r = StashDatacite::RelatedIdentifier.add_zenodo_relation(resource_id: @resource.id, doi: test_doi)
 
@@ -150,7 +150,7 @@ module Stash
 
         it 'adds isSupplementTo to the Zenodo software to reference the Dryad dataset' do
           ids = @mg.related_identifiers.map { |i| i[:identifier] }
-          expect(ids).to include(@resource.identifier.identifier)
+          expect(ids).to include(StashDatacite::RelatedIdentifier.standardize_doi(@resource.identifier.identifier))
         end
       end
     end

--- a/spec/lib/stash/zenodo_software/copier_spec.rb
+++ b/spec/lib/stash/zenodo_software/copier_spec.rb
@@ -27,6 +27,7 @@ module Stash
         my_path = @file.calc_file_path[0..-(File.basename(@file.calc_file_path).length + 1)]
         FileUtils.mkdir_p(my_path)
         FileUtils.touch(@file.calc_file_path)
+        WebMock.disable_net_connect!(allow_localhost: true)
       end
 
       after(:each) do

--- a/spec/lib/stash/zenodo_software/copier_spec.rb
+++ b/spec/lib/stash/zenodo_software/copier_spec.rb
@@ -219,7 +219,7 @@ module Stash
             stub_get_existing_ds(deposition_id: @zc2.deposition_id)
             allow(@zsc).to receive(:publish_dataset).and_return(nil)
             @zsc.add_to_zenodo
-            expect(@resource.related_identifiers.map(&:related_identifier).first).to eq("10.5072/zenodo.#{@zc.deposition_id}")
+            expect(@resource.related_identifiers.map(&:related_identifier).first).to eq("https://doi.org/10.5072/zenodo.#{@zc.deposition_id}")
           end
         end
 

--- a/spec/models/stash_datacite/related_identifier_spec.rb
+++ b/spec/models/stash_datacite/related_identifier_spec.rb
@@ -90,10 +90,10 @@ module StashDatacite
         test_doi = "#{rand.to_s[2..6]}/zenodo#{rand.to_s[2.11]}"
         r = StashDatacite::RelatedIdentifier.add_zenodo_relation(resource_id: @resource.id, doi: test_doi)
         expect(r.related_identifier).to eq(test_doi)
-        expect(r.relation_type).to eq('issupplementto')
+        expect(r.relation_type).to eq('ispartof')
       end
 
-      it "doesn't add the zenodo issupplement doi multiple times" do
+      it "doesn't add the zenodo doi multiple times" do
         test_doi = "#{rand.to_s[2..6]}/zenodo#{rand.to_s[2.11]}"
         StashDatacite::RelatedIdentifier.add_zenodo_relation(resource_id: @resource.id, doi: test_doi)
         StashDatacite::RelatedIdentifier.add_zenodo_relation(resource_id: @resource.id, doi: test_doi)

--- a/spec/support/helpers/dataset_helper.rb
+++ b/spec/support/helpers/dataset_helper.rb
@@ -14,6 +14,12 @@ module DatasetHelper
   end
 
   def navigate_to_software_upload
+    # Sets this up as a page that can see the software/supp info upload page.
+    se_identifier = StashEngine::Identifier.all.first
+    StashEngine::InternalDatum.create(identifier_id: se_identifier.id, data_type: 'publicationISSN', value: '1687-7667')
+    se_identifier.reload
+    navigate_to_upload # so the menus refresh to show newly-allowed tab for special zenodo uploads
+
     click_link 'Upload Supporting Information'
     click_link 'Upload directly'
     expect(page).to have_content('Choose Files')

--- a/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
@@ -130,13 +130,18 @@ module StashDatacite
     end
 
     def self.add_zenodo_relation(resource_id:, doi:)
+      doi = standardize_doi(doi)
       existing_item = where(resource_id: resource_id).where(related_identifier_type: 'doi')
-        .where(relation_type: 'issupplementto').where('related_identifier LIKE "%zenodo%"').last
+        .where(related_identifier: doi).last
       if existing_item.nil?
-        create(related_identifier: doi, related_identifier_type: 'doi', relation_type: 'issupplementto',
+        create(related_identifier: doi,
+               related_identifier_type: 'doi',
+               relation_type: 'ispartof',
+               work_type: 'supplemental_information',
+               verified: true,
                resource_id: resource_id)
       else
-        existing_item.update(related_identifier: doi)
+        existing_item.update(related_identifier: doi, relation_type: 'ispartof', work_type: 'supplemental_information', verified: true)
       end
     end
 

--- a/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
@@ -30,22 +30,9 @@
   <% end %>
 </div>
 
-<% if @review.software_uploads.count > 0 %>
-	<div>
-		<h3>License and Terms of Service for Supplemental Information</h3>
-		<p>Supplemental Information and other files uploaded will be managed and preserved at Zenodo. Your related DOI will be linked to
-			your dataset. Please select a license from the below dropdown list for your Zenodo deposit. For guidance,
-			check <a href="https://choosealicense.com/" target="_blank">choosealicense.org</a>.</p>
-		<div>
-			<label for="zenodo_license" class="required">Select license for files (type to search within list)</label>
-			<%# select_tag 'zenodo_license', options_for_select([ ["MIT License", 'mit'], ["GNU public dedication", 'gnu'] ]) %>
-			<%= select_tag 'zenodo_license',
-		 		options_from_collection_for_select(StashEngine::SoftwareLicense.all, 'identifier', 'name',
-																					 @resource&.identifier&.software_license&.identifier || 'MIT') %>
-
-		</div>
-	</div>
-<% end %>
+<%# if @review.software_uploads.count > 0 %>
+	<%# render partial: 'stash_datacite/licenses/software_license' %>
+<%# end %>
 
 <div>
 	<h3>Payment</h3>

--- a/stash/stash_datacite/app/views/stash_datacite/licenses/_software_license.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/licenses/_software_license.html.erb
@@ -1,0 +1,14 @@
+<% # moving this here since I suspect this will need to be used again later %>
+<div>
+  <h3>License and Terms of Service for Supplemental Information</h3>
+  <p>Supplemental Information and other files uploaded will be managed and preserved at Zenodo. Your related DOI will be linked to
+    your dataset. Please select a license from the below dropdown list for your Zenodo deposit. For guidance,
+    check <a href="https://choosealicense.com/" target="_blank">choosealicense.org</a>.</p>
+  <div>
+    <label for="zenodo_license" class="required">Select license for files (type to search within list)</label>
+    <%= select_tag 'zenodo_license',
+                   options_from_collection_for_select(StashEngine::SoftwareLicense.all, 'identifier', 'name',
+                                                      @resource&.identifier&.software_license&.identifier || 'CC-BY-4.0') %>
+
+  </div>
+</div>

--- a/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
@@ -87,8 +87,13 @@
     <%= render partial: "stash_datacite/licenses/review" %>
 
 <div class="o-dataset-nav">
-  <%= link_to 'Back to Upload Supporting Information', stash_url_helpers.up_code_resource_path(@resource), id: 'dashboard_path',
+  <% if @resource.identifier.allow_supplemental_info? %>
+    <%= link_to 'Back to Upload Supporting Information', stash_url_helpers.up_code_resource_path(@resource), id: 'dashboard_path',
             class: 'o-button__icon-left', role: 'button' %>
+  <% else %>
+    <%= link_to 'Back to Upload Data', stash_engine.upload_resource_path(params[:id]), class: 'o-button__icon-left',
+                role: 'button' %>
+  <% end %>
 
   <% if @data.blank? # valid data %>
     <%= form_tag stash_datacite.resources_submission_path do -%>

--- a/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
@@ -98,7 +98,7 @@
   <% if @data.blank? # valid data %>
     <%= form_tag stash_datacite.resources_submission_path do -%>
       <%= hidden_field_tag :resource_id, @resource.id %>
-      <%= hidden_field_tag :software_license, @resource&.identifier&.software_license&.identifier || 'MIT' %>
+      <%= hidden_field_tag :software_license, @resource&.identifier&.software_license&.identifier || 'CC-BY-4.0' %>
       <%= check_box_tag 'all_filled',  1, true, :style => "display: none;", class: 'all_filled js-agrees' %>
       <div>
         <% if current_user.id != @resource.user_id # only show to admins %>

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -480,6 +480,15 @@ module StashEngine
         .order(id: :desc).limit(1).first
     end
 
+    def allow_supplemental_info?
+      @allow_supplemental_info ||=
+        begin
+          my_internal = StashEngine::InternalDatum.where(identifier_id: id, data_type: 'publicationISSN').first
+          my_issn = my_internal&.value
+          APP_CONFIG.supplemental_info_issns.include?(my_issn)
+        end
+    end
+
     private
 
     def abstracts

--- a/stash/stash_engine/app/views/stash_engine/resources/upload.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/resources/upload.html.erb
@@ -16,9 +16,15 @@
 
 <div class="o-dataset-nav">
   <% if params[:controller].end_with?('resources') && params[:action].include?('upload') %>
+    <!-- standard upload page -->
     <%= link_to 'Back to Describe Dataset', metadata_entry_pages_find_or_create_path(resource_id: params[:id]), class: 'o-button__icon-left', role: 'button', id: 'describe_back' %>
-    <%= link_to 'Proceed to Upload Supporting Information', up_code_resource_path(params[:id]), class: 'o-button__icon-right', role: 'button', id: 'proceed_review' %>
+    <% if @resource.identifier.allow_supplemental_info? %>
+      <%= link_to 'Proceed to Upload Supporting Information', up_code_resource_path(params[:id]), class: 'o-button__icon-right', role: 'button', id: 'proceed_review' %>
+    <% else %>
+      <%= link_to 'Proceed to Review', review_resource_path(params[:id]), class: 'o-button__icon-right', role: 'button', id: 'proceed_review' %>
+    <% end %>
   <% else %>
+    <!-- software/supplemental zenodo upload page, should only get here if you can upload to zenodo -->
     <%= link_to 'Back to Upload Data', stash_engine.upload_resource_path(params[:id]), class: 'o-button__icon-left', role: 'button', id: 'describe_back' %>
     <%= link_to 'Proceed to Review', review_resource_path(params[:id]), class: 'o-button__icon-right', role: 'button', id: 'proceed_review' %>
   <% end %>

--- a/stash/stash_engine/app/views/stash_engine/shared/_dataset_steps_nav.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/shared/_dataset_steps_nav.html.erb
@@ -5,8 +5,10 @@
   <%= link_to 'Upload Data', stash_engine.upload_resource_path(@resource.id),
             class: "c-progress__tab2#{ (params[:controller].end_with?('resources') && params[:action].include?('upload') ? '--active' : '') } js-nav-out" %>
 
-  <%= link_to 'Upload Supporting Information', stash_engine.up_code_resource_path(@resource.id),
+  <% if @resource.identifier.allow_supplemental_info? %>
+    <%= link_to 'Upload Supporting Information', stash_engine.up_code_resource_path(@resource.id),
               class: "c-progress__tab2#{ (params[:controller].end_with?('resources') && params[:action].include?('up_') ? '--active' : '') } js-nav-out" %>
+  <% end %>
 
   <%= link_to 'Review and Submit', stash_engine.review_resource_path(@resource.id),
             class: "c-progress__tab3#{ (params[:controller].end_with?('resources') && params[:action] == 'review' ? '--active' : '') } js-nav-out" %>

--- a/stash/stash_engine/db/migrate/20201022145656_update_stash_engine_software_licenses.rb
+++ b/stash/stash_engine/db/migrate/20201022145656_update_stash_engine_software_licenses.rb
@@ -1,0 +1,31 @@
+require 'http'
+
+# needs to include CC-BY which isn't OSI approved
+class UpdateStashEngineSoftwareLicenses < ActiveRecord::Migration[4.2]
+  def up
+    # remove licenses and repopulate them from larger list
+    execute 'DELETE FROM stash_engine_software_licenses'
+    populate_table_from_spdx unless Rails.env == 'test'
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def populate_table_from_spdx
+    http = HTTP.get('https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json')
+    if http.status.success?
+      json = JSON.parse(http.body.to_s)
+      json['licenses'].each do |license|
+        # the list is ridiculously huge without limiting to OsiApproved and not deprecated items
+        if license['isDeprecatedLicenseId'] == false
+          StashEngine::SoftwareLicense.create(name: license['name'], identifier: license['licenseId'],
+                                              details_url: license['detailsUrl'])
+        end
+      end
+    end
+  rescue HTTP::Error
+    # just ignore and you'll need to fix manually
+    puts "WARNING, couldn't get license list from SPDX on github"
+  end
+end

--- a/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
@@ -101,10 +101,16 @@ module Stash
           { relation: ri.relation_type_friendly&.camelize(:lower), identifier: ri.related_identifier }
         end
 
-        # this relation is for myself and created in Dryad, so doesn't make sense here
-        related.delete_if { |i| i[:relation] == 'isSupplementTo' && i[:identifier].include?('/zenodo.') && @software_upload }
+        # this relation is for myself and created in Dryad, so doesn't make sense to send to zenodo
+        related.delete_if { |i| i[:relation] == 'isPartOf' && i[:identifier].include?('/zenodo.') && @software_upload }
 
-        related.push(relation: 'isSupplementTo', identifier: @resource.identifier.identifier) if @software_upload
+        # though this says software, it's hijacked for supplemental information for now because that is what we needed first
+        # This is adding the link back from zenodo to our datasets
+        if @software_upload
+          related.push(relation: 'isSupplementTo',
+                       identifier: StashDatacite::RelatedIdentifier.standardize_doi(@resource.identifier.identifier),
+                       scheme: 'doi')
+        end
         related ||= []
         related
       end


### PR DESCRIPTION
This builds on the previous PRs and just adds additional changes, so probably best to go through those in order first.

Moved the former choose-license to a different partial so it can be resurrected when it comes back again.

Migration to add all of the non-obsolete licenses, even if they don't meet the standard of open source purity (because CC-BY wasn't in the list before).

Change the submission form to always submit CC-BY-4.0

Test to be sure it is set as CC-BY-4.0