### PR TITLE
Curation state changes

### DIFF
--- a/spec/features/stash_engine/curation_activity_spec.rb
+++ b/spec/features/stash_engine/curation_activity_spec.rb
@@ -125,14 +125,14 @@ RSpec.feature 'CurationActivity', type: :feature do
 
     end
 
-    context :curating_dataset, js: true  do
+    context :curating_dataset, js: true do
 
       before(:each) do
         mock_stripe!
         mock_ror!
         @user = create(:user, tenant_id: 'ucop')
-        @resource = create(:resource, user: @user , identifier: create(:identifier))
-        create(:curation_activity_no_callbacks, status: 'curation', user_id: @user.id, resource_id: @resource.id )
+        @resource = create(:resource, user: @user, identifier: create(:identifier))
+        create(:curation_activity_no_callbacks, status: 'curation', user_id: @user.id, resource_id: @resource.id)
         @resource.resource_states.first.update(resource_state: 'submitted')
         sign_in(create(:user, role: 'superuser', tenant_id: 'ucop'))
         visit "#{dashboard_path}?curation_status=curation"
@@ -147,7 +147,7 @@ RSpec.feature 'CurationActivity', type: :feature do
         find("#resource_curation_activity_status option[value='action_required']").select_option
 
         # fill in a note
-        fill_in(id: 'resource_curation_activity_note', with: "My cat says hi")
+        fill_in(id: 'resource_curation_activity_note', with: 'My cat says hi')
         click_button('Submit')
 
         within(:css, '.c-lined-table__row', wait: 10) do

--- a/spec/features/stash_engine/curation_activity_spec.rb
+++ b/spec/features/stash_engine/curation_activity_spec.rb
@@ -131,7 +131,7 @@ RSpec.feature 'CurationActivity', type: :feature do
         mock_stripe!
         mock_ror!
         @user = create(:user, tenant_id: 'ucop')
-        @resource = create(:resource, user: @user, identifier: create(:identifier))
+        @resource = create(:resource, user: @user, identifier: create(:identifier), skip_datacite_update: true)
         create(:curation_activity_no_callbacks, status: 'curation', user_id: @user.id, resource_id: @resource.id)
         @resource.resource_states.first.update(resource_state: 'submitted')
         sign_in(create(:user, role: 'superuser', tenant_id: 'ucop'))

--- a/spec/models/stash_engine/admin_datasets/curation_table_row_spec.rb
+++ b/spec/models/stash_engine/admin_datasets/curation_table_row_spec.rb
@@ -49,7 +49,7 @@ module StashEngine
 
         it 'returns only one record when id requested specifically' do
           dataset = StashEngine::AdminDatasets::CurationTableRow.where(params: {}, tenant: nil,
-                                                                        identifier_id: @identifiers[1].id).first
+                                                                       identifier_id: @identifiers[1].id).first
           expect(dataset.identifier_id).to eq(@identifiers[1].id)
         end
       end

--- a/spec/models/stash_engine/admin_datasets/curation_table_row_spec.rb
+++ b/spec/models/stash_engine/admin_datasets/curation_table_row_spec.rb
@@ -23,16 +23,13 @@ module StashEngine
           @tenant = StashEngine::Tenant.find('ucop')
         end
 
-        # TODO: Fix this intermittently-failing test. Ticket #806.
-        # Probably need to make a factory for the @tenant
-        xit "returns records only matching tenant_id when author RORs aren't set" do
+        it "returns records only matching tenant_id when author RORs aren't set" do
           @datasets = StashEngine::AdminDatasets::CurationTableRow.where(params: {}, tenant: @tenant)
           # this should only return the first dataset which belongs to the ucop tenant
           expect(@datasets.length).to eql(1)
         end
 
-        # [TODO] Fix this intermittently-failing test. Ticket #806.
-        xit 'returns both matching tenant results AND authors with RORs for a partner' do
+        it 'returns both matching tenant results AND authors with RORs for a partner' do
           # make this random author claim to be part of this institution though not submitted under it
           @identifiers.second.resources.first.authors.first.affiliations.first.update(ror_id: @tenant.ror_ids.first)
 
