### PR TITLE
Adding log check for counter upload logs

### DIFF
--- a/spec/fixtures/counter_processor/sample_log.txt
+++ b/spec/fixtures/counter_processor/sample_log.txt
@@ -1,0 +1,45 @@
+<replace-time> 21067/21067 Calculating stats for doi:10.5061/dryad.ss25rp7
+
+submitted
+
+Remove old logs past their deletion time
+fatal: not a git repository (or any parent up to mount point /apps)
+Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
+fatal: not a git repository (or any parent up to mount point /apps)
+Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
+fatal: not a git repository (or any parent up to mount point /apps)
+Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
+fatal: not a git repository (or any parent up to mount point /apps)
+Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
+fatal: not a git repository (or any parent up to mount point /apps)
+Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
+fatal: not a git repository (or any parent up to mount point /apps)
+Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
+fatal: not a git repository (or any parent up to mount point /apps)
+Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
+fatal: not a git repository (or any parent up to mount point /apps)
+Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
+fatal: not a git repository (or any parent up to mount point /apps)
+Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
+fatal: not a git repository (or any parent up to mount point /apps)
+Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
+There was an error and rspec was not available.
+Deleted counter_2020-09-12.log_combined
+Deleted counter_2020-09-14.log
+Deleted counter_2020-09-16.log_0
+Deleted counter_2020-09-12.log_0
+Deleted counter_2020-09-13.log
+Deleted counter_2020-09-14.log_0
+Deleted counter_2020-09-15.log
+Deleted counter_2020-09-15.log_0
+Deleted counter_2020-09-12.log
+Deleted counter_2020-09-11.log_combined
+Deleted counter_2020-09-11.log
+Deleted counter_2020-09-16.log_combined
+Deleted counter_2020-09-16.log
+Deleted counter_2020-09-13.log_0
+Deleted counter_2020-09-13.log_combined
+Deleted counter_2020-09-11.log_0
+Deleted counter_2020-09-14.log_combined
+Deleted counter_2020-09-15.log_combined
+Deleted counter_2020-09-04.log

--- a/spec/services/stash_engine/status_dashboard/counter_calculation_service_spec.rb
+++ b/spec/services/stash_engine/status_dashboard/counter_calculation_service_spec.rb
@@ -1,0 +1,73 @@
+require 'byebug'
+
+require 'rails_helper'
+require 'fileutils'
+
+RSpec.configure(&:infer_spec_type_from_file_location!)
+
+module StashEngine
+  module StatusDashboard
+    describe CounterCalculationService do
+      before(:each) do
+        @cc_service = StashEngine::StatusDashboard::CounterCalculationService.new
+      end
+
+      it "returns false if the log file doesn't exist" do
+        result = @cc_service.check_counter_log('/badpath')
+        expect(result[0]).to eq(false)
+        expect(result[1]).to eq('Log file does not exist')
+      end
+
+      it 'returns false if there is no date in the file' do
+        f = Rails.root.join('spec', 'fixtures', 'counter_processor', 'sample_log.txt').to_s
+        result = @cc_service.check_counter_log(f)
+        expect(result[0]).to eq(false)
+        expect(result[1]).to eq("Log file doesn't contain an output date")
+      end
+
+      it 'returns false if the last date is long ago' do
+        sample_file = Rails.root.join('spec', 'fixtures', 'counter_processor', 'sample_log.txt').to_s
+        temp_file = Rails.root.join('spec', 'fixtures', 'counter_processor', 'temp_log').to_s
+        contents = File.read(sample_file)
+        contents.gsub!('<replace-time>', (Time.new - 86_400 * 7).strftime('%Y-%m-%d %H:%M:%S'))
+        File.write(temp_file, contents)
+
+        result = @cc_service.check_counter_log(temp_file)
+        expect(result[0]).to eq(false)
+        expect(result[1]).to eq("Counter hasn't successfully processed this week")
+
+        File.delete(temp_file)
+      end
+
+      it 'returns false if not submitted' do
+        sample_file = Rails.root.join('spec', 'fixtures', 'counter_processor', 'sample_log.txt').to_s
+        temp_file = Rails.root.join('spec', 'fixtures', 'counter_processor', 'temp_log').to_s
+        contents = File.read(sample_file)
+        contents.gsub!('<replace-time>', (Time.new - 86_400).strftime('%Y-%m-%d %H:%M:%S'))
+        contents.gsub!(/^submitted/, '')
+        File.write(temp_file, contents)
+
+        result = @cc_service.check_counter_log(temp_file)
+        expect(result[0]).to eq(false)
+        expect(result[1]).to eq("Counter doesn't seem to have successfully submitted this week")
+
+        File.delete(temp_file)
+      end
+
+      it 'returns true if the log file has correct output' do
+        sample_file = Rails.root.join('spec', 'fixtures', 'counter_processor', 'sample_log.txt').to_s
+        temp_file = Rails.root.join('spec', 'fixtures', 'counter_processor', 'temp_log').to_s
+        contents = File.read(sample_file)
+        contents.gsub!('<replace-time>', (Time.new - 86_400).strftime('%Y-%m-%d %H:%M:%S'))
+        File.write(temp_file, contents)
+
+        result = @cc_service.check_counter_log(temp_file)
+        expect(result[0]).to eq(true)
+        expect(result[1]).to eq('The counter log indicates successful submission to DataCite this week')
+
+        File.delete(temp_file)
+      end
+
+    end
+  end
+end

