### PR TITLE
Fix URI errors when people enter invalid URLs in the upload box

### DIFF
--- a/spec/models/stash/url_translator_spec.rb
+++ b/spec/models/stash/url_translator_spec.rb
@@ -45,6 +45,11 @@ module Stash
       expect(translator.direct_download).to eql('https://ucop.box.com/public/static/o39s94g28puss5ttt7vss8b0qrlge184')
     end
 
+    it 'returns the original value with invalid URIs' do
+      translator = Stash::UrlTranslator.new('cat dog')
+      expect(translator.original_url).to eql('cat dog')
+    end
+
   end
 
 end

--- a/stash/stash_engine/lib/stash/url_translator.rb
+++ b/stash/stash_engine/lib/stash/url_translator.rb
@@ -32,6 +32,9 @@ module Stash
         @service = 'google' if m.start_with?('google')
         break
       end
+    rescue URI::InvalidURIError
+      @original_url = original_url
+      @service = nil
     end
 
     private


### PR DESCRIPTION
The URIs were erroring when being passed through the URI translator (that tries to convert URIs to special URIs for things like Google Drive).

This changes the translator so that it just passes the bad URI through without doing anything if it gets an invalid URI error.