### PR TITLE
prevent updated_at from changing in Merritt update script

### DIFF
--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -147,6 +147,11 @@ namespace :dev_ops do
     puts APP_CONFIG[:counter][:token]
   end
 
+  # this is for Merritt changes moving the old UC collections into the Dryad collections
+  # After things are moved, two things need to happen 1) the tenant config needs to be
+  # changed to point to dryad, and 2) this script needs to be run against the text file
+  # provided by David Loy in order to update the ARKs in the sword URLs so that downloads
+  # and further version submissions work.
   desc 'Updates database for Merritt ark changes'
   task download_uri: :environment do
     # example command

--- a/lib/tasks/dev_ops/download_uri.rb
+++ b/lib/tasks/dev_ops/download_uri.rb
@@ -17,8 +17,10 @@ module DevOps
       resources = my_id.resources.where('download_uri LIKE ?', "%#{CGI.escape(old_ark)}")
 
       resources.each do |resource|
+        old_dl_uri = resource.download_uri
+        resource.record_timestamps = false # prevents updated_at from being changed automatically
         resource.update!(download_uri: resource.download_uri.gsub(CGI.escape(old_ark), CGI.escape(new_ark)))
-        puts "Resource: #{resource.id} download_uri updated to #{resource.download_uri}"
+        puts "Resource: #{resource.id} download_uri updated from #{old_dl_uri} to #{resource.download_uri}"
       end
     end
   end

--- a/spec/tasks/dev_ops_spec.rb
+++ b/spec/tasks/dev_ops_spec.rb
@@ -90,6 +90,8 @@ describe 'dev_ops:download_uri', type: :task do
 
     it 'updates the database download_uri' do
       resource = create(:resource)
+      old_time = Time.parse('2020-10-11').utc
+      resource.update(updated_at: old_time)
       # the throwaway resource is just to obtain another download_uri and ark to test for the new_ark and transformation
       throwaway_resource = create(:resource)
       expect(resource.download_uri).not_to eq(throwaway_resource.download_uri)
@@ -101,6 +103,7 @@ describe 'dev_ops:download_uri', type: :task do
 
       resource.identifier.resources.each do |res|
         expect(res.download_uri).to eq(throwaway_resource.download_uri)
+        expect(res.updated_at).to eq(old_time)
       end
     end
   end


### PR DESCRIPTION
Minor changes with comments, test and preventing updated_at time from changing with changes in the URL for merritt

BTW, I ran tests against this locally and they passed.