### PR TITLE
Rake task and documentation for embargoing at zenodo

### DIFF
--- a/documentation/server_maintenance/troubleshooting.md
+++ b/documentation/server_maintenance/troubleshooting.md
@@ -147,6 +147,13 @@ update stash_engine_resources set publication_date='2020-07-25 01:01:01' where i
 update stash_engine_identifiers set pub_state='embargoed' where id=;
 ```
 
+Now run a command like the one one below if it has been published to Zenodo.  It will
+re-open the published record, set embargo and publish it again with the
+embargo date.  You can find the deposition_id in the stash_engine_zenodo_copies table.
+```
+# the arguments are 1) resource_id, 2) deposition_id at zenodo, 3) date
+RAILS_ENV=production bundle exec rake dev_ops:embargo_zenodo 97683 4407065 2021-12-31
+```
 
 Error message: Maybe you tried to change something you didn't have access to
 ============================================================================

--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -174,7 +174,10 @@ namespace :dev_ops do
   task embargo_zenodo: :environment do
     # apparently I have to do this, at least in some cases because arguments to rake are ugly
     # https://www.seancdavis.com/blog/4-ways-to-pass-arguments-to-a-rake-task/
-    ARGV.each { |a| task a.to_sym do ; end }
+
+    # rubocop:disable Style/BlockDelimiters
+    ARGV.each { |a| task a.to_sym do; end }
+    # rubocop:enable Style/BlockDelimiters
 
     unless ENV['RAILS_ENV']
       puts 'RAILS_ENV must be explicitly set before running this script'

--- a/spec/fixtures/zenodo/embargo_sample.json
+++ b/spec/fixtures/zenodo/embargo_sample.json
@@ -1,0 +1,42 @@
+{
+  "metadata": {
+    "access_right": "embargoed",
+    "communities": [
+      {
+        "identifier": "dryad"
+      },
+      {
+        "identifier": "zenodo"
+      }
+    ],
+    "creators": [
+      {
+        "affiliation": "University of California, Office of the President",
+        "name": "Account, Testing",
+        "orcid": "0000-0002-4734-4551"
+      }
+    ],
+    "description": "<p>Whale blubber must be left behind.</p>",
+    "doi": "10.55072/FK2KP83D7Z",
+    "embargo_date": "2021-07-28",
+    "keywords": [
+      "Blubber"
+    ],
+    "license": "CC0-1.0",
+    "notes": "<p>Funding provided by: Wild Blueberry Producers Association of Nova Scotia<br>Crossref Funder Registry ID: http://dx.doi.org/10.13039/100008767<br>Award Number: NovaBlubber33</p>",
+    "prereserve_doi": {
+      "doi": "10.5072/zenodo.715501",
+      "recid": 715501
+    },
+    "publication_date": "2021-01-11",
+    "related_identifiers": [
+      {
+        "identifier": "10.5072/zenodo.715499",
+        "relation": "isDerivedFrom",
+        "scheme": "doi"
+      }
+    ],
+    "title": "Blubber Free Whales",
+    "upload_type": "dataset"
+  }
+}

--- a/stash/stash_engine/lib/stash/zenodo_replicate/deposit.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/deposit.rb
@@ -26,9 +26,12 @@ module Stash
 
       # PUT /api/deposit/depositions/123
       # Need to have gotten or created the deposition for this to work
-      def update_metadata
-        mg = MetadataGenerator.new(resource: @resource)
-        ZC.standard_request(:put, "#{ZC.base_url}/api/deposit/depositions/#{@deposition_id}", json: { metadata: mg.metadata })
+      def update_metadata(manual_metadata: nil)
+        if manual_metadata.nil?
+          mg = MetadataGenerator.new(resource: @resource)
+          manual_metadata = mg.metadata
+        end
+        ZC.standard_request(:put, "#{ZC.base_url}/api/deposit/depositions/#{@deposition_id}", json: { metadata: manual_metadata })
       end
 
       # GET /api/deposit/depositions/123


### PR DESCRIPTION
Embargoes at zenodo, I needed to do that for another previously published item.

The smaller things this changes.

1. Allows arbitrary metadata to be passed into the zenodo update method, so it can take existing metadata already there without having to regenerate it (which is our usual submission/update case).
2. Puts the series of steps needed at zenodo into a rake task so we don't have to do it manually or email Alex every time.
3. Added to the documentation about how to run the rake task after the other queries that embargo something. (In normal circumstances the extra copy isn't sent to zenodo until published).

I didn't add a test for the rake task since it mostly is just validation and calls a few steps from the stash/zenodo_replicate/deposit class (basically *get*, *reopen* for editing, *update metadata* with embargo set, *re-publish*).

