### PR TITLE
Editorial Manager bridge API

### DIFF
--- a/documentation/apis/emDeposit.json
+++ b/documentation/apis/emDeposit.json
@@ -1,0 +1,45 @@
+{
+    "_comment": "This is a sample file to illustrate the format of the data sent by the Editorial Manager API. Although Dryad supports this API, it is not recommended for general use, as our processing may change to suit the needs of Editorial Manager.",
+   "publication_code": "DEMO170",
+   "journal_full_title": "Journal of Demonstration for Version v17.0",
+   "document_id": "12345",
+   "authors": [ {
+      "first_name": "Amy",
+      "last_name": "Author",
+      "email": "amy.author@test.demo",
+      "people_id": "126",
+      "orcid": "1234-1234-1234-1234",
+      "corresponding": true,
+      "custom_user_ids": [
+         {
+            "custom_id": "12065346",
+            "custom_id_type": "Society ID"
+         },
+         {
+            "custom_id": "A314552",
+            "custom_id_type": "Identity Mgmt System ID"
+         }
+      ]
+   } ],
+   "file_data": {
+      "file_description": "Research Datasets",
+      "file_guid": "e88bb0fd-8fa0-4e7f-831a-6aa54c8cb803",
+      "file_custom_metadata": [
+         {
+            "field_name": "Comments",
+            "field_custom_meta_id": "cq_1",
+            "field_value": "Additional comments on the file (this field can be configured per-repository)"
+         },
+         {
+            "field_name": "Research Location",
+            "field_custom_meta_id": "cq_2",
+            "field_value": "Location provided by author (this field can also be configured per-repository)"
+         },
+         {
+            "field_name": "Research Date",
+            "field_custom_meta_id": "cq_3",
+            "field_value": "06/15/2018"
+         }
+      ]
+   }
+}

--- a/documentation/apis/emSubmission.json
+++ b/documentation/apis/emSubmission.json
@@ -1,0 +1,92 @@
+{
+    "_comment": "This is a sample file to illustrate the format of the data sent by the Editorial Manager API. Although Dryad supports this API, it is not recommended for general use, as our processing may change to suit the needs of Editorial Manager.",
+    "publication_code": "DEMO170",
+    "journal_full_title": "Journal of Demonstration for Version v17.0",
+    "embargo_type": "Publication",
+    "embargo_days": "30",
+    "article": {
+	"article_doi": "10.11260150004",
+	"document_id": "12345",
+	"manuscript_number": "DEMO170-D-19-00051",
+	"article_title": "Title of the Submission",
+	"article_type": "Original Article",
+	"abstract": "The abstract provided by the author for the entire submission appears here.",
+	"initial_date_submitted": "2019-02-28T13:32:12.000Z",
+	"revision": "2",
+	"date_revision_submitted": "2019-03-31T09:15:51.000Z",
+	"final_disposition": "ACCEPT",
+	"date_final_disposition_set": "2019-04-30T22:25:35.000Z",
+	"publication_status": "TRUE",
+	"publication_date": "2019-05-31T12:39:45.000Z",
+	"keywords": [
+            "key1",
+            "key2",
+            "key3"
+	],
+	"classifications": [
+            "class1",
+            "class2",
+            "class3"
+	],
+	"custom_question": [
+            {
+		"custom_question_name": "Custom Question on the EM site",
+		"custom_question_metadata_id": "cq001",
+		"custom_question_value": "Answer from the author"
+            },
+            {
+		"custom_question_name": "Second Custom Question",
+		"custom_question_metadata_id": "cq002",
+		"custom_question_value": "Author's answer"
+            }
+	],
+	"funding_source": [
+            {
+		"funder": "National Institutes of Health",
+		"funder_id": "http://dx.doi.org/10.13039/100000002",
+		"award_number": "12345",
+		"grant_recipient": "33182"
+            },
+            {
+		"funder": "Pan-Massachusetts Challenge",
+		"funder_id": "http://dx.doi.org/10.13039/100001286",
+		"award_number": "66-09-8877",
+		"grant_recipient": "33183"
+            }
+	]
+    },
+    "authors": [
+	{
+            "first_name": "Amy",
+            "last_name": "Author",
+            "email": "amy.author@test.demo",
+            "people_id": "126",
+	    "custom_user_ids": [
+		{
+		    "custom_id": "12065346",
+		    "custom_id_type": "Society ID"
+		},
+		{
+		    "custom_id": "A314552",
+		    "custom_id_type": "Identity Mgmt System ID"
+		}
+	    ],
+            "orcid": "1234-1234-1234-1234",
+            "institution": "Aries Systems Corporation",
+            "institution_id": "9144",
+            "corresponding": "true",
+            "author_order": "1",
+            "author_guid": "35ea4e8e-3f80-4ef7-b9b1-06d0489484bf"
+	},
+	{
+            "first_name": "Chris",
+            "last_name": "Co-Author",
+            "email": "co.author@testemail.com",
+            "institution": "sample Institution",
+            "institution_id": "10000",
+            "corresponding": "false",
+            "author_order": "2",
+            "author_guid": "3fc9fd95-1db3-4bb1-8584-805390128c21"
+	}
+    ]
+}

