### PR TITLE
Updating the forms from using form_for and form_tag to use the Rails 6 form_with

### DIFF
--- a/stash/stash_datacite/app/views/stash_datacite/authors/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/_form.html.erb
@@ -1,7 +1,7 @@
 <%# the local variable 'author' should be passed in to this partial when there are multiple per page.
   # the 'path' to submit to should also be passed in. %>
 <% form_id = unique_form_id(author) %>
-<%= form_for(author, url: path, remote: true, authenticity_token: true, html: {id: form_id, class: 'c-input__inline js-author_form'}) do |f| %>
+<%= form_with(model: author, url: path, remote: true, authenticity_token: true, id: form_id, class: 'c-input__inline js-author_form') do |f| %>
   <% my_suffix = field_suffix(author) %>
 
   <div class="c-input">

--- a/stash/stash_datacite/app/views/stash_datacite/contributors/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/contributors/_form.html.erb
@@ -1,6 +1,6 @@
 <%# the local variable 'contributor' should be passed in to this partial when there are multiple per page %>
 <% form_id = unique_form_id(contributor) %>
-<%= form_for(contributor, url: path, remote: true, authenticity_token: true, html: { id: form_id, class: 'c-input__inline' }) do |f| %>
+<%= form_with(model: contributor, url: path, remote: true, authenticity_token: true, id: form_id, class: 'c-input__inline') do |f| %>
 <% my_suffix = field_suffix(contributor) %>
 <%#= render "datacite/shared/error_messages", target: @contributor %>
 	<div class="c-input">

--- a/stash/stash_datacite/app/views/stash_datacite/descriptions/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/descriptions/_form.html.erb
@@ -1,6 +1,6 @@
 <%# the local variable 'description' should be passed in to this partial when there are multiple per page %>
-<%= form_for(description, url: stash_datacite.descriptions_update_path, remote: true, authenticity_token: true,
-             html: {id: "description_form_#{description_type}", class: 'c-input'}) do |f| %>
+<%= form_with(model: description, url: stash_datacite.descriptions_update_path, remote: true, authenticity_token: true,
+             id: "description_form_#{description_type}", class: 'c-input') do |f| %>
   <%#= render "datacite/shared/error_messages", :target => @description %>
   <%# f.text_area :description, class: "c-input__textarea js-description", id: "description_#{description_type}" %>
   <%= f.cktext_area :description, class: "c-input__textarea js-description", id: "description_#{description_type}" %>

--- a/stash/stash_datacite/app/views/stash_datacite/fos_subjects/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/fos_subjects/_form.html.erb
@@ -1,6 +1,7 @@
 <%# the local variable 'resource' should be passed in to this partial %>
 <% form_id = "dc_fos_subjects_#{resource.id}" %>
-<%= form_tag(fos_subjects_update_path, method: :patch, remote: true, authenticity_token: true, html: { id: form_id, class: 'c-input' }) do |f| %>
+<%= form_with(url: fos_subjects_update_path, method: :patch, remote: true, authenticity_token: true, id: form_id,
+              class: 'c-input' ) do |f| %>
   <% my_suffix = field_suffix(resource) %>
   <strong><%= label_tag "#{my_suffix}", "Research Domain", class: 'c-input__label' %></strong><br/>
   <%= text_field_tag :fos_subjects, resource&.subjects&.permissive_fos&.first&.subject, id: "fos_subjects_#{my_suffix}",

--- a/stash/stash_datacite/app/views/stash_datacite/geolocation_boxes/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/geolocation_boxes/_form.html.erb
@@ -1,5 +1,6 @@
 <%# the local variable 'geolocation_box' should be passed in to this partial when there are multiple per page %>
