### PR TITLE
Add "progress" format to remaining tests

### DIFF
--- a/.github/workflows/rspec_features.yml
+++ b/.github/workflows/rspec_features.yml
@@ -62,4 +62,4 @@ jobs:
       run: bin/rails assets:precompile
 
     - name: 'Run RSpec Feature Tests'
-      run: bin/bundle exec rspec --force-color --format RSpec::Github::Formatter --tag ~skip spec/features/
+      run: bin/bundle exec rspec --force-color --format RSpec::Github::Formatter --format progress --tag ~skip spec/features/

--- a/.github/workflows/rspec_internal.yml
+++ b/.github/workflows/rspec_internal.yml
@@ -59,10 +59,10 @@ jobs:
         bin/rails db:setup RAILS_ENV=test
 
     - name: 'RSpec Controller Tests'
-      run: bin/bundle exec rspec --force-color --format RSpec::Github::Formatter --tag ~skip spec/controllers
+      run: bin/bundle exec rspec --force-color --format RSpec::Github::Formatter --format progress --tag ~skip spec/controllers
 
     - name: 'RSpec Job Tests'
-      run: bin/bundle exec rspec --force-color --format RSpec::Github::Formatter --tag ~skip spec/jobs
+      run: bin/bundle exec rspec --force-color --format RSpec::Github::Formatter --format progress --tag ~skip spec/jobs
 
     - name: 'RSpec Model Tests'
       run: bin/bundle exec rspec --force-color --format RSpec::Github::Formatter --format progress --tag ~skip spec/models
@@ -74,4 +74,4 @@ jobs:
       run: bin/bundle exec rspec --force-color --format RSpec::Github::Formatter --format progress --tag ~skip spec/tasks
 
     - name: 'RSpec Stash-Notifier Tests'
-      run: bin/bundle exec rspec --force-color --format RSpec::Github::Formatter --tag ~skip stash/stash-notifier/spec/
+      run: bin/bundle exec rspec --force-color --format RSpec::Github::Formatter --format progress --tag ~skip stash/stash-notifier/spec/

--- a/.github/workflows/rspec_responses.yml
+++ b/.github/workflows/rspec_responses.yml
@@ -59,4 +59,4 @@ jobs:
         bin/rails db:setup RAILS_ENV=test
 
     - name: 'Run RSpec Response Tests'
-      run: bin/bundle exec rspec --force-color --format RSpec::Github::Formatter --tag ~skip spec/responses
+      run: bin/bundle exec rspec --force-color --format RSpec::Github::Formatter --format progress --tag ~skip spec/responses


### PR DESCRIPTION
I forgot to add these into every test. It's just nice to see the line of periods in the output to know that the tests are actually running.