### PR TITLE
Removes rails environment variable not available in non-rails env

### DIFF
--- a/stash/script/counter-uploader/submitted_reports.rb
+++ b/stash/script/counter-uploader/submitted_reports.rb
@@ -31,7 +31,7 @@ class SubmittedReports
   def list_reports(retries: 12)
     puts 'Asking for list of reports from DataCite.  This might take a long while.'
 
-    resp = get_with_retries("https://api.datacite.org/reports?client-id=#{APP_CONFIG[:counter][:account]}&page[size]=500", retries: retries)
+    resp = get_with_retries("https://api.datacite.org/reports?client-id=CDL.DASH&page[size]=500", retries: retries)
 
     json = resp.parse
 

--- a/stash/script/counter-uploader/submitted_reports.rb
+++ b/stash/script/counter-uploader/submitted_reports.rb
@@ -31,7 +31,7 @@ class SubmittedReports
   def list_reports(retries: 12)
     puts 'Asking for list of reports from DataCite.  This might take a long while.'
 
-    resp = get_with_retries("https://api.datacite.org/reports?client-id=CDL.DASH&page[size]=500", retries: retries)
+    resp = get_with_retries('https://api.datacite.org/reports?client-id=CDL.DASH&page[size]=500', retries: retries)
 
     json = resp.parse
 


### PR DESCRIPTION
Because this is a standalone script and doesn't have access to this variable.  I think I changed this at some point with some updates by mistake.

