### PR TITLE
Transform github blob urls into the raw format

### DIFF
--- a/spec/models/stash/url_translator_spec.rb
+++ b/spec/models/stash/url_translator_spec.rb
@@ -50,6 +50,11 @@ module Stash
       expect(translator.original_url).to eql('cat dog')
     end
 
+    it 'sets things correctly for special github software blob urls' do
+      translator = Stash::UrlTranslator.new('https://github.com/tracykteal/chicken-naming/blob/master/chicken-naming.ipynb')
+      expect(translator.service).to eql('github')
+      expect(translator.direct_download).to eql('https://raw.githubusercontent.com/tracykteal/chicken-naming/master/chicken-naming.ipynb')
+    end
   end
 
 end

--- a/stash/stash_engine/lib/stash/url_translator.rb
+++ b/stash/stash_engine/lib/stash/url_translator.rb
@@ -17,6 +17,7 @@ module Stash
     GOOGLE_SHEET = %r{^https://docs\.google\.com/spreadsheets/d/(\S+)/edit(?:\?usp=sharing)?$}.freeze
     DROPBOX = %r{^https://www\.dropbox\.com/s/(\S+)/([^/]+)(?:\?dl=[0-9]+)$}.freeze
     BOX = %r{^https://([^/]+box\.com)/s/(\S+)$}.freeze
+    GITHUB = %r{^https?://github.com/([^/]+/[^/]+)/blob(/[^/]+/[^/]+)$}.freeze
 
     attr_reader :service, :direct_download, :original_url
 
@@ -25,7 +26,7 @@ module Stash
       @original_url = (u.fragment ? original_url[0..-(u.fragment.length + 2)] : original_url)
       @service = nil
 
-      %w[google_drive google_doc google_presentation google_sheet dropbox box].each do |m|
+      %w[google_drive google_doc google_presentation google_sheet dropbox box github].each do |m|
         next unless (@direct_download = send(m))
 
         @service = m
@@ -74,6 +75,12 @@ module Stash
       return nil unless (m = BOX.match(@original_url))
 
       "https://#{m[1]}/public/static/#{m[2]}"
+    end
+
+    def github
+      return nil unless (m = GITHUB.match(@original_url))
+
+      "https://raw.githubusercontent.com/#{m[1]}#{m[2]}"
     end
 
   end


### PR DESCRIPTION
So that people don't get web pages saved when they want a raw file.

See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1061 .

