### PR TITLE
Email validation issue (author ordering)

### DIFF
--- a/spec/models/stash_datacite/completions_spec.rb
+++ b/spec/models/stash_datacite/completions_spec.rb
@@ -518,6 +518,9 @@ module StashDatacite
             author.author_email = nil
             author.save!
           end
+          @resource.save!
+          byebug
+          @completions = Completions.new(@resource)
           warnings = completions.all_warnings
           expect(warnings[0]).to include('email')
         end

--- a/spec/models/stash_datacite/completions_spec.rb
+++ b/spec/models/stash_datacite/completions_spec.rb
@@ -514,12 +514,9 @@ module StashDatacite
         end
 
         it 'warns on missing author email' do
-          @resource.authors.find_each do |author|
-            author.author_email = nil
-            author.save!
+          @resource.authors.each do |author|
+            author.update(author_email: nil)
           end
-          @resource.save!
-          byebug
           @completions = Completions.new(@resource)
           warnings = completions.all_warnings
           expect(warnings[0]).to include('email')

--- a/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
@@ -52,7 +52,7 @@ module StashDatacite
         num_authors = @resource.authors.count
         return false if num_authors < 1
 
-        author = @resource.authors.order(created_at: :asc).first
+        author = @resource.authors.first
         author.author_email.present? ? true : false
       end
 


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/949

I'm not 100% certain this fixes the problem, since I can not reproduce the issue, but this seems like the most likely cause. Authors in the UI, and generally throughout the system, are ordered by the default database ordering (presumably `id`). Prior to this change, the validation step was explicitly using a different ordering (`created_at`). There is the potential that the two orders could get out of sync, which would cause the validator to operate on a different author than expected. 