-<%= form_for(geolocation_box, url: stash_datacite.geolocation_boxes_create_path, remote: true, authenticity_token: true, html: {id: "geolocation_box_new_form", class: 'c-location__box-inputs'}) do |f| %>
+<%= form_with(model: geolocation_box, url: stash_datacite.geolocation_boxes_create_path, remote: true,
+              authenticity_token: true, id: "geolocation_box_new_form", class: 'c-location__box-inputs') do |f| %>
   <div class="c-location__coordinates" role="group" aria-labelledby="c-location__legend1">
     <div class="c-location__legend" id="c-location__legend1"><abbr title="Southwest">SW</abbr></div>
     <%= f.text_field :sw_latitude, class: 'c-location__input', id: "geo_sw_lat_point" %>

--- a/stash/stash_datacite/app/views/stash_datacite/geolocation_points/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/geolocation_points/_form.html.erb
@@ -1,5 +1,6 @@
 <%# the local variable 'geolocation_point' should be passed in to this partial when there are multiple per page %>
-<%= form_for(geolocation_point, url: stash_datacite.geolocation_points_create_path, remote: true, authenticity_token: true, html: {id: "geolocation_point_new_form", class: 'c-location__point-inputs'}) do |f| %>
+<%= form_with(model: geolocation_point, url: stash_datacite.geolocation_points_create_path, remote: true,
+              authenticity_token: true, id: "geolocation_point_new_form", class: 'c-location__point-inputs') do |f| %>
   <%#= render "datacite/shared/error_messages", :target => @geolocation_point %>
   <%= f.text_field :latitude, class: 'c-location__input', placeholder: "e.g., 37.8012", id: "geo_lat_point" %>&nbsp;,&nbsp;
   <%= f.text_field :longitude, class: 'c-location__input', placeholder: "e.g., -122.2583", id: "geo_lng_point" %>

--- a/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
@@ -1,5 +1,6 @@
 <p id="import-choices-label">My data is related to:</p>
-<%= form_for(@publication_issn, url: publications_update_path, method: :patch, remote: true, authenticity_token: true) do |f| %>
+<%= form_with(model: @publication_issn, url: publications_update_path, method: :patch, remote: true,
+							authenticity_token: true) do |f| %>
 	<div class="c-import__choicesbox js-import-choice" role="group" aria-labelledby="import-choices-label">
 		<div class="c-import__choicebox">
 			<div class="c-import__icon"><i class="fa fa-pencil-square-o fa-3x"></i></div>

--- a/stash/stash_datacite/app/views/stash_datacite/peer_review/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/peer_review/_review.html.erb
@@ -6,7 +6,7 @@
     at any point if your dataset is ready to enter curation.</p>
 
   <div>
-    <%= form_for @resource, url: stash_datacite.peer_review_path, remote: true, authenticity_token: true do |f| %>
+    <%= form_with model: @resource, url: stash_datacite.peer_review_path, remote: true, authenticity_token: true do |f| %>
       <%= f.check_box :hold_for_peer_review %>
       <label for="resource_hold_for_peer_review">Keep my dataset private while my related article is in peer review</label>
       <span class="c-input__error-message"><%= @error %></span>

--- a/stash/stash_datacite/app/views/stash_datacite/resource_types/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/resource_types/_form.html.erb
@@ -1,7 +1,7 @@
 <%# the local variable 'resource_type' should be passed in to this partial when there are multiple per page %>
 <% form_id = unique_form_id(resource_type) %>
-<%= form_for(resource_type, url: path, remote: true, authenticity_token: true, html: { id: form_id,
-       class: 't-describe__select1 c-input' }) do |f| %>
+<%= form_with(model: resource_type, url: path, remote: true, authenticity_token: true, id: form_id,
+       class: 't-describe__select1 c-input' ) do |f| %>
   <% my_suffix = field_suffix(resource_type) %>
   <%#= render "datacite/shared/error_messages", :target => @resource_type %>
   <%= f.label "#{my_suffix}", "Type of Data", class: 'c-input__label' %>

--- a/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
@@ -76,7 +76,7 @@
             class: 'o-button__icon-left', role: 'button' %>
 
   <% if @data.blank? # valid data %>