--- a/stash/stash_engine/app/services/stash_engine/status_dashboard/counter_calculation_service.rb
+++ b/stash/stash_engine/app/services/stash_engine/status_dashboard/counter_calculation_service.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module StashEngine
+  module StatusDashboard
+
+    class CounterCalculationService < DependencyCheckerService
+
+      LOG_FILE = '/dryad/apps/ui/shared/cron/logs/counter.log'
+
+      def ping_dependency
+        super
+        # Do not check unless it's Thursday or after in the week and after 9.
+        # It takes the script a while to run so we shouldn't really consider it a problem until late in the week around Thurs.
+        # Also, do not check any environments but production since we don't run and submit stats for others.
+        if (Time.new.wday < 4 && Time.new.hour < 9) || Rails.env != 'production'
+          record_status(online: true, message: "Assumed online, counter processing status isn't checked until Thursday to give time to run")
+          return true
+        end
+
+        result = check_counter_log(LOG_FILE)
+        record_status(online: result[0], message: "#{result[1]} -- See #{LOG_FILE}")
+        result[0]
+      rescue StandardError => e
+        record_status(online: false, message: e.to_s)
+        false
+      end
+
+      # passing in log since it will make it easier to test if log path is passed in
+      def check_counter_log(log)
+        # check file exists
+        return [false, 'Log file does not exist'] unless File.exist?(log)
+
+        # read the end of the log file
+        f = File.new(log)
+        # Read back approx the last 1,000 lines at 50 characters a line, one run of the processor is much more than this
+        seek_back = (f.size < 50_000 ? f.size : 50_000)
+        f.seek(-seek_back, IO::SEEK_END)
+        str = f.read
+
+        # check latest formatted date at beginning of a line like '2020-11-20 12:51:20'
+        idx = str.rindex(/^\d{4}-\d{2}-\d{2}/)
+        return [false, "Log file doesn't contain an output date"] if idx.nil?
+
+        time = str[idx, 10].to_time
+        return [false, "Counter hasn't successfully processed this week"] if ((Time.new - time) / 86_400) > 6
+
+        # check it has 'submitted' at beginning of line in recent output
+        submitted_idx = str.rindex(/^submitted/)
+        return [false, "Counter doesn't seem to have successfully submitted this week"] if submitted_idx.nil?
+
+        [true, 'The counter log indicates successful submission to DataCite this week']
+      end
+    end
+
+  end
+end

--- a/stash/stash_engine/lib/tasks/status_dashboard.rake
+++ b/stash/stash_engine/lib/tasks/status_dashboard.rake
@@ -120,6 +120,14 @@ namespace :status_dashboard do
       documentation: 'Dryad uses the EventData API to collect statistics for Counter.<br><br>The logic behind this integration can be found in `stash_engine/lib/stash/event_data`',
       internally_managed: false,
       status: 1
+    },
+    {
+      abbreviation: 'counter_calculation',
+      name: 'Counter Calculation Script',
+      description: 'Dryad calculates stats weekly and submits them to the DataCite hub, required for correct stats',
+      documentation: 'Dryad calculates the stats using a Python library that may run for a few days. https://github.com/CDLUC3/counter-processor .  It should submit stats after running and by done by late in the week (Thursday).  It checks the log to see if it ran.',
+      internally_managed: true,
+      status: 1
     }
   ].freeze
   # rubocop:enable Layout/LineLength


### PR DESCRIPTION
This will wait until Thursday every week and then check if the log looks like it has successfully processed and submitted since last week.

Should work OK because even if it fails repeatedly I think it only notifies once unless the service is flapping with failure/success/failure.