### PR TITLE
Related Works update for the API

### DIFF
--- a/documentation/apis/dataset_metadata.md
+++ b/documentation/apis/dataset_metadata.md
@@ -45,8 +45,8 @@ Descriptive fields
 Other fields with descriptive metadata include:
 - `relatedWorks` - Relationships to other objects may be specified by
   giving a `relationship` and identifier information. The allowed
-  values for `relationship` are the same as for DataCite's
-  `relationType` field.
+  values for `relationship` are: `undefined`, `article`, `dataset`, `preprint`,
+  `software`, `supplemental_information`
 - `funders` - Funding organizations and award numbers may be
   specified. 
 - `methods` - Description of methods for collecting and processing the

--- a/documentation/apis/embedded_submission.md
+++ b/documentation/apis/embedded_submission.md
@@ -89,7 +89,7 @@ A sample call using the [sample dataset file](sample_dataset.json), with results
   "methods": "My cat will help you to discover why you can't get the data to work.",
   "relatedWorks": [
     {
-	  "relationship": "Cites",
+	  "relationship": "article",
 	  "identifierType": "DOI",
 	  "identifier": "10.1111/j.1558-5646.2007.00022.x"
 	}
@@ -179,7 +179,7 @@ Sample call and (abbreviated) response:
   "methods": "My cat will help you to discover why you can't get the data to work.",
   "relatedWorks": [
     {
-	  "relationship": "Cites",
+	  "relationship": "article",
 	  "identifierType": "DOI",
 	  "identifier": "10.1111/j.1558-5646.2007.00022.x"
 	}

--- a/documentation/apis/sample_dataset.json
+++ b/documentation/apis/sample_dataset.json
@@ -18,7 +18,7 @@
 	}
     ],
     "relatedWorks" : [ {
-	"relationship" : "Cites",
+	"relationship" : "article",
 	"identifierType" : "DOI",
 	"identifier" : "10.1111/j.1558-5646.2007.00022.x"
     } ],

--- a/spec/fixtures/stash_api/metadata.rb
+++ b/spec/fixtures/stash_api/metadata.rb
@@ -44,6 +44,17 @@ module Fixtures
         )
       end
 
+      def add_related_work(work_type: 'article')
+        create_key_and_array(key: :relatedWorks)
+        @metadata[:relatedWorks].push(
+          {
+            relationship: work_type,
+            identifierType: 'DOI',
+            identifier: "10.#{Faker::Number.number(digits: 4)}/fakedoi.#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}"
+          }.with_indifferent_access
+        )
+      end
+
       def add_abstract
         @metadata.merge!(abstract: Faker::Lorem.paragraph)
       end

--- a/spec/models/stash_api/dataset_spec.rb
+++ b/spec/models/stash_api/dataset_spec.rb
@@ -129,7 +129,7 @@ module StashApi
         rw = @metadata[:relatedWorks].first
         expect(rw[:identifier]).to eq(ri.related_identifier)
         expect(rw[:identifierType]).to eq('DOI')
-        expect(rw[:relationship]).to eq('Cites')
+        expect(rw[:relationship]).to eq('article')
       end
 
       it 'defaults to the correct license' do

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -83,6 +83,19 @@ module StashApi
         expect(output[:userId]).to eq(test_user.id)
       end
 
+      it 'creates a new basic dataset with related software' do
+        @meta.add_related_work(work_type: 'software')
+        response_code = post '/api/v2/datasets', params: @meta.json, headers: default_authenticated_headers
+        output = response_body_hash
+        expect(response_code).to eq(201)
+
+        # check it against the database
+        @stash_id = StashEngine::Identifier.find(output[:id])
+        @resource = @stash_id.resources.first
+        expect(@resource.related_identifiers.first.work_type).to eq('software')
+        expect(@resource.related_identifiers.first.related_identifier).to be
+      end
+
       it 'creates a new basic dataset with a placename' do
         @meta.add_place
         response_code = post '/api/v2/datasets', params: @meta.json, headers: default_authenticated_headers

--- a/stash/stash_api/app/controllers/stash_api/application_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/application_controller.rb
@@ -27,8 +27,8 @@ module StashApi
       accept = request.headers['accept']
       content_type = request.headers['content-type']
       # check that content_type and accept headers are as expected
