### PR TITLE
Making return-to after editing work gloriously with many windows open

### DIFF
--- a/spec/features/stash_engine/curation_activity_spec.rb
+++ b/spec/features/stash_engine/curation_activity_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'CurationActivity', type: :feature do
   include Mocks::Stripe
   include Mocks::Ror
   include Mocks::Tenant
+  include DatasetHelper
 
   # TODO: This should probably be defined in routes.rb and have appropriate helpers
   let(:dashboard_path) { '/stash/ds_admin' }
@@ -171,8 +172,26 @@ RSpec.feature 'CurationActivity', type: :feature do
         expect(page).to have_text('My cat says hi')
       end
 
+      it 'allows curation editing of users dataset and returning to admin list in same state afterward' do
+        # the button to edit has this class on it
+        find('.js-trap-curator-url').click
+        navigate_to_review
+        agree_to_everything
+        fill_in 'user_comment', with: Faker::Lorem.sentence
+        submit = find_button('submit_dataset', disabled: :all)
+        submit.click
+        expect(URI.parse(current_url).request_uri).to eq("#{dashboard_path}?curation_status=curation")
+      end
+
+      it 'allows curation editing and aborting editing of user dataset and return to list in same state afterward' do
+        # the button to edit has this class on it
+        find('.js-trap-curator-url').click
+        accept_alert do
+          click_on('Cancel and Discard Changes')
+        end
+
+        expect(URI.parse(current_url).request_uri).to eq("#{dashboard_path}?curation_status=curation")
+      end
     end
-
   end
-
 end

--- a/spec/features/stash_engine/curation_activity_spec.rb
+++ b/spec/features/stash_engine/curation_activity_spec.rb
@@ -7,6 +7,8 @@ RSpec.feature 'CurationActivity', type: :feature do
   include Mocks::Ror
   include Mocks::Tenant
   include DatasetHelper
+  include Mocks::Repository
+  include Mocks::RSolr
 
   # TODO: This should probably be defined in routes.rb and have appropriate helpers
   let(:dashboard_path) { '/stash/ds_admin' }
@@ -144,6 +146,7 @@ RSpec.feature 'CurationActivity', type: :feature do
       before(:each) do
         mock_stripe!
         mock_ror!
+        mock_repository!
         @user = create(:user, tenant_id: 'ucop')
         @resource = create(:resource, user: @user, identifier: create(:identifier), skip_datacite_update: true)
         create(:curation_activity_no_callbacks, status: 'curation', user_id: @user.id, resource_id: @resource.id)

--- a/spec/features/stash_engine/curation_activity_spec.rb
+++ b/spec/features/stash_engine/curation_activity_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature 'CurationActivity', type: :feature do
   include DatasetHelper
   include Mocks::Repository
   include Mocks::RSolr
+  include Mocks::Datacite
 
   # TODO: This should probably be defined in routes.rb and have appropriate helpers
   let(:dashboard_path) { '/stash/ds_admin' }
@@ -121,6 +122,9 @@ RSpec.feature 'CurationActivity', type: :feature do
       before(:each) do
         mock_stripe!
         mock_ror!
+        mock_solr!
+        mock_repository!
+        mock_datacite_and_idgen!
 
         create(:resource, user: create(:user, tenant_id: 'ucop'), identifier: create(:identifier))
         sign_in(create(:user, role: 'admin', tenant_id: 'ucop'))
@@ -147,6 +151,7 @@ RSpec.feature 'CurationActivity', type: :feature do
         mock_stripe!
         mock_ror!
         mock_repository!
+        mock_datacite_and_idgen!
         @user = create(:user, tenant_id: 'ucop')
         @resource = create(:resource, user: @user, identifier: create(:identifier), skip_datacite_update: true)
         create(:curation_activity_no_callbacks, status: 'curation', user_id: @user.id, resource_id: @resource.id)

--- a/spec/models/stash_engine/curation_activity_spec.rb
+++ b/spec/models/stash_engine/curation_activity_spec.rb
@@ -55,7 +55,7 @@ module StashEngine
 
         # get rid of callbacks for adding one and testing
         @curation_activity1 = create(:curation_activity, resource: @resource)
-        CurationActivity.set_callback(:create, :after, :submit_to_datacite)
+        # CurationActivity.set_callback(:create, :after, :submit_to_datacite)
       end
 
       it "doesn't submit when a status besides Embargoed or Published is set" do

--- a/stash/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
@@ -70,10 +70,10 @@ module StashDatacite
 
       resource.reload
 
-      if session[:returnURL]
-        return_url = session[:returnURL]
-        session[:returnURL] = nil
-        redirect_to(return_url)
+      if session["return_url_#{resource.identifier_id}"]
+        return_url = session["return_url_#{resource.identifier_id}"]
+        session["return_url_#{resource.identifier_id}"] = nil
+        redirect_to return_url, notice: "Submitted updates for #{resource.identifier.to_s}, title: #{resource.title}"
       else
         redirect_to(stash_url_helpers.dashboard_path, notice: resource_submitted_message(resource))
       end

--- a/stash/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
@@ -57,6 +57,7 @@ module StashDatacite
       end
     end
 
+    # rubocop:disable Metrics/AbcSize
     def submission
       resource_id = params[:resource_id]
       resource = StashEngine::Resource.find(resource_id)
