### PR TITLE
Switch ftp to sftp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'bootsnap', require: false
 gem 'exception_notification'
 gem 'httparty'
 gem 'jbuilder', '~> 2.0'
+gem 'net-sftp'
 gem 'stripe'
 
 # #########################

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -530,6 +530,8 @@ GEM
       connection_pool (~> 2.2)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
+    net-sftp (3.0.0)
+      net-ssh (>= 5.0.0, < 7.0.0)
     net-ssh (6.1.0)
     netrc (0.11.0)
     nio4r (2.5.4)
@@ -859,6 +861,7 @@ DEPENDENCIES
   listen
   mocha
   mysql2 (~> 0.5.3)
+  net-sftp
   oai
   passenger (~> 6.0.5)
   pry

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -144,7 +144,7 @@ defaults: &DEFAULTS
       ftp_provider_id: 1012
     # LinkOut FTP information for NCBI
     pubmed:
-      ftp_host: ftp-private.ncbi.nlm.nih.gov
+      ftp_host: sftp-private.ncbi.nlm.nih.gov
       ftp_dir: holdings
       ftp_username: <%= Rails.application.credentials[Rails.env.to_sym][:pubmed_ftp_username] %> 
       ftp_password: <%= Rails.application.credentials[Rails.env.to_sym][:pubmed_ftp_password] %> 


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/820

Since NCBI doesn't have a test server, we cannot fully test this until it is deployed to production, but I have tested it with transferring some dummy files, and those appear fine.

Note that this does *not* switch the transfer mechanism for LabsLink. Although that system uses the same files, they have not converted their servers to SFTP yet.