@@ -41,14 +38,19 @@ module StashEngine
           expect(@datasets.length).to eql(2)
         end
 
-        # [TODO] Fix this intermittently-failing test. Ticket #806.
-        xit "doesn't duplicate results when multiple authors are from same ROR affiliation" do
+        it "doesn't duplicate results when multiple authors are from same ROR affiliation" do
           @identifiers.second.resources.first.authors << create(:author)
           @identifiers.second.resources.first.authors.first.affiliations.first.update(ror_id: @tenant.ror_ids.first)
           @identifiers.second.resources.first.authors.second.affiliations.first.update(ror_id: @tenant.ror_ids.first)
 
           @datasets = StashEngine::AdminDatasets::CurationTableRow.where(params: {}, tenant: @tenant)
           expect(@datasets.length).to eql(2)
+        end
+
+        it 'returns only one record when id requested specifically' do
+          dataset = StashEngine::AdminDatasets::CurationTableRow.where(params: {}, tenant: nil,
+                                                                        identifier_id: @identifiers[1].id).first
+          expect(dataset.identifier_id).to eq(@identifiers[1].id)
         end
       end
     end

--- a/spec/models/stash_engine/curation_activity_spec.rb
+++ b/spec/models/stash_engine/curation_activity_spec.rb
@@ -150,5 +150,15 @@ module StashEngine
       end
     end
 
+    describe 'self.allowed_states(current_state)' do
+      it 'indicates the states that are allowed from each' do
+        expect(CurationActivity.allowed_states('curation')).to \
+          eq(%w[peer_review curation action_required withdrawn embargoed published])
+
+        expect(CurationActivity.allowed_states('withdrawn')).to \
+          eq(%w[withdrawn curation])
+      end
+    end
+
   end
 end

--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -73,6 +73,7 @@ module StashEngine
       end
     end
 
+    # rubocop:disable Metrics/AbcSize
     def curation_activity_change
       respond_to do |format|
         format.js do
@@ -96,6 +97,7 @@ module StashEngine
         end
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     # show curation activities for this item
     def activity_log

--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -74,7 +74,7 @@ module StashEngine
       end
     end
 
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def curation_activity_change
       respond_to do |format|
         format.js do
@@ -82,10 +82,12 @@ module StashEngine
           @resource = @identifier.last_submitted_resource
           @last_resource = @identifier.resources.order(id: :desc).first # the last resource of all, even not submitted
 
-          return publishing_error if @resource.id != @last_resource.id && %w[embargoed published].include?(params[:resource][:curation_activity][:status])
+          if @resource.id != @last_resource.id && %w[embargoed published].include?(params[:resource][:curation_activity][:status])
+            return publishing_error
+          end
 
           @last_state = @resource&.curation_activities&.last&.status
-          @this_state = ( params[:resource][:curation_activity][:status].blank? ? @last_state : params[:resource][:curation_activity][:status] )
+          @this_state = (params[:resource][:curation_activity][:status].blank? ? @last_state : params[:resource][:curation_activity][:status])
 
           return state_error unless CurationActivity.allowed_states(@last_state).include?(@this_state)
 
@@ -104,7 +106,7 @@ module StashEngine
         end
       end
     end
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     # show curation activities for this item
     def activity_log

--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -92,6 +92,7 @@ module StashEngine
                                                                    note: @note)
           @resource.save
           @resource.reload
+          @curation_row = StashEngine::AdminDatasets::CurationTableRow.where(params: {}, tenant: nil, identifier_id: @resource.identifier.id).first
         end
       end
     end

--- a/stash/stash_engine/app/helpers/stash_engine/admin_datasets_helper.rb
+++ b/stash/stash_engine/app/helpers/stash_engine/admin_datasets_helper.rb
@@ -12,24 +12,13 @@ module StashEngine
       end
     end
 
+    # this is crazy and needlessly complex
     def filter_status_select(current_status)
