### PR TITLE
adding link to Board COI forms

### DIFF
--- a/app/views/layouts/_our_governance.html.md
+++ b/app/views/layouts/_our_governance.html.md
@@ -87,3 +87,5 @@
 <h2>Board Information</h2>
 
 Dryad Board maintains <a href=https://github.com/datadryad/governance/blob/main/meeting-minutes/index.md>meeting minutes</a> for all of its meetings.
+
+<a href=https://github.com/datadryad/governance/blob/main/COIs/index.md>Dryad Board Conflict of Interest Forms</a>


### PR DESCRIPTION
Adding link to Board COI forms on the governance web page