### PR TITLE
In API, do not "auto match" affiliations to the closest ROR entry

### DIFF
--- a/documentation/apis/submission.md
+++ b/documentation/apis/submission.md
@@ -79,8 +79,6 @@ You should see a 200 response and some information something like:
 
 ## Create metadata for the dataset
 
-## Create metadata for the dataset
-
 Create the appropriate metadata. A sample of the bare minimum metadata
 is shown below, but typical metadata should be more complete:
 

--- a/documentation/technical_notes/affiliations.md
+++ b/documentation/technical_notes/affiliations.md
@@ -1,0 +1,21 @@
+
+Author Affiliations
+===================
+
+Author affiliations are associated with ROR identifiers. When there is
+not corresponding ROR identifier for an affiliation, the affiliation
+name is stored with an asterisk appended, so the curators can easily
+see that there is no maching ROR.
+
+Overview of the UI pieces
+- on the view for editing a dataset, there is a partial for the given
+  affiliation
+  - `stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb`
+- this partial makes a GET call to find the affiliation values
+  - `https://datadryad.org/stash_datacite/affiliations/autocomplete?term=unc`
+- the affiliation_controller handles the GET and makes the actual call
+  to ROR to find the values, then returns JSON into the partial for
+  rendering
+  - `stash/stash_datacite/app/controllers/stash_datacite/affiliations_controller.rb`
+  - `stash_engine/lib/stash/organization/ror.rb`
+

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -51,7 +51,8 @@ module StashApi
         expect(hsh[:abstract]).to eq(output[:abstract])
         in_author = hsh[:authors].first
         out_author = output[:authors].first
-        expect(in_author[:email]).to eq(out_author[:email])
+        expect(out_author[:email]).to eq(in_author[:email])
+        expect(out_author[:affiliation]).to eq(in_author[:affiliation])
       end
 
       it 'creates a new dataset with a userId explicitly set by superuser)' do

--- a/stash/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser.rb
@@ -139,7 +139,7 @@ module StashApi
         afis = StashDatacite::Affiliation.from_isni_id(isni_id: json_author[:affiliationISNI])
         a.affiliation = afis
       elsif json_author[:affiliation].present?
-        a.affiliation = StashDatacite::Affiliation.from_long_name(long_name: json_author[:affiliation], check_ror: true)
+        a.affiliation = StashDatacite::Affiliation.from_long_name(long_name: json_author[:affiliation], check_ror: false)
       end
 
       a.save(validate: false) # we can validate on submission, keeps from saving otherwise


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1046

Disables automatic matching for affiliation names submitted via the API, and adds some documentation about how affiliations are implemented (to make these issues easier to solve in the future).