-      ct_ok = !content_type.nil? && content_type.start_with?('application/json')
-      accept_ok = !accept.nil? && (accept.include?('*/*') || accept.include?('application/json'))
+      ct_ok = content_type.nil? || content_type.start_with?('application/json')
+      accept_ok = accept.nil? || (accept.include?('*/*') || accept.include?('application/json'))
       return if ct_ok && accept_ok
 
       render json: { error: UNACCEPTABLE_MSG }.to_json, status: 406

--- a/stash/stash_api/app/controllers/stash_api/curation_activity_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/curation_activity_controller.rb
@@ -17,7 +17,7 @@ module StashApi
     def show
       @curation_activity = StashEngine::CurationActivity.find(params[:id])
       respond_to do |format|
-        format.json { render json: @curation_activity }
+        format.any { render json: @curation_activity }
       end
     end
 
@@ -28,7 +28,7 @@ module StashApi
       @curation_activity = @curation_activity.where(user_id: @user.id) if params.key?(:user_id)
       @curation_activity = @curation_activity.order(updated_at: :desc)
       respond_to do |format|
-        format.json { render json: @curation_activity }
+        format.any { render json: @curation_activity }
       end
     end
 
@@ -37,7 +37,7 @@ module StashApi
       resource = StashEngine::Identifier.find_with_id(params[:dataset_id]).latest_resource
       create_curation_activity(resource)
       respond_to do |format|
-        format.json { render json: resource&.reload&.current_curation_activity }
+        format.any { render json: resource&.reload&.current_curation_activity }
       end
     end
 
@@ -46,7 +46,7 @@ module StashApi
       resource = StashEngine::Identifier.find(params[:dataset_id]).latest_resource
       create_curation_activity(resource)
       respond_to do |format|
-        format.json { render json: resource&.reload&.current_curation_activity }
+        format.any { render json: resource&.reload&.current_curation_activity }
       end
     end
 

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -30,7 +30,7 @@ module StashApi
     def show
       ds = Dataset.new(identifier: @stash_identifier.to_s, user: @user)
       respond_to do |format|
-        format.json { render json: ds.metadata }
+        format.any { render json: ds.metadata }
         res = @stash_identifier.latest_viewable_resource(user: @user)
         StashEngine::CounterLogger.general_hit(request: request, resource: res) if res
       end
@@ -39,7 +39,7 @@ module StashApi
     # post /datasets
     def create
       respond_to do |format|
-        format.json do
+        format.any do
           dp = DatasetParser.new(hash: params['dataset'], id: nil, user: @user)
           @stash_identifier = dp.parse
           ds = Dataset.new(identifier: @stash_identifier.to_s, user: @user) # sets up display objects
@@ -147,7 +147,7 @@ module StashApi
       # otherwise this is a PUT of the dataset metadata
       check_status { return } # check it's in progress, clone a submitted or raise an error
       respond_to do |format|
-        format.json do
+        format.any do
           dp = if @resource
                  DatasetParser.new(hash: params['dataset'], id: @resource.identifier, user: @user) # update dataset
                else

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -124,7 +124,7 @@ module StashApi
         if art_params['article_doi']
           em_params['relatedWorks'] = []
           em_params['relatedWorks'] << {
-            relationship: 'Cites',
+            relationship: 'article',
             identifierType: 'DOI',
             identifier: art_params['article_doi']
           }.with_indifferent_access

--- a/stash/stash_api/app/controllers/stash_api/files_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/files_controller.rb
@@ -28,7 +28,7 @@ module StashApi
     def show
       file = StashApi::File.new(file_id: params[:id])
       respond_to do |format|
-        format.json { render json: file.metadata }
+        format.any { render json: file.metadata }
       end
     end
 
@@ -36,7 +36,7 @@ module StashApi
     def index
       files = paged_files_for_version
       respond_to do |format|
-        format.json { render json: files }
+        format.any { render json: files }
       end
     end
 
@@ -50,7 +50,7 @@ module StashApi
       after_upload_processing { return }
       file = StashApi::File.new(file_id: @file.id)
       respond_to do |format|
-        format.json { render json: file.metadata, status: 201 }
+        format.any { render json: file.metadata, status: 201 }
       end
     end
 
@@ -62,7 +62,7 @@ module StashApi
       end
       file_hash = make_deleted(file_upload: @stash_file)
       respond_to do |format|
-        format.json { render json: file_hash, status: 200 }
+        format.any { render json: file_hash, status: 200 }
       end
     end
 

--- a/stash/stash_api/app/controllers/stash_api/general_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/general_controller.rb
@@ -13,7 +13,7 @@ module StashApi
     # All this really does is return the basic HATEOAS link to the base level dataset links
     def index
       respond_to do |format|