-    <%= form_tag stash_datacite.resources_submission_path do -%>
+    <%= form_with(url: stash_datacite.resources_submission_path, local: true) do -%>
       <%= hidden_field_tag :resource_id, @resource.id %>
       <%= check_box_tag 'all_filled',  1, true, :style => "display: none;", class: 'all_filled js-agrees' %>
       <div>

--- a/stash/stash_datacite/app/views/stash_datacite/subjects/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/subjects/_form.html.erb
@@ -1,5 +1,5 @@
 <%# the local variable 'subject' should be passed in to this partial when there are multiple per page %>
-<%= form_tag(stash_datacite.subjects_create_path, method: :post, remote: true, authenticity_token: true, class: 'c-keywords', id: "subject_new_form") do %>
+<%= form_with(url: stash_datacite.subjects_create_path, method: :post, remote: true, authenticity_token: true, class: 'c-keywords', id: "subject_new_form") do %>
   <%#= render "datacite/shared/error_messages", target: @subject %>
   <%= label_tag :keyword, "Keywords:", class: 'c-input__label', for: 'keyword' %>&nbsp;&nbsp;Adding keywords improves the findability of your dataset. E.g. scientific names, method type
   <%= render partial: "stash_datacite/subjects/keywords_list", locals: { subjects: @metadata_entry.subjects, resource_id: resource_id } %>

--- a/stash/stash_datacite/app/views/stash_datacite/titles/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/titles/_form.html.erb
@@ -1,6 +1,6 @@
 <%# the local variable 'resource' should be passed in to this partial %>
 <% form_id = "resource_title_#{resource.id}" %>
-<%= form_tag(titles_update_path, method: :patch, remote: true, authenticity_token: true, html: { id: form_id, class: 'c-input' }) do |f| %>
+<%= form_with(url: titles_update_path, method: :patch, remote: true, authenticity_token: true, id: form_id, class: 'c-input' ) do %>
   <% my_suffix = field_suffix(resource) %>
   <strong><%= label_tag "#{my_suffix}", "Dataset Title", class: 'required c-input__label' %></strong><br/>
   <%= text_field_tag :title, resource.title, id: "title_#{my_suffix}", class: 'title c-input__text', size: 130 %>

--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -54,7 +54,11 @@ module StashEngine
     def note_popup
       respond_to do |format|
         @identifier = Identifier.where(id: params[:id]).first