--- a/documentation/server_maintenance/merritt.md
+++ b/documentation/server_maintenance/merritt.md
@@ -43,7 +43,7 @@ the RepoQueueState:
 resource_ids =
   StashEngine::RepoQueueState.latest_per_resource.where(state: 'errored').order(:updated_at).map(&:resource_id)
 resource_ids.each do |res_id|
- repo_queue_id = StashEngine::RepoQueueState.where(state: 'processing', resource_id: res_id).last
+ repo_queue_id = StashEngine::RepoQueueState.where(state: 'processing', resource_id: res_id).last.id
  StashEngine::RepoQueueState.find(repo_queue_id).destroy
  StashEngine.repository.submit(resource_id: res_id)
 end

--- a/documentation/server_maintenance/troubleshooting.md
+++ b/documentation/server_maintenance/troubleshooting.md
@@ -4,8 +4,7 @@ Troubleshooting and Maintenance
 Some common problems and how to deal with them.
 
 Also see the notes on:
--
-[handling failed submissions](https://confluence.ucop.edu/display/Stash/Dryad+Operations#DryadOperations-FixingaFailedSubmission).
+- [handling failed submissions](https://confluence.ucop.edu/display/Stash/Dryad+Operations#DryadOperations-FixingaFailedSubmission).
 - [Interactions with Merritt](merritt.md)
 
 

--- a/spec/fixtures/stash_api/em_metadata.rb
+++ b/spec/fixtures/stash_api/em_metadata.rb
@@ -1,0 +1,78 @@
+require 'faker'
+require 'json'
+
+# This fixture generates metadata for the API in the format produced by Editorial Manager.
+# It should only be used for testing Editorial Manager functionality, not regular Dryad API calls.
+module Fixtures
+  module StashApi
+    class EmMetadata
+
+      def initialize
+        @metadata = ActiveSupport::HashWithIndifferentAccess.new
+      end
+
+      def hash
+        @metadata.with_indifferent_access
+      end
+
+      def json
+        @metadata.to_json
+      end
+
+      def make_deposit_metadata
+        add_journal_name
+        add_author
+      end
+
+      def make_submission_metadata
+        add_journal_name
+        add_embargo_info
+        add_article
+        add_author
+      end
+
+      def add_journal_name
+        @metadata.merge!(journal_full_title: Faker::Book.title)
+      end
+
+      def add_author
+        create_key_and_array(key: :authors)
+        @metadata[:authors].push(
+          { "first_name": Faker::Name.first_name,
+            "last_name": Faker::Name.last_name,
+            email: Faker::Internet.email,
+            orcid: "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}-" \
+                   "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}",
+            institution: Faker::University.name }.with_indifferent_access
+        )
+      end
+
+      def create_key_and_array(key:)
+        @metadata[key] = [] unless @metadata[key]
+      end
+
+      def add_embargo_info
+        @metadata.merge!(embargo_type: 'Publication')
+        @metadata.merge!(embargo_days: Faker::Number.number(digits: 2))
+      end
+
+      def add_article
+        article = ActiveSupport::HashWithIndifferentAccess.new
+        article.merge!(article_doi: "10.#{Faker::Number.number(digits: 4)}/#{Faker::Number.number(digits: 10)}")
+        article.merge!(article_title: Faker::TvShows::SiliconValley.quote)
+        article.merge!(abstract: Faker::Lorem.paragraph)
+        article.merge!(final_disposition: 'ACCEPT')
+        article.merge!(keywords: [Faker::Cosmere.aon, Faker::Cosmere.metal, Faker::Cosmere.spren])
+        article.merge!(funding_source: [{
+                         "funder": 'National Institutes of Health',
+                         "funder_id": 'http://dx.doi.org/10.13039/100000002',
+                         "award_number": '12345',
+                         "grant_recipient": '33182'
+                       }])
+
+        @metadata[:article] = article
+      end
+
+    end
+  end
+end

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -2,6 +2,7 @@ require 'uri'
 require_relative 'helpers'
 require 'fixtures/stash_api/metadata'
 require 'fixtures/stash_api/curation_metadata'
+require 'fixtures/stash_api/em_metadata'
 require 'cgi'
 
 # see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
@@ -140,6 +141,68 @@ module StashApi
         @resource.reload
         expect(@resource.curation_activities.size).to eq(2)
         expect(@resource.publication_date).to be_within(10.days).of(publish_date)
+      end
+    end
+
+    # test creation of a new dataset
+    describe '#create Editorial Manager' do
+      before(:each) do
+        @meta = Fixtures::StashApi::EmMetadata.new
+        @meta.make_deposit_metadata
+      end
+
+      it 'creates a new dataset from EM deposit metadata' do
+        # the following works for post with headers
+        response_code = post '/api/v2/em_submission_metadata', params: @meta.json, headers: default_authenticated_headers
+        output = response_body_hash
+        expect(response_code).to eq(201)
+        hsh = @meta.hash
+        ident = StashEngine::Identifier.where(identifier: output[:deposit_id]).first
+        res = ident.latest_resource
+
+        expect(ident).to be
+        expect(ident.publication_name).to eq(hsh[:journal_full_title])
+        expect(res.authors.first.author_first_name).to eq(hsh[:authors].first[:first_name])
+        expect(res.authors.first.author_last_name).to eq(hsh[:authors].first[:last_name])
+        expect(res.authors.first.author_orcid).to eq(hsh[:authors].first[:orcid])
+        expect(res.authors.first.author_email).to eq(hsh[:authors].first[:email])
+      end
+
+      it 'creates a new dataset from EM submission metadata' do
+        @meta.make_submission_metadata
+        response_code = post '/api/v2/em_submission_metadata', params: @meta.json, headers: default_authenticated_headers
+        output = response_body_hash
+        expect(response_code).to eq(201)
+        hsh = @meta.hash
+        ident = StashEngine::Identifier.where(identifier: output[:deposit_id]).first
+        res = ident.latest_resource
+
+        expect(ident).to be
+        expect(ident.publication_name).to eq(hsh[:journal_full_title])
+        expect(res.authors.first.author_first_name).to eq(hsh[:authors].first[:first_name])
+
+        article = hsh[:article]
+        expect(res.title).to eq(article[:article_title])
+      end
+
+      it 'allows update of deposit metadata with new submission metadata' do
+        response_code = post '/api/v2/em_submission_metadata', params: @meta.json, headers: default_authenticated_headers
+        output = response_body_hash
+        expect(response_code).to eq(201)
+        ident = StashEngine::Identifier.where(identifier: output[:deposit_id]).first
+        res = ident.latest_resource
+
+        @meta.make_submission_metadata
+        response_code = post "/api/v2/em_submission_metadata/doi%3A#{ERB::Util.url_encode(ident.identifier)}",
+                             params: @meta.json,
+                             headers: default_authenticated_headers
+        expect(response_code).to eq(201)
+        ident.reload
+        res.reload
+        hsh = @meta.hash
+        expect(res.authors.first.author_first_name).to eq(hsh[:authors].first[:first_name])
+        article = hsh[:article]
+        expect(res.title).to eq(article[:article_title])
       end
     end
 

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -48,6 +48,33 @@ module StashApi
       end
     end
 
+    # post /em_submission_metadata
+    def em_submission_metadata
+      # The Editorial Manager API sends metadata that is largely similar to our normal API, but it needs to be
+      # reformatted before use.
+      puts "XXXXX  em_submission_metadata"
+      respond_to do |format|
+        format.json do
+          dp = DatasetParser.new(hash: em_reformat_request, id: nil, user: @user)
+          @stash_identifier = dp.parse
+          ds = Dataset.new(identifier: @stash_identifier.to_s, user: @user) # sets up display objects
+          render json: ds.metadata, status: 201
+        end
+      end
+    end
+
+    def em_reformat_request
+      puts "XXXX dataset #{params['dataset']}"
+      em_params = {}
+      em_params['journal_full_title'] = 'Can I change it j?'
+      puts "XXXX journal_full_title #{em_params['journal_full_title']}"
+
+      em_params['title'] = params['article']['article_title']
+      em_params['abstract'] = params['article']['abstract']
+      puts "XXXX em_params #{em_params}"
+      em_params
+    end
+    
     # get /datasets
     def index
       ds_query = StashEngine::Identifier.user_viewable(user: @user) # this limits to a user's list based on their role/permissions (or public ones)

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -113,6 +113,7 @@ module StashApi
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
+    # Reformat a `metadata` response object, putting it in the format that Editorial Manager prefers
     def em_reformat_response(metadata)
       {
         deposit_id: @stash_identifier.identifier,

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -85,7 +85,8 @@ module StashApi
         em_params['manuscriptNumber'] = art_params['manuscript_number'] if art_params['manuscript_number']
         em_params['title'] = art_params['article_title']
         em_params['abstract'] = art_params['abstract']
-        em_params['keywords'] = art_params['keywords'] | art_params['classifications'] if art_params['keywords'] || art_params['classifications']
+        keywords = [art_params['keywords'], art_params['classifications']].flatten.compact
+        em_params['keywords'] = keywords if keywords
         if art_params['funding_source']
           em_funders = []
           art_params['funding_source'].each do |f|

--- a/stash/stash_api/config/initializers/doorkeeper.rb
+++ b/stash/stash_api/config/initializers/doorkeeper.rb
@@ -71,7 +71,7 @@ Doorkeeper.configure do
   # Define access token scopes for your provider
   # For more information go to
   # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
-  default_scopes  :all
+  default_scopes :all
   # optional_scopes :write, :update
 
   # Change the way client credentials are retrieved from the request object.

--- a/stash/stash_api/config/initializers/doorkeeper.rb
+++ b/stash/stash_api/config/initializers/doorkeeper.rb
@@ -71,7 +71,7 @@ Doorkeeper.configure do
   # Define access token scopes for your provider
   # For more information go to
   # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
-  # default_scopes  :public
+  default_scopes  :all
   # optional_scopes :write, :update
 
   # Change the way client credentials are retrieved from the request object.

--- a/stash/stash_api/config/locales/doorkeeper.en.yml
+++ b/stash/stash_api/config/locales/doorkeeper.en.yml
@@ -47,7 +47,7 @@ en:
         scopes: 'Scopes'
         callback_urls: 'Callback urls'
         actions: 'Actions'
-
+      
     authorizations:
       buttons:
         authorize: 'Authorize'
@@ -120,3 +120,6 @@ en:
           home: 'Home'
       application:
         title: 'OAuth authorization required'
+
+    scopes:
+      all: 'All actions that are available for this user'

--- a/stash/stash_api/config/routes.rb
+++ b/stash/stash_api/config/routes.rb
@@ -8,6 +8,11 @@ StashApi::Engine.routes.draw do
   match '/test', to: 'general#test', via: %i[get post]
   match '/search', to: 'datasets#search', via: %i[get]
 
+  # Support for the Editorial Manager API
+  match '/em_deposit', to: 'datasets#em_deposit', via: %i[post]
+  match '/em_submission_metadata', to: 'datasets#em_submission_metadata', via: %i[post]
+
+  
   resources :datasets, shallow: true, id: %r{[^\s/]+?}, format: /json|xml|yaml/ do
     member do
       get 'download'

--- a/stash/stash_api/config/routes.rb
+++ b/stash/stash_api/config/routes.rb
@@ -9,10 +9,8 @@ StashApi::Engine.routes.draw do
   match '/search', to: 'datasets#search', via: %i[get]
 
   # Support for the Editorial Manager API
-  match '/em_deposit', to: 'datasets#em_deposit', via: %i[post]
-  match '/em_submission_metadata', to: 'datasets#em_submission_metadata', via: %i[post]
+  match '/em_submission_metadata(/:id)', constraints: { id: /\S+/ }, to: 'datasets#em_submission_metadata', via: %i[post put]
 
-  
   resources :datasets, shallow: true, id: %r{[^\s/]+?}, format: /json|xml|yaml/ do
     member do
       get 'download'


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/718

This is the basis for supporting Editorial Manager's API workflow. I expect it will be refined as we iterate with the Editorial Manager team.

Takes requests in the Editorial Manager format, transforms them into the format used by the Dryad API, runs the regular process, and reformats the results into the output format desired by Editorial Manager.

A single endpoint (`em_submission_metadata`) is used. It handles both creating a new dataset (POST) or modifying an existing dataset (PUT), though I believe Editorial Manager will be using POST for both types of request. The endpoint is also agnostic about whether the request is the minimal "deposit" request or the more fully-specified "submission metadata" request.

To test: use the normal format of a submission request with the new endpoint, like `curl --data "@my_metadata.json" -i -X POST https://<domain-name>/api/v2/em_submission_metadata -H "Authorization: Bearer <token>" -H "Content-Type: application/json"`. But ensure your JSON document has the format of the samples included in this PR.

Note that I've changed the Doorkeeper config so that all new requests for tokens are assigned the scope `all` by default. I have asked EM to use a more descriptive scope, but have not received a final decision on that yet. We may not want to continue using a default scope... at some point, it would probably be better to let EM use `all`, and assign more specific scopes to other users. But we were not using the scopes before, so I think this is ok for now. 