### PR TITLE
Replace the dead link for 'About Dryad'

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ framework for research data publication and preservation, based on the
 [DataCite Metadata Schema](https://schema.datacite.org/) and the University
 of California’s [Merritt](https://merritt.cdlib.org/) repository service.
 
-- [About Dryad](app/views/layouts/_about.html.md)
+- [About Dryad](https://datadryad.org/)
 
 ## Development
 


### PR DESCRIPTION
#### Description:

Change the 'About Dryad' link from a non existance repo file to 'https://datadryad.org/'

#### Testing:

Successfully followed the link after pushing this branch to my fork.

Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC