### PR TITLE
Monitor DB backups

### DIFF
--- a/documentation/server_maintenance/status_dashboard.md
+++ b/documentation/server_maintenance/status_dashboard.md
@@ -1,0 +1,14 @@
+
+The status dashboard allows monitoring of the various services that
+are required for Dryad to run, both internal and external.
+
+To add a new checker:
+- add a checker to `stash/stash_engine/app/services/stash_engine/status_dashboard/`
+- add an entry to `stash/stash_engine/lib/tasks/status_dashboard.rake`
+
+To run a checker manually, in the Rails console, both instantiate it
+and specify its abbreviation:
+```
+dc=StashEngine::StatusDashboard::DBBackupService.new(abbreviation: 'db_backup')
+dc.ping_dependency
+```

--- a/documentation/server_maintenance/status_dashboard.md
+++ b/documentation/server_maintenance/status_dashboard.md
@@ -5,6 +5,8 @@ are required for Dryad to run, both internal and external.
 To add a new checker:
 - add a checker to `stash/stash_engine/app/services/stash_engine/status_dashboard/`
 - add an entry to `stash/stash_engine/lib/tasks/status_dashboard.rake`
+- on any server where the checker needs to run, re-seed the database
+  with the list of checkers: `rails status_dashboard:seed`
 
 To run a checker manually, in the Rails console, both instantiate it
 and specify its abbreviation:

--- a/stash/stash_engine/app/services/stash_engine/status_dashboard/db_backup_service.rb
+++ b/stash/stash_engine/app/services/stash_engine/status_dashboard/db_backup_service.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'httparty'
+
+module StashEngine
+  module StatusDashboard
+
+    class DBBackupService < DependencyCheckerService
+
+      BACKUP_DIR = '/dryad/apps/ui/shared/cron/backups'
+
+      def ping_dependency
+        super
+        record_status(online: false, message: "No backup dir found at '#{BACKUP_DIR}'.") unless File.exist?(BACKUP_DIR) &&
+                                                                                                File.directory?(BACKUP_DIR)
+        return false unless File.exist?(BACKUP_DIR) && File.directory?(BACKUP_DIR)
+
+        # Find the date of the most recent file modification
+        last_run_date = 1.year.ago
+        last_file = ''
+        Dir.each_child(BACKUP_DIR) do |f|
+          modified = File.mtime("#{BACKUP_DIR}/#{f}")
+          if modified >= last_run_date
+            last_run_date = modified
+            last_file = f
+          end
+        end
+
+        online = last_run_date >= (Time.now - 45.minutes)
+
+        msg = "The database backup service last ran at '#{last_run_date}'. " unless online
+        record_status(online: online, message: msg)
+        online
+      rescue StandardError => e
+        record_status(online: false, message: e.to_s)
+        false
+      end
+
+    end
+
+  end
+end

--- a/stash/stash_engine/lib/tasks/status_dashboard.rake
+++ b/stash/stash_engine/lib/tasks/status_dashboard.rake
@@ -22,8 +22,8 @@ namespace :status_dashboard do
 
   desc 'Seed the external_dependencies table'
   task seed: :environment do
-    p 'The external_dependencies table is not empty! Aborting seed process' if StashEngine::ExternalDependency.all.any?
-    exit if StashEngine::ExternalDependency.all.any?
+    p 'Seeding the external_dependencies table.'
+    StashEngine::ExternalDependency.all.destroy_all
 
     BASELINE_EXTERNAL_DEPENDENCIES.each do |dependency_hash|
       StashEngine::ExternalDependency.create(dependency_hash)
@@ -45,6 +45,14 @@ namespace :status_dashboard do
       name: 'Stash Notifier',
       description: 'The service that lets Dryad know when Merritt has finished processing (via the OAI-PMH feed)',
       documentation: 'If the OAI-PMH feed is working and the item is present, check the stash-notifier logs.  A pid file that was never removed may prevent the notifier from processing additional items since it believes a notifier instance is already running.  You may need to remove the pid file or look to see if there is some problem with the notifier.  Maybe a server got shut down in the middle of a run so the notifier didn\'t have a chance to remove it\'s own pid.',
+      internally_managed: true,
+      status: 1
+    },
+    {
+      abbreviation: 'db_backup',
+      name: 'Database Backups',
+      description: 'The service manages short-term backups of the database',
+      documentation: 'This is managed by the 30-minute cron job on the server.',
       internally_managed: true,
       status: 1
     },


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1031

Add a dependency checker to ensure database backups are occurring regularly. Also improve the rake task for setting up the dependency checkers, so new checkers can be added more easily.

Before testing, re-initialize the dependency checkers in your database with `rails status_dashboard:seed`