### PR TITLE
Prevent stats from being uncached and just return what is in the database

### DIFF
--- a/cron/counter.sh
+++ b/cron/counter.sh
@@ -60,15 +60,15 @@ cd /apps/dryad/apps/ui/current
 # --------------------------------------
 # clear out cached stats in our database
 # --------------------------------------
-# echo "Clearing cached stats from database"
-# bundle exec rails counter:clear_cache
+echo "Clearing cached stats from database"
+bundle exec rails counter:clear_cache
 
 # This was from when we weren't getting stats back from DataCite because of problems
 # -----------------------------------------
 # repopulate all stats back into our tables
 # -----------------------------------------
-# echo "Repopulating stats into database cache"
-# JSON_DIRECTORY="$COUNTER_JSON_STORAGE" bundle exec rails counter:cop_manual
+echo "Repopulating stats into database cache"
+JSON_DIRECTORY="$COUNTER_JSON_STORAGE" bundle exec rails counter:cop_manual
 
 # -----------------------------------------------
 # remove old logs that are past our deletion time

--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -157,12 +157,12 @@ namespace :dev_ops do
     end
 
     unless ARGV.length == 2
-      puts "Please put the path to the file to process"
+      puts 'Please put the path to the file to process'
       next
     end
 
     DevOps::DownloadUri.update_from_file(file_path: ARGV[1])
-    puts "Done"
+    puts 'Done'
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/lib/tasks/dev_ops/download_uri.rb
+++ b/lib/tasks/dev_ops/download_uri.rb
@@ -6,7 +6,7 @@ module DevOps
     def self.update_from_file(file_path:)
       File.readlines(file_path).each do |line|
         parts = line.strip.split('|')
-        self.update(doi: parts[0], old_ark: parts[1], new_ark: parts[2])
+        update(doi: parts[0], old_ark: parts[1], new_ark: parts[2])
       end
     end
 

--- a/spec/tasks/dev_ops_spec.rb
+++ b/spec/tasks/dev_ops_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'byebug'
+require 'cgi'
 
 describe 'dev_ops:retry_zenodo_errors', type: :task do
   it 'preloads the Rails environment' do
@@ -69,7 +70,7 @@ describe 'dev_ops:download_uri', type: :task do
   it 'runs the rake task' do
     test_path = File.join(Rails.root, 'spec', 'fixtures', 'merritt_ark_changing_test.txt')
     argv = ['', test_path]
-    stub_const("ARGV", argv)
+    stub_const('ARGV', argv)
     expect { task.execute }.to output(/Done/).to_stdout
   end
 
@@ -81,7 +82,7 @@ describe 'dev_ops:download_uri', type: :task do
     it 'loads the file and calls updates' do
       # testing one specific value from the file
       expect(DevOps::DownloadUri).to receive(:update)\
-        .with(doi: 'doi:10.5072/FK20R9S858', old_ark:'ark:/99999/fk4np2b23p', new_ark: 'ark:/99999/fk4cv5xm2w').once
+        .with(doi: 'doi:10.5072/FK20R9S858', old_ark: 'ark:/99999/fk4np2b23p', new_ark: 'ark:/99999/fk4cv5xm2w').once
       # testing that it is called for the other 11
       expect(DevOps::DownloadUri).to receive(:update).at_least(11).times
       DevOps::DownloadUri.update_from_file(file_path: @test_path)
@@ -93,8 +94,8 @@ describe 'dev_ops:download_uri', type: :task do
       throwaway_resource = create(:resource)
       expect(resource.download_uri).not_to eq(throwaway_resource.download_uri)
 
-      old_ark = URI.unescape(resource.download_uri.match(/[^\/]+$/).to_s)
-      new_ark = URI.unescape(throwaway_resource.download_uri.match(/[^\/]+$/).to_s)
+      old_ark = CGI.unescape(resource.download_uri.match(%r{[^/]+$}).to_s)
+      new_ark = CGI.unescape(throwaway_resource.download_uri.match(%r{[^/]+$}).to_s)
 
       DevOps::DownloadUri.update(doi: resource.identifier.to_s, old_ark: old_ark, new_ark: new_ark)
 

--- a/stash/stash_engine/app/models/stash_engine/counter_stat.rb
+++ b/stash/stash_engine/app/models/stash_engine/counter_stat.rb
@@ -8,17 +8,17 @@ module StashEngine
     # all these "check" methods may be obsolete if we do scripts for population of everything ahead
     # and then we could just pull from database
     def check_unique_investigation_count
-      update_if_necessary
+      # update_if_necessary
       unique_investigation_count
     end
 
     def check_unique_request_count
-      update_if_necessary
+      # update_if_necessary
       unique_request_count
     end
 
     def check_citation_count
-      update_if_necessary
+      # update_if_necessary
       citation_count
     end
 
@@ -46,9 +46,9 @@ module StashEngine
       # only update stats if it's a later calendar week than this record was updated
       return unless new_record? || updated_at.nil? || calendar_week(Time.new) > calendar_week(updated_at)
 
-      # do no update the usage data until we can successfully get all of our reports in to DataCite in order to pull them back
-      update_usage!
-      update_citation_count!
+      # do not update the usage data until we can successfully get all of our reports in to DataCite in order to pull them back
+      # update_usage!
+      # update_citation_count!
       self.updated_at = Time.new.utc # seem to need this for some reason, since not always updating automatically
       save!
     end


### PR DESCRIPTION
Changes:

- Uncommented the code that re-populates stats into the database after weekly counter run.
- Commented out calls to `update_if_necessary` which checks cached value and updates if it is old, so it will never update in the UI itself.
- A bunch of small rubocop (auto) fixes which seemed to be left over from a couple other PRs and I didn't notice when tests stopped running.

I ran tests against this locally (since no travis) and it passes.