### PR TITLE
Default the return_url to the dashboard

### DIFF
--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_edit_dataset_button.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_edit_dataset_button.html.erb
@@ -2,6 +2,6 @@
   <%= form_with(url: metadata_entry_pages_new_version_path, method: :post, local: true) do -%>
     <button class="c-admin-edit-icon js-trap-curator-url" title="Edit Dataset"><i class="fa fa-pencil" aria-hidden="true"></i></button>
     <%= hidden_field_tag :resource_id, resource_id, id: "resource_id_#{resource_id}" %>
-    <%= hidden_field_tag :return_url, 'blfj' %>
+    <%= hidden_field_tag :return_url, '/stash/dashboard' %>
   <% end %>
 <% end %>


### PR DESCRIPTION
If the return_url is not set by the javascript, default it to the user's dashboard.

This addresses the issue reported in https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1016