### PR TITLE
Ignore insert errors

### DIFF
--- a/stash/stash_engine/db/migrate/20201102215917_add_admin_user.rb
+++ b/stash/stash_engine/db/migrate/20201102215917_add_admin_user.rb
@@ -1,6 +1,6 @@
 class AddAdminUser < ActiveRecord::Migration[5.2]
   def up
-    execute "INSERT INTO stash_engine_users (id, first_name, last_name, role, created_at, updated_at) VALUES (0, 'Dryad', 'System', 'user', '2020-01-01', '2020-01-01')"
+    execute "INSERT IGNORE INTO stash_engine_users (id, first_name, last_name, role, created_at, updated_at) VALUES (0, 'Dryad', 'System', 'user', '2020-01-01', '2020-01-01')"
   end
 
   def down


### PR DESCRIPTION
Small tweak to the add_admin_user migration to ensure it will work even if the System user already exists.