### PR TITLE
Adding Rancho Santa Ana as author institution for Claremont admins

### DIFF
--- a/config/tenants/clare-cs.yml
+++ b/config/tenants/clare-cs.yml
@@ -18,6 +18,7 @@ default: &default
     - https://ror.org/0197n2v40
     - https://ror.org/0074grg94
     - https://ror.org/00p55jd14
+    - https://ror.org/01n260e81
   tenant_id: clare-cs
   identifier_service:
     provider: datacite


### PR DESCRIPTION
This adds Rancho Santa Ana Botanical Gardens to the view for the administrators for including datasets to look at