### PR TITLE
Fixing manifest upload to correctly decode encoded URLs.

### DIFF
--- a/spec/models/stash_engine/url_validator_spec.rb
+++ b/spec/models/stash_engine/url_validator_spec.rb
@@ -159,5 +159,22 @@ module StashEngine
         expect(filename).to eq('🦄.txt')
       end
     end
+
+    describe :upload_attributes_from do
+      before(:each) do
+        stub_request(:head, 'http://ftp.datadryad.org/InCuration/test-sfisher/My%20cAT%20hAS%20FlEaS.jpg')
+          .to_return(status: 200, body: '', headers: {})
+      end
+
+      it 'decodes and also makes prettier filenames with urlencoding' do
+        url_validator = UrlValidator.new(url: 'http://ftp.datadryad.org/InCuration/test-sfisher/My%20cAT%20hAS%20FlEaS.jpg')
+        resource = create(:resource)
+        translator = Stash::UrlTranslator.new('http://ftp.datadryad.org/InCuration/test-sfisher/My%20cAT%20hAS%20FlEaS.jpg')
+        result = url_validator.upload_attributes_from(translator: translator, resource: resource)
+
+        expect(result[:upload_file_name]).to eq('My_cAT_hAS_FlEaS.jpg')
+        expect(result[:original_filename]).to eq('My cAT hAS FlEaS.jpg')
+      end
+    end
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/url_validator.rb
+++ b/stash/stash_engine/app/models/stash_engine/url_validator.rb
@@ -1,6 +1,7 @@
 require 'httpclient'
 require 'net/http'
 require 'fileutils'
+require 'cgi'
 
 # getting cert errors, maybe https://www.engineyard.com/blog/ruby-ssl-error-certificate-verify-failed fixes it ?
 
@@ -79,11 +80,11 @@ module StashEngine
       # (duplicate indicated with 409 Conflict)
       return upload_attributes.merge(status_code: 409) if resource.url_in_version?(url)
 
-      sanitized_filename = StashEngine::FileUpload.sanitize_file_name(UrlValidator.make_unique(resource: resource, filename: filename))
+      sanitized_filename = StashEngine::FileUpload.sanitize_file_name(UrlValidator.make_unique(resource: resource, filename: CGI.unescape(filename)))
 
       upload_attributes.merge(
         upload_file_name: sanitized_filename,
-        original_filename: UrlValidator.make_unique(resource: resource, filename: filename),
+        original_filename: UrlValidator.make_unique(resource: resource, filename: CGI.unescape(filename)),
         upload_content_type: mime_type,
         upload_file_size: size
       )

--- a/stash/stash_engine/app/views/stash_engine/file_uploads/_manifest_upload.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/file_uploads/_manifest_upload.html.erb
@@ -2,7 +2,7 @@
 <h2 class="t-upload__choose-heading--active">Step 2: Enter Files</h2>
 
 <%= form_tag stash_engine.file_uploads_validate_urls_path(resource.id),
-             remote: true, html: { id: 'url_validate' } do  %>
+             remote: true, id: 'url_validate' do  %>
   <%= hidden_field_tag :resource_id, resource.id %>
 	<%= text_area_tag :url, '', cols: 80, rows: 15, id: 'location_urls', placeholder: 'List file location URLs here'	%>
 


### PR DESCRIPTION
CGI unescape all filenames we extract from URLs so they no longer have percent encoding in them.  This also allows the filename sanitizing and renaming to work correctly.