@@ -70,14 +71,19 @@ module StashDatacite
 
       resource.reload
 
-      if session["return_url_#{resource.identifier_id}"]
-        return_url = session["return_url_#{resource.identifier_id}"]
+      # There is a return URL for a simple case and backwards compatibility (only for for whole user and for journals).
+      # There is also one for curators and need to return back to different pages/filter setting for each dataset they
+      # edit in one of dozens of different windows at the same time, so needs to be specific to each dataset.
+      if session["return_url_#{resource.identifier_id}"] || session[:returnURL]
+        return_url = session["return_url_#{resource.identifier_id}"] || session[:returnURL]
         session["return_url_#{resource.identifier_id}"] = nil
-        redirect_to return_url, notice: "Submitted updates for #{resource.identifier.to_s}, title: #{resource.title}"
+        session[:returnURL] = nil
+        redirect_to return_url, notice: "Submitted updates for #{resource.identifier}, title: #{resource.title}"
       else
         redirect_to(stash_url_helpers.dashboard_path, notice: resource_submitted_message(resource))
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     private
 

--- a/stash/stash_engine/app/assets/javascripts/stash_engine/admin_datasets.js
+++ b/stash/stash_engine/app/assets/javascripts/stash_engine/admin_datasets.js
@@ -1,2 +1,13 @@
 // Place all the behaviors and hooks related to the matching controller here.
 // All this logic will automatically be available in application.js.
+
+$(document).ready(function() {
+    $('.js-trap-curator-url').click(function (e) {
+        e.preventDefault();
+        // set the url to come back to for this dataset and they may have a million or two tabs open
+        var returnUrl = $(e.target).closest('form').find('input#return_url');
+        $(returnUrl).val(window.location.href);
+
+        $(e.target).closest('form').submit();
+    })
+});

--- a/stash/stash_engine/app/controllers/stash_engine/metadata_entry_pages_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/metadata_entry_pages_controller.rb
@@ -60,6 +60,8 @@ module StashEngine
 
     # create a new version of this resource before editing with find or create
     def new_version
+      # save a URL to go back to if possible, for each individual identifier since may have many windows open
+      session["return_url_#{@identifier.id}"] = params[:return_url] if params[:return_url] && @identifier
       duplicate_resource
 
       # redirect to find or create path

--- a/stash/stash_engine/app/controllers/stash_engine/resources_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/resources_controller.rb
@@ -88,10 +88,10 @@ module StashEngine
       respond_to do |format|
         format.html do
           notice = 'The in-progress version was successfully deleted.'
-          if session[:returnURL]
-            return_url = session[:returnURL]
-            session[:returnURL] = nil
-            redirect_to return_url
+          if session["return_url_#{@resource.identifier_id}"]
+            return_url = session["return_url_#{@resource.identifier_id}"]
+            session["return_url_#{@resource.identifier_id}"] = nil
+            redirect_to return_url, notice: notice
           elsif current_user
             redirect_to return_to_path_or(dashboard_path), notice: notice
           else

--- a/stash/stash_engine/app/controllers/stash_engine/resources_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/resources_controller.rb
@@ -87,10 +87,14 @@ module StashEngine
       resource.destroy
       respond_to do |format|
         format.html do
+          # There is a return URL for a simple case and backwards compatibility (only for for whole user and for journals).
+          # There is also one for curators and need to return back to different pages/filter setting for each dataset they
+          # edit in one of dozens of different windows at the same time, so needs to be specific to each dataset.
           notice = 'The in-progress version was successfully deleted.'
-          if session["return_url_#{@resource.identifier_id}"]
-            return_url = session["return_url_#{@resource.identifier_id}"]
+          if session["return_url_#{@resource.identifier_id}"] || session[:returnURL]
+            return_url = session["return_url_#{@resource.identifier_id}"] || session[:returnURL]
             session["return_url_#{@resource.identifier_id}"] = nil
+            session[:returnURL] = nil
             redirect_to return_url, notice: notice
           elsif current_user
             redirect_to return_to_path_or(dashboard_path), notice: notice

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_edit_dataset_button.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_edit_dataset_button.html.erb
@@ -1,6 +1,7 @@
 <% if current_user.superuser? %>
   <%= form_with(url: metadata_entry_pages_new_version_path, method: :post, local: true) do -%>
-    <button class="c-admin-edit-icon" title="Edit Dataset"><i class="fa fa-pencil" aria-hidden="true"></i></button>
+    <button class="c-admin-edit-icon js-trap-curator-url" title="Edit Dataset"><i class="fa fa-pencil" aria-hidden="true"></i></button>
     <%= hidden_field_tag :resource_id, resource_id, id: "resource_id_#{resource_id}" %>
+    <%= hidden_field_tag :return_url, 'blfj' %>
   <% end %>
 <% end %>


### PR DESCRIPTION
https://github.com/CDL-Dryad/dryad-product-roadmap/issues/933

This traps the edit links for curators, adds something to the form that gets submitted and then the controller stores a return to url in the session for each open dataset they are editing at once.

Fixed problem with the old-style return-to (one in session for user).

Added tests to be sure both the editing and cancel workflows return to the page they came from afterwards.