-        resource = Resource.includes(:identifier, :curation_activities).find(@identifier.last_submitted_resource.id)
+        if @identifier.last_submitted_resource&.id.present?
+          resource = Resource.includes(:identifier, :curation_activities).find(@identifier.last_submitted_resource.id)
+        else
+          resource = @identifier.latest_resource # usually notes go on latest submitted, but there is none, so put it here
+        end
         @curation_activity = CurationActivity.new(
           resource_id: resource.id,
           status: resource.current_curation_activity.status

--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -54,11 +54,12 @@ module StashEngine
     def note_popup
       respond_to do |format|
         @identifier = Identifier.where(id: params[:id]).first
-        if @identifier.last_submitted_resource&.id.present?
-          resource = Resource.includes(:identifier, :curation_activities).find(@identifier.last_submitted_resource.id)
-        else
-          resource = @identifier.latest_resource # usually notes go on latest submitted, but there is none, so put it here
-        end
+        resource =
+          if @identifier.last_submitted_resource&.id.present?
+            Resource.includes(:identifier, :curation_activities).find(@identifier.last_submitted_resource.id)
+          else
+            @identifier.latest_resource # usually notes go on latest submitted, but there is none, so put it here
+          end
         @curation_activity = CurationActivity.new(
           resource_id: resource.id,
           status: resource.current_curation_activity.status

--- a/stash/stash_engine/app/views/stash_engine/admin/_admin_level_form.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin/_admin_level_form.html.erb
@@ -6,7 +6,7 @@
     role_radios.pop if current_user.role == 'admin' # don't give admins a choice to make a superuser
   %>
 
-  <%= form_tag(admin_set_role_path(user.id), method: :post, remote: true) do -%>
+  <%= form_with(url: admin_set_role_path(user.id), method: :post, remote: true) do -%>
     <% role_radios.each do |role| %>
       <p><%= radio_button_tag('role', role.first, user.role == role.first) %> <label for="<%= "role_#{role.first}" %>"><%= role[1] %></label></p>
     <% end %>

--- a/stash/stash_engine/app/views/stash_engine/admin/_user_datasets.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin/_user_datasets.erb
@@ -28,7 +28,7 @@
       </td>
       <td class="c-admin-hide-border-left">
         <% if p.resource.submitted? || p.resource.dataset_in_progress_editor.id == current_user.id %>
-          <%= form_tag(metadata_entry_pages_new_version_path, method: :post) do -%>
+          <%= form_with(url: metadata_entry_pages_new_version_path, method: :post, local: true) do -%>
             <button class="c-admin-edit-icon" title="Edit Dataset"><i class="fa fa-pencil" aria-hidden="true"></i></button>
             <%= hidden_field_tag :resource_id, p.resource.id %>
           <% end %>
@@ -52,7 +52,7 @@
         <%= p.edited_by_name_w_role %>
       </td>
       <td class="c-admin-hide-border-left">
-        <%= form_tag(edit_histories_path, method: :get) do -%>
+        <%= form_with(url: edit_histories_path, method: :get) do -%>
           <%= hidden_field_tag :resource_id, p.resource.id %>
           <button class="c-admin-edit-icon" title="See History"><i class="fa fa-history" aria-hidden="true"></i></button>
         <% end %>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_curation_activity_form.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_curation_activity_form.html.erb
@@ -1,7 +1,8 @@
 <% # locals: resource, curation_activity %>
 <div class="o-admin-dialog">
 
-  <%= form_for :resource, url: curation_activity_change_path(resource.id), method: :post, remote: true do |f| %>
+  <%= form_with model: StashEngine::Resource.new, url: curation_activity_change_path(resource.id),
+                method: :post, remote: true do |f| %>
 
     <p class="c-alert--error">Unable to save your changes at this time due to an internal error. Please contact a developer.</p>
 

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_curation_note_popup.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_curation_note_popup.html.erb
@@ -1,6 +1,6 @@
 <% # local: identifier %>
 <div class="o-admin-dialog">
-  <%= form_for :curation_activity,
+  <%= form_with model: StashEngine::CurationActivity.new,
         url: curation_note_path(@curation_activity.resource.identifier_id),
         method: :post,
         remote: true do |f| %>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_datasets_row.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_datasets_row.html.erb
@@ -27,8 +27,8 @@
   </td>
   <td class="c-admin-hide-border-left">
     <% if current_user.superuser? && dataset.resource_state == 'submitted' %>
-      <%= form_tag({ controller: '/stash_engine/admin_datasets',
-                     action: 'curation_activity_popup', id: dataset.identifier_id },
+      <%= form_with(url: url_for(controller: '/stash_engine/admin_datasets',
+                     action: 'curation_activity_popup', id: dataset.identifier_id, only_path: true ),
                    method: :get, remote: true) do -%>
         <button class="c-admin-edit-icon" aria-label="Update status" alt="Update status">
           <i class="fa fa-pencil" aria-hidden="true"></i>
@@ -48,7 +48,9 @@
     <%= formatted_datetime(dataset.updated_at) %>
   </td>
   <td class="c-admin-hide-border-left">
-    <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'activity_log', id: dataset.identifier_id }, method: :get) do -%>
+    <%= form_with(url: url_for(controller: '/stash_engine/admin_datasets', action: 'activity_log',
+                               id: dataset.identifier_id, only_path: true),
+                  method: :get, local: true) do -%>
       <button class="c-admin-edit-icon" aria-label="View Activity Log" alt="View Activity Log">
         <i class="fa fa-clock-o" aria-hidden="true"></i>
       </button>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_edit_dataset_button.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_edit_dataset_button.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.superuser? %>
-  <%= form_tag(metadata_entry_pages_new_version_path, method: :post) do -%>
+  <%= form_with(url: metadata_entry_pages_new_version_path, method: :post, local: true) do -%>
     <button class="c-admin-edit-icon" title="Edit Dataset"><i class="fa fa-pencil" aria-hidden="true"></i></button>
     <%= hidden_field_tag :resource_id, resource_id, id: "resource_id_#{resource_id}" %>
   <% end %>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_filter.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_filter.html.erb
@@ -1,4 +1,5 @@
-<%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'index' }, method: 'get', id: 'filter_form' ) do -%>
+<%= form_with(url: url_for(controller: '/stash_engine/admin_datasets', action: 'index', only_path: true),
+              method: 'get', id: 'filter_form', local: true) do -%>
   <label for="tenant" class="c-horizontal-form__input--filter-by">Filter by:</label>
   <% if current_user.superuser? %>
     <%= select_tag(:tenant, options_for_select( [['Institution', '']] + institution_select, params[:tenant]),

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_internal_data_popup.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_internal_data_popup.html.erb
@@ -5,7 +5,7 @@
   else
     my_path = internal_datum_path(@internal_datum)
   end %>
-  <%= form_for(@internal_datum, url: my_path, method: params[:sub_method], remote: true ) do |f| -%>
+  <%= form_with(model: @internal_datum, url: my_path, method: params[:sub_method], remote: true ) do |f| -%>
     <div class="c-input">
       <%= f.select(:data_type, options_for_select( @options, @internal_datum.data_type), {}, { disabled: ( params[:sub_method] == 'put' ) } ) %>
     </div>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_search.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_search.html.erb
@@ -1,5 +1,6 @@
 <div class="c-horizontal-form">
-  <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'index' }, method: 'get', id: 'search_form' ) do %>
+  <%= form_with(url: url_for(controller: '/stash_engine/admin_datasets', action: 'index', only_path: true),
+               method: 'get', id: 'search_form', local: true ) do %>
     <label for="search-terms">Search Terms:</label>
     <%= search_field_tag(:q, params[:q], class: 'c-horizontal-form__input--search', id: 'search-terms' ) %>
     <%= hidden_field_tag(:sort, 'relevance') %>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_show_stats_button.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_show_stats_button.html.erb