-      statuses = StashEngine::CurationActivity.statuses
+      statuses = StashEngine::CurationActivity.allowed_states(current_status)
 
-      case current_status
-      when 'submitted'
-        statuses = statuses.select { |s| %w[curation withdrawn peer_review].include?(s) }
-      when 'peer_review'
-        statuses = statuses.select { |s| %w[curation withdrawn].include?(s) }
-      when 'withdrawn'
-        statuses = statuses.select { |s| %w[curation].include?(s) }
-      when 'embargoed'
-        statuses = statuses.select { |s| %w[curation withdrawn published].include?(s) }
-      else
-        unavailable = %w[in_progress submitted]
-        unavailable << current_status
-        statuses = statuses.reject { |s| unavailable.include?(s) }
-      end
+      statuses.delete(current_status) # because we don't show the current state as an option, it is implied by leaving state blank
 
+      # makes select list
       status_select(statuses)
     end
 

--- a/stash/stash_engine/app/helpers/stash_engine/admin_datasets_helper.rb
+++ b/stash/stash_engine/app/helpers/stash_engine/admin_datasets_helper.rb
@@ -12,7 +12,6 @@ module StashEngine
       end
     end
 
-    # this is crazy and needlessly complex
     def filter_status_select(current_status)
       statuses = StashEngine::CurationActivity.allowed_states(current_status)
 

--- a/stash/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -136,7 +136,7 @@ module StashEngine
     end
 
     def self.allowed_states(current_state)
-      CURATOR_ALLOWED_STATES[current_state]
+      CURATOR_ALLOWED_STATES[current_state].dup
     end
 
     # Private methods

--- a/stash/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -42,14 +42,14 @@ module StashEngine
     # Note that setting the next state to the same as the current state is just to add a note and doesn't actually
     # change state in practice.  The UI may choose not to display the same state in the list, but it is allowed.
     CURATOR_ALLOWED_STATES = {
-        in_progress: %w[in_progress],
-        submitted: %w[submitted curation withdrawn peer_review],
-        peer_review: %w[peer_review curation withdrawn],
-        curation: ( enum_vals - %w[in_progress submitted] ),
-        action_required: ( enum_vals - %w[in_progress submitted] ),
-        withdrawn: %w[withdrawn curation],
-        embargoed: %w[embargoed curation withdrawn published],
-        published: ( enum_vals - %w[in_progress submitted] )
+      in_progress: %w[in_progress],
+      submitted: %w[submitted curation withdrawn peer_review],
+      peer_review: %w[peer_review curation withdrawn],
+      curation: (enum_vals - %w[in_progress submitted]),
+      action_required: (enum_vals - %w[in_progress submitted]),
+      withdrawn: %w[withdrawn curation],
+      embargoed: %w[embargoed curation withdrawn published],
+      published: (enum_vals - %w[in_progress submitted])
     }.with_indifferent_access.freeze
 
     # Validations

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_activity_log_row.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_activity_log_row.html.erb
@@ -1,6 +1,7 @@
 <% # pass in local of curation_activity %>
 <tr class="c-lined-table__row">
   <td><%= formatted_datetime(curation_activity.created_at) %></td>
+  <td><%= curation_activity.resource.stash_version.version %></td>
   <td><%= curation_activity.readable_status %></td>
   <td><%= curation_activity.user&.name || "System" %></td>
   <td><%= curation_activity.note %></td>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_curation_activity_form.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_curation_activity_form.html.erb
@@ -1,6 +1,4 @@
-<% # local: resource, curation_activity, original_resource_id
-   # original_resource_id is the resource that was passed into the dialog and is identified in the list but may be stale/obsolete
-%>
+<% # locals: resource, curation_activity %>
 <div class="o-admin-dialog">
 
   <%= form_for :resource, url: curation_activity_change_path(resource.id), method: :post, remote: true do |f| %>
@@ -32,7 +30,7 @@
       </div>
     <% end %>
 
