### PR TITLE
changes to be sure collection name in sword update url is also changed

### DIFF
--- a/lib/tasks/dev_ops/download_uri.rb
+++ b/lib/tasks/dev_ops/download_uri.rb
@@ -18,8 +18,16 @@ module DevOps
 
       resources.each do |resource|
         old_dl_uri = resource.download_uri
+        # extract the part of the path with the old merrritt collection name and replace it with /cdl_dryad/
+        collection_match = resource.update_uri.match(%r{39001/[^/]+/[^/]+/([^/]+)/doi})
+        new_update = (if collection_match.present?
+                        resource.update_uri.gsub(collection_match[1], '/cdl_dryad/')
+                      else
+                        resource.update_uri
+                      end)
+        new_dl = resource.download_uri.gsub(CGI.escape(old_ark), CGI.escape(new_ark))
         resource.record_timestamps = false # prevents updated_at from being changed automatically
-        resource.update!(download_uri: resource.download_uri.gsub(CGI.escape(old_ark), CGI.escape(new_ark)))
+        resource.update!(download_uri: new_dl, update_uri: new_update)
         puts "Resource: #{resource.id} download_uri updated from #{old_dl_uri} to #{resource.download_uri}"
       end
     end

--- a/spec/factories/stash_engine/resources.rb
+++ b/spec/factories/stash_engine/resources.rb
@@ -7,7 +7,10 @@ FactoryBot.define do
     has_geolocation { true }
     title { Faker::Lorem.sentence }
     download_uri { "http://merritt-fake.cdlib.org/d/ark%3A%2F99999%2Ffk#{Faker::Alphanumeric.alphanumeric(number: 8)}" }
-    update_uri { Faker::Internet.url }
+    update_uri do
+      "http://mrtsword-fake.cdlib.org:39001/mrtsword/edit/#{Faker::Alphanumeric.alpha(number: 8)}/" \
+      "doi%3A10.5061%2Fdryad.#{Faker::Alphanumeric.alphanumeric(number: 6)}"
+    end
     publication_date { Time.new.utc }
 
     before(:create) do |resource|

--- a/spec/tasks/dev_ops_spec.rb
+++ b/spec/tasks/dev_ops_spec.rb
@@ -88,9 +88,10 @@ describe 'dev_ops:download_uri', type: :task do
       DevOps::DownloadUri.update_from_file(file_path: @test_path)
     end
 
-    it 'updates the database download_uri' do
+    it 'updates the database download_uri and update_uri' do
       resource = create(:resource)
       old_time = Time.parse('2020-10-11').utc
+      old_update_uri = resource.update_uri
       resource.update(updated_at: old_time)
       # the throwaway resource is just to obtain another download_uri and ark to test for the new_ark and transformation
       throwaway_resource = create(:resource)
@@ -103,6 +104,9 @@ describe 'dev_ops:download_uri', type: :task do
 
       resource.identifier.resources.each do |res|
         expect(res.download_uri).to eq(throwaway_resource.download_uri)
+        expect(res.update_uri).not_to eq(old_update_uri)
+        expect(res.update_uri[-28..]).to eq(old_update_uri[-28..]) # last (doi) of string should be the same
+        expect(res.update_uri).to include('/cdl_dryad/') # because we're always moving into that collection
         expect(res.updated_at).to eq(old_time)
       end
     end


### PR DESCRIPTION
Sorry about this additional update for this.  The requirement for this wasn't clear to me since I just saw the DOI in the URL and didn't spot that they had embedded more of the Merritt internal data into the URL (collection name) also.

I updated the code for this as well as tests and ran tests locally which show it's working.

I also went and manually changed the URLs for the ~10 items we changed yesterday and tried a new version submission for one of them which worked in the new collection.