-        format.json { render json: output }
+        format.any { render json: output }
       end
     end
 
@@ -21,7 +21,7 @@ module StashApi
     # see if you can do a post request and connect with the key you've obtained
     def test
       respond_to do |format|
-        format.json { render json: { message: "Welcome application owner #{@user.name}", user_id: @user.id } }
+        format.any { render json: { message: "Welcome application owner #{@user.name}", user_id: @user.id } }
       end
     end
 

--- a/stash/stash_api/app/controllers/stash_api/internal_data_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/internal_data_controller.rb
@@ -13,7 +13,7 @@ module StashApi
     def show
       @internal_data = StashEngine::InternalDatum.find(params[:id])
       respond_to do |format|
-        format.json { render json: @internal_data }
+        format.any { render json: @internal_data }
       end
     end
 
@@ -22,7 +22,7 @@ module StashApi
       @internal_data = StashEngine::InternalDatum.where(identifier_id: @stash_identifier.id)
       @internal_data = @internal_data.data_type(params[:data_type]) if params.key?(:data_type)
       respond_to do |format|
-        format.json { render json: @internal_data }
+        format.any { render json: @internal_data }
       end
     end
 
@@ -38,7 +38,7 @@ module StashApi
       @internal_data = StashEngine::InternalDatum.find(params[:id])
       @internal_data.update!(params[:internal_datum])
       respond_to do |format|
-        format.json { render json: @internal_data }
+        format.any { render json: @internal_data }
       end
     end
 

--- a/stash/stash_api/app/controllers/stash_api/submission_queue_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/submission_queue_controller.rb
@@ -14,7 +14,7 @@ module StashApi
       @queue_length = StashEngine::RepoQueueState.latest_per_resource.where(state: %w[enqueued rejected_shutting_down]).count
       @executor = StashEngine.repository.executor
       respond_to do |format|
-        format.json { render json: { queue_length: @queue_length, executor_queue_length: @executor.queue_length } }
+        format.any { render json: { queue_length: @queue_length, executor_queue_length: @executor.queue_length } }
       end
     end
   end

--- a/stash/stash_api/app/controllers/stash_api/urls_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/urls_controller.rb
@@ -31,7 +31,7 @@ module StashApi
       check_file_size(file_upload: fu) { return }
       file = StashApi::File.new(file_id: fu.id) # parse file display object
       respond_to do |format|
-        format.json { render json: file.metadata, status: 201 }
+        format.any { render json: file.metadata, status: 201 }
       end
     end
 

--- a/stash/stash_api/app/controllers/stash_api/users_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/users_controller.rb
@@ -20,7 +20,7 @@ module StashApi
       user = StashEngine::User.find(params[:id])
       user = User.new(user_id: user)
       respond_to do |format|
-        format.json { render json: user.metadata }
+        format.any { render json: user.metadata }
       end
     end
 
@@ -30,8 +30,7 @@ module StashApi
       filtered_users = StashEngine::User.where(query_hash.to_hash) # this was ActionController::Parameters
       out = paged_users(filtered_users)
       respond_to do |format|
-        format.json { render json: out }
-        format.html { render plain: UNACCEPTABLE_MSG, status: 406 }
+        format.any { render json: out }
       end
     end
 

--- a/stash/stash_api/app/controllers/stash_api/versions_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/versions_controller.rb
@@ -16,7 +16,7 @@ module StashApi
     def show
       v = Version.new(resource_id: params[:id])
       respond_to do |format|
-        format.json { render json: v.metadata_with_links }
+        format.any { render json: v.metadata_with_links }
         res = @stash_resources.first
         StashEngine::CounterLogger.general_hit(request: request, resource: res) if res
       end
@@ -26,7 +26,7 @@ module StashApi
     def index
       versions = paged_versions_for_dataset
       respond_to do |format|
-        format.json { render json: versions }
+        format.any { render json: versions }
       end
     end
 

--- a/stash/stash_api/app/models/stash_api/dataset.rb
+++ b/stash/stash_api/app/models/stash_api/dataset.rb
@@ -87,7 +87,7 @@ module StashApi
       {
         identifier: @se_identifier&.to_s || @identifier_s,
         id: @se_identifier&.id,
-        message: 'identifier cannot be viewed, may be missing required elements'
+        message: 'Identifier cannot be viewed. Either you lack permission to view it, or it is missing required elements.'
       }
     end
 