-    <%= hidden_field_tag :original_resource_id, original_resource_id %>
+    <%= hidden_field_tag :identifier_id, @resource.identifier_id %>
 
     <%= submit_tag 'Submit' %>
     <%= button_tag 'Cancel', type: 'button', id: 'cancel_dialog' %>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_curation_activity_form.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_curation_activity_form.html.erb
@@ -1,4 +1,6 @@
-<% # local: resource, curation_activity %>
+<% # local: resource, curation_activity, original_resource_id
+   # original_resource_id is the resource that was passed into the dialog and is identified in the list but may be stale/obsolete
+%>
 <div class="o-admin-dialog">
 
   <%= form_for :resource, url: curation_activity_change_path(resource.id), method: :post, remote: true do |f| %>
@@ -29,6 +31,8 @@
         <%= ca.text_area :note, class: 'c-input__textarea' %>
       </div>
     <% end %>
+
+    <%= hidden_field_tag :original_resource_id, original_resource_id %>
 
     <%= submit_tag 'Submit' %>
     <%= button_tag 'Cancel', type: 'button', id: 'cancel_dialog' %>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_datasets_row.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_datasets_row.html.erb
@@ -1,5 +1,5 @@
 <%# takes dataset as local variable, dataset is a custom object of type StashEngine::AdminDatasets::CurationTableRow %>
-<tr class="c-lined-table__row">
+<tr class="c-lined-table__row" id="js-dataset-row-id-<%= dataset.identifier_id %>">
   <td class="c-admin-hide-border-right">
     <% if dataset&.qualified_identifier %>
       <%= link_to dataset.title, show_path(id: dataset.qualified_identifier), target: :blank %>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_datasets_row.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_datasets_row.html.erb
@@ -28,7 +28,7 @@
   <td class="c-admin-hide-border-left">
     <% if current_user.superuser? && dataset.resource_state == 'submitted' %>
       <%= form_tag({ controller: '/stash_engine/admin_datasets',
-                     action: 'curation_activity_popup', id: dataset.resource_id },
+                     action: 'curation_activity_popup', id: dataset.identifier_id },
                    method: :get, remote: true) do -%>
         <button class="c-admin-edit-icon" aria-label="Update status" alt="Update status">
           <i class="fa fa-pencil" aria-hidden="true"></i>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_datasets_row.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_datasets_row.html.erb
