### PR TITLE
constrain matching to only valid strings to old Dryad redirects

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,19 +105,17 @@ Rails.application.routes.draw do
   get '/themes/Mirage/docs/:doc', to: redirect('/docs/%{doc}.%{format}')
 
   # Routing to redirect old Dryad landing pages to the correct location
+  # Regex based on https://www.crossref.org/blog/dois-and-matching-regular-expressions/ but a little more restrictive specific to old dryad
   # Dataset:            https://datadryad.org/resource/doi:10.5061/dryad.kq201
   # Version of Dataset: https://datadryad.org/resource/doi:10.5061/dryad.kq201.2
   get '/resource/:doi_prefix/:doi_suffix',
-    doi_prefix: /[^\/]+/,
-    doi_suffix: /[a-zA-Z0-9]+\.[a-zA-Z0-9]+/,
-    to: redirect{ |p, req| "stash/dataset/#{p[:doi_prefix]}/#{p[:doi_suffix]}" }
+      constraints: { doi_prefix: /doi:10.\d{4,9}/i, doi_suffix: /[A-Z0-9]+\.[A-Z0-9]+/i },
+      to: redirect{ |p, req| "stash/dataset/#{p[:doi_prefix]}/#{p[:doi_suffix]}" }
   # File within a Dataset:            https://datadryad.org/resource/doi:10.5061/dryad.kq201/3
   # Version of File within a Dataset: https://datadryad.org/resource/doi:10.5061/dryad.kq201/3.1
   # File within a Version:            https://datadryad.org/resource/doi:10.5061/dryad.kq201.2/3
   # Version of File within a Version: https://datadryad.org/resource/doi:10.5061/dryad.kq201.2/3.1
   get '/resource/:doi_prefix/:doi_suffix*file',
-    doi_prefix: /[^\/]+/,
-    doi_suffix: /[a-zA-Z0-9]+\.[a-zA-Z0-9]+/,
-    to: redirect{ |p, req| "stash/dataset/#{p[:doi_prefix]}/#{p[:doi_suffix]}" }
-
+      constraints: { doi_prefix: /doi:10.\d{4,9}/i, doi_suffix: /[A-Z0-9]+\.[A-Z0-9]+/i },
+      to: redirect{ |p, req| "stash/dataset/#{p[:doi_prefix]}/#{p[:doi_suffix]}" }
 end


### PR DESCRIPTION
fixing routes that redirected.  Constraining what they'll accept only valid strings

See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/973 .

It seems like the old way accepted anything with "/resource" or something like that.  Now it constrains accepting the URLs so they are only processed if they match valid values for the full path, including all IDs.  The URI module errors were from it accepting too much which were invalid URLs and caused internal URI module to throw errors somewhere in Rails.

I think this is fine and made them more restricted to the exact expected values.

Ryan can you validate that this is all correct for the Dryad classic URLs that this is doing redirects for and everything still works?

While we could theoretically do things like remove spaces from URLs where they are not supposed to be, I'm not inclined to do that since no one else in the world babysits users that type bad URLs.  When people put in bad URLs anywhere else on the internet they get a 404 if they can't bother to get the URL right.