### PR TITLE
Changes to get results for COUNTER from datacite again

### DIFF
--- a/cron/counter.sh
+++ b/cron/counter.sh
@@ -60,15 +60,15 @@ cd /apps/dryad/apps/ui/current
 # --------------------------------------
 # clear out cached stats in our database
 # --------------------------------------
-echo "Clearing cached stats from database"
-bundle exec rails counter:clear_cache
+# echo "Clearing cached stats from database"
+# bundle exec rails counter:clear_cache
 
 # This was from when we weren't getting stats back from DataCite because of problems
 # -----------------------------------------
 # repopulate all stats back into our tables
 # -----------------------------------------
-echo "Repopulating stats into database cache"
-JSON_DIRECTORY="$COUNTER_JSON_STORAGE" bundle exec rails counter:cop_manual
+# echo "Repopulating stats into database cache"
+# JSON_DIRECTORY="$COUNTER_JSON_STORAGE" bundle exec rails counter:cop_manual
 
 # -----------------------------------------------
 # remove old logs that are past our deletion time

--- a/stash/stash_engine/app/models/stash_engine/counter_stat.rb
+++ b/stash/stash_engine/app/models/stash_engine/counter_stat.rb
@@ -8,17 +8,17 @@ module StashEngine
     # all these "check" methods may be obsolete if we do scripts for population of everything ahead
     # and then we could just pull from database
     def check_unique_investigation_count
-      # update_if_necessary
+      update_if_necessary
       unique_investigation_count
     end
 
     def check_unique_request_count
-      # update_if_necessary
+      update_if_necessary
       unique_request_count
     end
 
     def check_citation_count
-      # update_if_necessary
+      update_if_necessary
       citation_count
     end
 
@@ -46,9 +46,8 @@ module StashEngine
       # only update stats if it's a later calendar week than this record was updated
       return unless new_record? || updated_at.nil? || calendar_week(Time.new) > calendar_week(updated_at)
 
-      # do not update the usage data until we can successfully get all of our reports in to DataCite in order to pull them back
-      # update_usage!
-      # update_citation_count!
+      update_usage!
+      update_citation_count!
       self.updated_at = Time.new.utc # seem to need this for some reason, since not always updating automatically
       save!
     end


### PR DESCRIPTION
I tested and resubmitted 2020-11 and 2020-12 reports and DataCite is now accepting updates to our reports.

This reverts the (non-rubocop) changes to only get report stats locally and not from datacite.  That PR was https://github.com/CDL-Dryad/dryad-app/pull/303/files .

I ran tests locally and it didn't give any errors.