@@ -1,5 +1,4 @@
-<%= form_tag({ controller: '/stash_engine/admin_datasets',
-               action: 'stats_popup', id: resource_id },
+<%= form_with(url: url_for(controller: '/stash_engine/admin_datasets', action: 'stats_popup', id: resource_id),
              method: :get, remote: true) do -%>
   <button class="c-admin-edit-icon js-stats" title="See Dataset Statistics"><i class="fa fa-bar-chart" aria-hidden="true"></i></button>
 <% end %>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/activity_log.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/activity_log.html.erb
@@ -5,7 +5,8 @@
   <div style="float: left;"><br/><%= @identifier.to_s %></div>
   <% if current_user.superuser? %>
     <div style="float: right;">
-      <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'note_popup', id: @identifier&.id }, method: :get, remote: true) do -%>
+      <%= form_with(url: url_for(controller: '/stash_engine/admin_datasets', action: 'note_popup', id: @identifier&.id, only_path: true),
+                    method: :get, remote: true) do -%>
         <button class="o-button__submit">Add Note</button>
       <% end %>
     </div>
@@ -43,7 +44,9 @@
   <% if current_user.superuser? %>
     <div style="float: right">
       <br/>
-      <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'data_popup', id: @identifier.id, sub_method: 'post' }, method: :get, remote: true) do -%>
+      <%= form_with(url: url_for(controller: '/stash_engine/admin_datasets', action: 'data_popup', id: @identifier.id,
+                                 sub_method: 'post', only_path: true),
+                    method: :get, remote: true) do -%>
         <button class="o-button__submit">Add Data</button>
       <% end %>
     </div>

--- a/stash/stash_engine/app/views/stash_engine/dashboard/migrate_data.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/dashboard/migrate_data.html.erb
@@ -7,7 +7,7 @@
 </p>
 
 <fieldset class="c-fieldset">