@@ -1,0 +1,62 @@
+<%# takes dataset as local variable, dataset is a custom object of type StashEngine::AdminDatasets::CurationTableRow %>
+<tr class="c-lined-table__row">
+  <td class="c-admin-hide-border-right">
+    <% if dataset&.qualified_identifier %>
+      <%= link_to dataset.title, show_path(id: dataset.qualified_identifier), target: :blank %>
+    <% else %>
+      <%= dataset.title %>
+    <% end %>
+  </td>
+  <td class="c-admin-hide-border-left" id="js-edit-dataset-button-column-<%= dataset.resource_id %>">
+    <%# only with permission and not being messed with or in_progress or they're the ones futzing with it and making it in progress, lockout other concurrent editing %>
+    <% if (dataset.resource&.permission_to_edit?(user: current_user) && dataset.resource_state == 'submitted') ||
+        (dataset.resource_state == 'in_progress' && dataset.resource.current_editor_id == current_user.id)
+    %>
+      <%= render partial: 'stash_engine/admin_datasets/edit_dataset_button', locals: { resource_id: dataset.resource_id } %>
+    <% end %>
+    <%= render partial: 'stash_engine/admin_datasets/show_stats_button', locals: { resource_id: dataset.resource_id } %>
+  </td>
+  <td class="c-admin-hide-border-right" id="js-curation-state-<%= dataset.identifier_id %>">
+    <% if (dataset.resource_state == 'error') %>
+      Merritt Error
+    <% elsif (dataset.resource_state == 'processing') %>
+      Processing
+    <% else %>
+      <%= StashEngine::CurationActivity.readable_status(dataset.status) %>
+    <% end %>
+  </td>
+  <td class="c-admin-hide-border-left">
+    <% if current_user.superuser? && dataset.resource_state == 'submitted' %>
+      <%= form_tag({ controller: '/stash_engine/admin_datasets',
+                     action: 'curation_activity_popup', id: dataset.resource_id },
+                   method: :get, remote: true) do -%>
+        <button class="c-admin-edit-icon" aria-label="Update status" alt="Update status">
+          <i class="fa fa-pencil" aria-hidden="true"></i>
+        </button>
+      <% end %>
+    <% end %>
+  </td>
+  <td>
+    <% if (dataset&.author_names&.length || 0) > 50 %>
+      <%= "#{dataset.author_names[0..49]} ..." %>
+    <% else %>
+      <%= dataset.author_names %>
+    <% end %>
+  </td>
+  <td><%= dataset.identifier %></td>
+  <td class="c-admin-hide-border-right" id="js-curation-activity-date-<%= dataset.identifier_id %>">
+    <%= formatted_datetime(dataset.updated_at) %>
+  </td>
+  <td class="c-admin-hide-border-left">
+    <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'activity_log', id: dataset.identifier_id }, method: :get) do -%>
+      <button class="c-admin-edit-icon" aria-label="View Activity Log" alt="View Activity Log">
+        <i class="fa fa-clock-o" aria-hidden="true"></i>
+      </button>
+    <% end %>
+  </td>
+  <td id="js-curation-activity-user-<%= dataset.identifier_id %>"><%= dataset.editor_name %></td>
+  <td><%= filesize(dataset.storage_size) %></td>
+  <td class="c-admin" id="js-embargo-state-<%= dataset.identifier_id %>">
+    <%= formatted_date(dataset.publication_date) %>
+  </td>
+</tr>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -28,67 +28,7 @@
   </tr>
 
   <% datasets.each do |dataset| %>
-    <tr class="c-lined-table__row">
-      <td class="c-admin-hide-border-right">
-        <% if dataset&.qualified_identifier %>
-            <%= link_to dataset.title, show_path(id: dataset.qualified_identifier), target: :blank %>
-        <% else %>
-          <%= dataset.title %>
-        <% end %>
-      </td>
-      <td class="c-admin-hide-border-left" id="js-edit-dataset-button-column-<%= dataset.resource_id %>">
-        <%# only with permission and not being messed with or in_progress or they're the ones futzing with it and making it in progress, lockout other concurrent editing %>
-        <% if (dataset.resource&.permission_to_edit?(user: current_user) && dataset.resource_state == 'submitted') ||
-            (dataset.resource_state == 'in_progress' && dataset.resource.current_editor_id == current_user.id)
-        %>
-          <%= render partial: 'stash_engine/admin_datasets/edit_dataset_button', locals: { resource_id: dataset.resource_id } %>
-        <% end %>
-          <%= render partial: 'stash_engine/admin_datasets/show_stats_button', locals: { resource_id: dataset.resource_id } %>
-      </td>
-      <td class="c-admin-hide-border-right" id="js-curation-state-<%= dataset.identifier_id %>">
-	  <% if (dataset.resource_state == 'error') %>
-	      Merritt Error
-	  <% elsif (dataset.resource_state == 'processing') %>
-	      Processing
-	  <% else %>
-              <%= StashEngine::CurationActivity.readable_status(dataset.status) %>
-	  <% end %>
-      </td>
-      <td class="c-admin-hide-border-left">
-        <% if current_user.superuser? && dataset.resource_state == 'submitted' %>
-          <%= form_tag({ controller: '/stash_engine/admin_datasets',
-                         action: 'curation_activity_popup', id: dataset.resource_id },
-                         method: :get, remote: true) do -%>
-            <button class="c-admin-edit-icon" aria-label="Update status" alt="Update status">
-              <i class="fa fa-pencil" aria-hidden="true"></i>
-            </button>
-          <% end %>
-        <% end %>
-      </td>
-      <td>
-        <% if (dataset&.author_names&.length || 0) > 50 %>
-          <%= "#{dataset.author_names[0..49]} ..." %>
-        <% else %>
-          <%= dataset.author_names %>
-        <% end %>
-      </td>
-      <td><%= dataset.identifier %></td>
-      <td class="c-admin-hide-border-right" id="js-curation-activity-date-<%= dataset.identifier_id %>">
-        <%= formatted_datetime(dataset.updated_at) %>
-      </td>
-      <td class="c-admin-hide-border-left">
-        <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'activity_log', id: dataset.identifier_id }, method: :get) do -%>
-          <button class="c-admin-edit-icon" aria-label="View Activity Log" alt="View Activity Log">
-            <i class="fa fa-clock-o" aria-hidden="true"></i>
-          </button>
-        <% end %>
-      </td>
-      <td id="js-curation-activity-user-<%= dataset.identifier_id %>"><%= dataset.editor_name %></td>
-      <td><%= filesize(dataset.storage_size) %></td>
-      <td class="c-admin" id="js-embargo-state-<%= dataset.identifier_id %>">
-        <%= formatted_date(dataset.publication_date) %>
-      </td>
-    </tr>
+    <%= render partial: 'stash_engine/admin_datasets/datasets_row', locals: { dataset: dataset } %>
   <% end %>
   <% if datasets.empty? %>
     <tr><td colspan="8">

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/activity_log.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/activity_log.html.erb
@@ -5,7 +5,7 @@
   <div style="float: left;"><br/><%= @identifier.to_s %></div>
   <% if current_user.superuser? %>
     <div style="float: right;">
