### PR TITLE
Change UCOP to point to Dryad migrated storage

### DIFF
--- a/config/tenants/ucop.yml
+++ b/config/tenants/ucop.yml
@@ -59,9 +59,9 @@ production:
   #Add any items that need to override the defaults here
   repository:
     domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/ucop_dash"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_ucop_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_ucop_password] %> 
+    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
+    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
+    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: ezid
     shoulder: "doi:10.18737/D7"


### PR DESCRIPTION
Just changing the UCOP tenant to use Dryad instead of UCOP collection storage in Merritt.  I'll run the script to update the database from the file david loy gave me.