### PR TITLE
Get working under Python 3.7 and log cleanup fix

### DIFF
--- a/cron/counter.sh
+++ b/cron/counter.sh
@@ -25,8 +25,9 @@ bundle exec rails counter:combine_files
 # set up python and run counter-processor (maybe twice)
 # ---------------------------------------
 echo "Running counter-processor"
-export PATH=$HOME/opt/bin:$PATH
-export PYTHONPATH=$HOME/opt/bin/python-3.6.9
+export VIRTUAL_ENV=/apps/dryad/python_venv/python3.7.9
+export PATH=$VIRTUAL_ENV/bin:$PATH
+export PYTHONPATH=$VIRTUAL_ENV
 python --version
 cd /apps/dryad/apps/counter/counter-processor
 # may need to to run the following lines to get dependencies (like bundler) before the first time the processor is run

--- a/cron/production_counter.sh
+++ b/cron/production_counter.sh
@@ -1,3 +1,3 @@
 # specifics for environment that get sourced into the counter.sh
 export SCP_HOSTS="uc3-dryaduix2-prd-2c.cdlib.org"
-COUNTER_JSON_STORAGE="/apps/dryad-prd-shared/json-reports"
+export COUNTER_JSON_STORAGE="/apps/dryad-prd-shared/json-reports"

--- a/stash/stash_engine/lib/tasks/counter.rake
+++ b/stash/stash_engine/lib/tasks/counter.rake
@@ -17,6 +17,7 @@ namespace :counter do
   task :remove_old_logs do
     lc = Counter::LogCombiner.new(log_directory: ENV['LOG_DIRECTORY'], scp_hosts: ENV['SCP_HOSTS'].split(' '), scp_path: ENV['LOG_DIRECTORY'])
     lc.remove_old_logs(days_old: 60)
+    lc.remove_old_logs_remote(days_old: 60)
   end
 
   desc 'validate counter logs format (filenames come after rake task)'

--- a/stash/stash_engine/lib/tasks/counter/log_combiner.rb
+++ b/stash/stash_engine/lib/tasks/counter/log_combiner.rb
@@ -59,6 +59,21 @@ module Counter
       end
     end
 
+    def remove_old_logs_remote(days_old: 60)
+      # ssh dryad@uc3-dryaduix2-prd-2c.cdlib.org "rm -f /apps/dryad/apps/ui/current/log/counter_2020-09-01.log"
+      @scp_hosts.each do |host|
+        log_filenames = `ssh #{USERNAME}@#{host} "cd /apps/dryad/apps/ui/current/log/; ls counter_*.log -1a"`.split("\n")
+        log_filenames.each do |fn|
+          m = ANY_LOG_FN_PATTERN.match(fn)
+          log_date = Time.new(m[1], m[2], m[3])
+          if log_date < Time.new - days_old.days
+            `ssh #{USERNAME}@#{host} "rm -f /apps/dryad/apps/ui/current/log/#{fn}"`
+            puts "Deleted #{fn}"
+          end
+        end
+      end
+    end
+
     # --- Private methods below ---
 
     private
@@ -71,6 +86,5 @@ module Counter
 
       puts "Skipped downloading #{host}:#{filename} file doesn't exist on secondary server"
     end
-
   end
 end


### PR DESCRIPTION
These are two separate changes.

1. Sets the environment variables and other things necessary to get it working under Python 3.7.9 with virtualenv which Ashley installed.
2. The remote counter logs (older than 60 days) from the other server were not getting deleted, just the one on the server.

For the deletion, it is hard to test this in our testing framework, but I duplicated the code changes onto the server and tested it there.  If you wanted to try it there you could add a file like `counter_2020-09-01.log` to the directory on `dryad@uc3-dryaduix2-prd-2c:~/apps/ui/current/log` and then run `bundle exec rails counter:remove_old_logs` on `2a` and then check that the older counter log file on 2c that you created is now gone. 

You'll notice that the "remove_old_logs_remote" is the same logic and structure as the "remove_old_logs" with only three real differences.  1) It iterates through each remote host defined, 2) it gets the list of files with an ssh command instead of from a local command and 3) it deletes with an ssh command instead of a local File.delete(fn) command.