### PR TITLE
Reinstate database backups

### DIFF
--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -88,7 +88,7 @@ namespace :dev_ops do
     FileUtils.mkdir directory unless File.exist?(directory)
     # YAML.safe_load is preferred by rubocop but it causes the read to fail on `unknown alias 'defaul'`
     # rubocop:disable Security/YAMLLoad
-    db = YAML.load(File.open(File.join(Rails.root, 'config', 'database.yml')))[Rails.env]
+    db = YAML.load(ERB.new(File.read(File.join(Rails.root, 'config', 'database.yml'))).result)[Rails.env]
     # rubocop:enable Security/YAMLLoad
     file = File.join(directory, "#{Rails.env}_#{Time.now.strftime('%H_%M')}.sql")
     p command = 'mysqldump --opt --skip-add-locks --single-transaction --no-create-db ' \


### PR DESCRIPTION
Database backups have not been running for a while, because the rake file was not processing the database config as an ERB. 