-  <%= form_tag auth_migrate_mail_path, method: "get" do %>
+  <%= form_with(url: auth_migrate_mail_path, method: "get", local: true) do %>
     <div class="c-input__emailcode-text">
       <%= label_tag("Email address", nil, {:class=>"c-input__label"})%>
       <%= text_field_tag(:email, current_user.old_dryad_email || params[:email], { :class=>"c-input__text" }) %>
@@ -19,7 +19,7 @@
     <div class="c-input__emailcode-spacer">&nbsp;</div>
   <% end %>
 
-  <%= form_tag auth_migrate_code_path, method: "get" do %>
+  <%= form_with(auth_migrate_code_path, method: "get", local: true) do %>
     <div class="c-input__emailcode-text">
       <%= label_tag("Validation code", nil, {:class=>"c-input__label"})%>
       <%= text_field_tag(:code, nil, {:class=>"c-input__text"}) %>

--- a/stash/stash_engine/app/views/stash_engine/dashboard/migrate_data.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/dashboard/migrate_data.html.erb
@@ -19,7 +19,7 @@
     <div class="c-input__emailcode-spacer">&nbsp;</div>
   <% end %>
 
-  <%= form_with(auth_migrate_code_path, method: "get", local: true) do %>
+  <%= form_with(url: auth_migrate_code_path, method: "get", local: true) do %>
     <div class="c-input__emailcode-text">
       <%= label_tag("Validation code", nil, {:class=>"c-input__label"})%>
       <%= text_field_tag(:code, nil, {:class=>"c-input__text"}) %>

--- a/stash/stash_engine/app/views/stash_engine/file_uploads/_files_upload.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/file_uploads/_files_upload.html.erb
@@ -2,7 +2,7 @@
 <h2 class="t-upload__choose-heading--active">Step 2: Choose Files</h2>
 
 <div>
-  <%= form_for file, html: {multipart: true, id: 'fileupload'} do |f| %>
+  <%= form_with model: file, multipart: true, id: 'fileupload' do |f| %>
     <div class="c-choose">
       <%= f.hidden_field :resource_id %>
       <div id="upload_bg" class="c-choose__drop o-drop">

--- a/stash/stash_engine/app/views/stash_engine/file_uploads/_manifest_upload.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/file_uploads/_manifest_upload.html.erb
@@ -1,8 +1,8 @@
 <%# locals: resource %>
 <h2 class="t-upload__choose-heading--active">Step 2: Enter Files</h2>
 
-<%= form_tag stash_engine.file_uploads_validate_urls_path(resource.id),
-             remote: true, id: 'url_validate' do  %>
+<%= form_with(url: stash_engine.file_uploads_validate_urls_path(resource.id),
+             remote: true, id: 'url_validate') do  %>
   <%= hidden_field_tag :resource_id, resource.id %>
 	<%= text_area_tag :url, '', cols: 80, rows: 15, id: 'location_urls', placeholder: 'List file location URLs here'	%>
 

--- a/stash/stash_engine/app/views/stash_engine/internal_data/_table.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/internal_data/_table.html.erb
@@ -25,7 +25,7 @@
             <button class="c-admin-edit-icon" title="Edit data item"><i class="fa fa-pencil" aria-hidden="true"></i></button>
           <% end %>
           <!--
-          <%= form_for(item, method: :put, remote: true, html: { class: 'o-button__inline-form' } ) do -%>
+          <%= form_with(model: item, method: :put, remote: true, class: 'o-button__inline-form' ) do -%>
             <button class="c-admin-edit-icon" title="Edit data item"><i class="fa fa-pencil" aria-hidden="true"></i></button>
           <% end %>
           -->

--- a/stash/stash_engine/app/views/stash_engine/internal_data/_table.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/internal_data/_table.html.erb
@@ -20,7 +20,9 @@
                         form_class: 'o-button__inline-form', class: 'c-admin-edit-icon', title: 'Delete internal data item' do %>
             <i class="fa fa-trash" aria-hidden="true"></i>
           <% end %>