-      <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'note_popup', id: @identifier&.latest_resource&.id }, method: :get, remote: true) do -%>
+      <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'note_popup', id: @identifier&.id }, method: :get, remote: true) do -%>
         <button class="o-button__submit">Add Note</button>
       <% end %>
     </div>
@@ -15,6 +15,9 @@
     <tr class="c-lined-table__head">
       <th class="c-admin-table <%= sort_display('created_at') %>">
         <%= sortable_column_head sort_field: 'created_at', title: 'Timestamp' %>
+      </th>
+      <th class="c-admin-table">
+        Version
       </th>
       <th class="c-admin-table">
         Status

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/curation_activity_change.js.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/curation_activity_change.js.erb
@@ -1,8 +1,9 @@
+<% # it might be easier just to redraw this row rather than changing all this individually? %>
 <% if @resource.current_curation_activity.curation? %>
-  $("#js-edit-dataset-button-column-<%= @resource.id %>").html("<%= escape_javascript(render partial: 'stash_engine/admin_datasets/edit_dataset_button', locals: { resource_id: @resource.id }) %>");
+  $("#js-edit-dataset-button-column-<%= @resource_display_id %>").html("<%= escape_javascript(render partial: 'stash_engine/admin_datasets/edit_dataset_button', locals: { resource_id: @resource.id }) %>");
 <% end %>