--- a/stash/stash_api/app/models/stash_api/dataset_parser/related_works.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser/related_works.rb
@@ -7,15 +7,13 @@ module StashApi
       # Related Works look like this and use a constrainted list of relationships and identifier types
       # "relatedWorks": [
       #   {
-      #     "relationship": "Cites",
+      #     "relationship": "software",
       #     "identifierType": "URL",
       #     "identifier": "http://example.org/cats"
       #   } ]
 
       # lists of allowed values
-      #   StashDatacite::RelatedIdentifier::RelationTypes
-      #   StashDatacite::RelatedIdentifier::RelatedIdentifierTypes
-      LowerRelationTypes = StashDatacite::RelatedIdentifier::RelationTypes.map(&:downcase)
+      LowerWorkTypes = StashDatacite::RelatedIdentifier.work_types.map(&:first)
       LowerIdentifierTypes = StashDatacite::RelatedIdentifier::RelatedIdentifierTypes.map(&:downcase)
 
       def parse
@@ -23,13 +21,14 @@ module StashApi
         return if @hash['relatedWorks'].blank?
 
         @hash['relatedWorks'].each do |rw|
-          next if rw.blank? || !LowerRelationTypes.include?(rw['relationship']&.downcase) ||
+          next if rw.blank? || !LowerWorkTypes.include?(rw['relationship']&.downcase) ||
               !LowerIdentifierTypes.include?(rw['identifierType']&.downcase)
 
           @resource.related_identifiers << StashDatacite::RelatedIdentifier.create(
             related_identifier: rw['identifier'],
             related_identifier_type: rw['identifierType']&.downcase,
-            relation_type: rw['relationship']&.downcase
+            work_type: rw['relationship']&.downcase,
+            relation_type: StashDatacite::RelatedIdentifier::WORK_TYPES_TO_RELATION_TYPE[rw['relationship']&.downcase]
           )
         end
       end

--- a/stash/stash_api/app/models/stash_api/version/metadata/related_works.rb
+++ b/stash/stash_api/app/models/stash_api/version/metadata/related_works.rb
@@ -10,7 +10,7 @@ module StashApi
         def value
           @resource.related_identifiers.map do |r|
             {
-              relationship: r.relation_type_friendly,
+              relationship: r.work_type,
               identifierType: r.related_identifier_type_friendly,
               identifier: r.related_identifier
             }

--- a/stash/stash_api/public/api/v2/docs/examples/dataset.json
+++ b/stash/stash_api/public/api/v2/docs/examples/dataset.json
@@ -87,7 +87,7 @@
   ],
   "relatedWorks": [
     {
-      "relationship": "Cites",
+      "relationship": "article",
       "identifierType": "URL",
       "identifier": "http://example.org/cats"
     }

--- a/stash/stash_api/public/api/v2/docs/examples/dataset_post_request.json
+++ b/stash/stash_api/public/api/v2/docs/examples/dataset_post_request.json
@@ -60,7 +60,7 @@
   ],
   "relatedWorks": [
     {
-      "relationship": "Cites",
+      "relationship": "article",
       "identifierType": "URL",
       "identifier": "http://example.org/cats"
     }

--- a/stash/stash_api/public/api/v2/docs/examples/datasets.json
+++ b/stash/stash_api/public/api/v2/docs/examples/datasets.json
@@ -173,7 +173,7 @@
         ],
         "relatedWorks": [
           {
-            "relationship": "Cites",
+            "relationship": "article",
             "identifierType": "DOI",
             "identifier": "foosball"
           }

--- a/stash/stash_api/public/api/v2/docs/examples/version.json
+++ b/stash/stash_api/public/api/v2/docs/examples/version.json
@@ -85,7 +85,7 @@
   ],
   "relatedWorks": [
     {
-      "relationship": "Cites",
+      "relationship": "article",
       "identifierType": "URL",
       "identifier": "http://example.org/cats"
     }


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/925

- Changed the meaning of the `relationship` field in the
  API so it uses the `work_type` enumeration instead of the DataCite 
  relationships. Technically, this change breaks functionality, since it's using a
  different vocab. I don't think anyone was using the old vocab, but
  if it seems like an issue, I could add a mapping from the old vocab
  to the new one.
- Changed the http header restrictions on most API methods --
  instead of "headers must specify JSON", changed to "if headers are
  specified, they must allow JSON". Since we only support JSON for
  most calls, we can assume that a request with unspecified format
  is using JSON. This simplifies using the API. Calls that don't
  require authentication can now be resolved in a browser (or other
  tool) without extra headers.
