### PR TITLE
Embargoed sharing link

### DIFF
--- a/spec/models/stash_api/dataset_spec.rb
+++ b/spec/models/stash_api/dataset_spec.rb
@@ -166,10 +166,16 @@ module StashApi
         expect(@metadata[:sharingLink]).to be(bogus_link)
       end
 
-      it 'has no sharingLink when it is in withdrawn status' do
+      it 'has no sharingLink when it is in embargoed or withdrawn status' do
         bogus_link = 'http://some.sharing.com/linkvalue'
         allow_any_instance_of(StashEngine::Share).to receive(:sharing_link).and_return(bogus_link)
         r = @identifier.resources.last
+
+        StashEngine::CurationActivity.create(resource: r, status: 'embargoed')
+        @dataset = Dataset.new(identifier: @identifier.to_s, user: @user)
+        @metadata = @dataset.metadata
+        expect(@metadata[:sharingLink]).to be(nil)
+
         StashEngine::CurationActivity.create(resource: r, status: 'withdrawn')
         @dataset = Dataset.new(identifier: @identifier.to_s, user: @user)
         @metadata = @dataset.metadata

--- a/stash/stash_api/app/models/stash_api/version/metadata.rb
+++ b/stash/stash_api/app/models/stash_api/version/metadata.rb
@@ -49,11 +49,15 @@ module StashApi
 
       def sharing_link
         curation_activity = StashEngine::CurationActivity.latest(resource: @resource)
-        if curation_activity.in_progress?
+        case curation_activity.status
+        when 'in_progress'
           # if it's in_progress, return the sharing_link for the previous submitted version
           prev_submitted_res = @resource&.identifier&.last_submitted_resource
-          prev_submitted_res&.identifier&.shares&.first&.sharing_link if prev_submitted_res
-        elsif !curation_activity.withdrawn? && !curation_activity.embargoed?
+          prev_submitted_res&.identifier&.shares&.first&.sharing_link
+        when 'embargoed', 'withdrawn'
+        # suppress the link -- even if the user has the rights to view
+        # the metadata, they should not be downloading it
+        else
           @resource&.identifier&.shares&.first&.sharing_link
         end
       end

--- a/stash/stash_api/app/models/stash_api/version/metadata.rb
+++ b/stash/stash_api/app/models/stash_api/version/metadata.rb
@@ -53,7 +53,7 @@ module StashApi
           # if it's in_progress, return the sharing_link for the previous submitted version
           prev_submitted_res = @resource&.identifier&.last_submitted_resource
           prev_submitted_res&.identifier&.shares&.first&.sharing_link if prev_submitted_res
-        elsif !curation_activity.withdrawn?
+        elsif !curation_activity.withdrawn? && !curation_activity.embargoed?
           @resource&.identifier&.shares&.first&.sharing_link
         end
       end


### PR DESCRIPTION
When providing metadata through the API, do not include the peer-review `sharingLink` if the item is in status `embargoed`. In general, the API assumes that anyone who has rights to view the metadata will also have rights to download the item, but this is not the case for `embargoed` items.

Note that `embargoed` items will still display the links for downloading files, but these links validate permissions on their own, and disallow downloads if the user does not have correct permissions.