-          <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'data_popup', id: item.identifier_id, sub_method: 'put' }, method: :get, remote: true) do -%>
+          <%= form_with(url: url_for( controller: '/stash_engine/admin_datasets', action: 'data_popup',
+                                      id: item.identifier_id, sub_method: 'put', only_path: true),
+                  method: :get, remote: true) do -%>
             <%= hidden_field_tag :internal_datum_id, item.id %>
             <button class="c-admin-edit-icon" title="Edit data item"><i class="fa fa-pencil" aria-hidden="true"></i></button>
           <% end %>

--- a/stash/stash_engine/app/views/stash_engine/publication_updater/_proposed_metadata.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/publication_updater/_proposed_metadata.html.erb
@@ -5,10 +5,10 @@
 <td class="c-proposed-change-table__column-centered">
   <strong>Changes</strong>
   <% url = "#{stash_url_helpers.publication_updater_path}/#{proposed_change.id}" %>
-  <%= form_for :proposed_change, url: url, method: :PUT, remote: true do |f| %>
+  <%= form_with model: StashEngine::ProposedChange.new, url: url, method: :PUT, remote: true do |f| %>
     <button name="accept_changes" type="submit">Accept</button>
   <% end %>
-  <%= form_for :proposed_change, url: url, method: :DELETE, remote: true do |f| %>
+  <%= form_with model: StashEngine::ProposedChange.new, url: url, method: :DELETE, remote: true do |f| %>
      <button name="reject_changes" type="submit">Reject</button>
     <% end %>
 </td>

--- a/stash/stash_engine/app/views/stash_engine/sessions/choose_sso.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/sessions/choose_sso.html.erb
@@ -5,7 +5,7 @@
 
     <h2>Your institution may be a member* of Dryad.</h2>
     <div class="c-institution__container">
-      <%= form_tag 'sso/', method: :post do %>
+      <%= form_with(url: 'sso/', method: :post, local: true) do %>
         <%= select_tag :tenant_id, options_from_collection_for_select(@tenants, "id", "name"), class: '.o-select' %>
         <%= submit_tag 'Login to verify', class: 't-login__buttonlink' %>
       <% end %>

--- a/stash/stash_engine/app/views/stash_engine/users/_admin_table.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/users/_admin_table.html.erb
@@ -25,7 +25,7 @@
         </td>
         <td class="c-admin-hide-border-left">
           <% if current_user.role == 'superuser' %>
-            <%= form_tag(popup_admin_path(u.id), method: :get, remote: true) do -%>
+            <%= form_with(url: popup_admin_path(u.id), method: :get, remote: true) do -%>
               <button class="c-admin-edit-icon" aria-label="Edit user role" alt="Edit user role">
                 <i class="fa fa-pencil" aria-hidden="true"></i>
               </button>


### PR DESCRIPTION
For the most part this went smoothly and I tried to test each form afterwards to be sure it still worked.  The rules for changing all this are.

- Form_for forms should have a "model:" param specified instead.  Where we were using symbols for the model no longer work, so seem to need to have _ModelName.new_ instead of the symbol.
- Form_tag forms would just have the _url:_ param and no model, but a bunch in the admin area didn't have special routes and were using the "action: controller:" syntax to specify the action and controller to use.  these had to be converted to _url_for_ with the model and controller and _only_path_ as true (so as not to generate full URL with domain).
- All forms are now "remote: true" by default which is what we want for AJAX stuff, but is annoying for non ajax.  the opposite of "remote: true" is actually "local: true" rather than "remote: false" which seems kind of ridiculous to have two different keywords for opposite states of the same thing, but whatever.
- I found a problem saving curation notes while testing, but only if a dataset had never been submitted, so added some fallback code to write to the in-progress version if a note was needed and no submitted version was available.

I manually tested form submissions after making the changes to be sure they worked and the tests all seem to work still.