-$("#js-curation-state-<%= @resource.identifier.id %>").html("<%= @resource.current_curation_activity.readable_status %>");
-$("#js-embargo-state-<%= @resource.identifier.id %>").html("<%= formatted_date(@resource.publication_date) %>");
-$("#js-curation-activity-date-<%= @resource.identifier.id %>").html("<%= formatted_datetime(@resource.current_curation_activity&.created_at) %>");
-$("#js-curation-activity-user-<%= @resource.identifier.id %>").html("<%= @resource.current_curation_activity.user&.name %>");
+$("#js-curation-state-<%= @resource_display_id %>").html("<%= @resource.current_curation_activity.readable_status %>");
+$("#js-embargo-state-<%= @resource_display_id %>").html("<%= formatted_date(@resource.publication_date) %>");
+$("#js-curation-activity-date-<%= @resource_display_id %>").html("<%= formatted_datetime(@resource.current_curation_activity&.created_at) %>");
+$("#js-curation-activity-user-<%= @resource_display_id %>").html("<%= @resource.current_curation_activity.user&.name %>");
 $("#popup_dialog").dialog("close");

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/curation_activity_change.js.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/curation_activity_change.js.erb
@@ -1,9 +1,5 @@
-<% # it might be easier just to redraw this row rather than changing all this individually? %>
-<% if @resource.current_curation_activity.curation? %>
-  $("#js-edit-dataset-button-column-<%= @resource_display_id %>").html("<%= escape_javascript(render partial: 'stash_engine/admin_datasets/edit_dataset_button', locals: { resource_id: @resource.id }) %>");
-<% end %>
-$("#js-curation-state-<%= @resource_display_id %>").html("<%= @resource.current_curation_activity.readable_status %>");
-$("#js-embargo-state-<%= @resource_display_id %>").html("<%= formatted_date(@resource.publication_date) %>");
-$("#js-curation-activity-date-<%= @resource_display_id %>").html("<%= formatted_datetime(@resource.current_curation_activity&.created_at) %>");
-$("#js-curation-activity-user-<%= @resource_display_id %>").html("<%= @resource.current_curation_activity.user&.name %>");
+<% # redrawing full row rather than trying to fix each item.  Will I need to reattach all button events after?  So far doesn't seem like it. %>
+
+$("#js-dataset-row-id-<%= @resource.identifier.id %>").replaceWith("<%= escape_javascript(render partial: 'stash_engine/admin_datasets/datasets_row', locals: { dataset: @curation_row }) %>")
+
 $("#popup_dialog").dialog("close");

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/curation_activity_error.js.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/curation_activity_error.js.erb
@@ -1,0 +1,24 @@
+// replace dialog div with contents of dialog text from partial
+<% title = @resource.title.html_safe %>
+
+$('#popup_dialog').html("<%= escape_javascript(@error_message) %>");
+
+// now open a jquery ui modal dialog
+$(function() {
+
+    $("#popup_dialog").dialog({
+        autoOpen: true,
+        height: 'auto',
+        width: '500px',
+        modal: true,
+        title: '<%= escape_javascript(title) %>'
+    });
+
+    $(document).keyup(function(e) {
+        if (e.key === "Escape") { // escape key maps to keycode `27`
+            $("#popup_dialog").dialog("close");
+        }
+    });
+
+
+});

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/curation_activity_popup.js.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/curation_activity_popup.js.erb
@@ -3,7 +3,7 @@
 
 $('#popup_dialog').html("<%= escape_javascript(
           render partial: 'stash_engine/admin_datasets/curation_activity_form', locals: {
-            resource: @resource, curation_activity: @curation_activity }) %>");
+            resource: @resource, curation_activity: @curation_activity, original_resource_id: @original_resource.id }) %>");
 
 // now open a jquery ui modal dialog
 $(function() {

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/curation_activity_popup.js.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/curation_activity_popup.js.erb
@@ -3,7 +3,7 @@
 
 $('#popup_dialog').html("<%= escape_javascript(
           render partial: 'stash_engine/admin_datasets/curation_activity_form', locals: {
-            resource: @resource, curation_activity: @curation_activity, original_resource_id: @original_resource.id }) %>");
+            resource: @resource, curation_activity: @curation_activity}) %>");
 
 // now open a jquery ui modal dialog
 $(function() {


### PR DESCRIPTION
This should fix problems with curation states being applied out of order because.

It is applied to the latest version of the dataset if it is possible and the state follows from a previous state.  It also will not apply an embargo or publication state if there is a version that is still being modified or hasn't gone through submission completely.

It refreshes the entire row for a dataset after a curation activity, also.

It is actually kind of hard to get bad states, but you can get one of two different new error messages if you 1) open the "change curation state" modal dialog in one window and 2) open another window and apply changes to the dataset.

There is one error because you're trying to publish or embargo (release metadata) while the dataset is still submitting or in-progress.

The other error you can get is if you change the curation status in another window and then try to apply an illegal status in the dialog you left open in the other window.

I revised quite a bit of the process and ajax and also added some tests and tried make it clearer which states follow from which other states.

I didn't add all possible simultaneous state changes in the UI, but there is a test which goes through the process of changing curation state through the UI and verifies that it saves.