### PR TITLE
Allow ROR affiliations to be converted to non-ROR

### DIFF
--- a/spec/features/stash_datacite/affiliation_autofill_spec.rb
+++ b/spec/features/stash_datacite/affiliation_autofill_spec.rb
@@ -26,16 +26,23 @@ RSpec.feature 'AffiliationAutofill', type: :feature do
       expect(page).to have_text('University of Testing v2')
     end
 
-    # Temporarily disabling this test because for some reason WebMock
-    # doesn't always load properly in this class and the test randomly fails.
-    xit 'sets the ROR id when user selects an option', js: true do
+    it 'sets the ROR id when user selects an option', js: true do
       stub_ror_id_lookup(university: 'University of Testing v2')
       fill_in 'author[affiliation][long_name]', with: 'Testing'
-      first('.ui-menu-item-wrapper', wait: 5).click
+      first('.ui-menu-item-wrapper', wait: 1).click
       expect(find('#author_affiliation_ror_id', visible: false).value).to eql('https://ror.org/TEST2')
     end
 
     it 'allows entries that are not registered with ROR', js: true do
+      fill_in 'author[affiliation][long_name]', with: 'Testing a non-ROR organization'
+      expect(find('#author_affiliation_ror_id', visible: false).value).to eql('')
+    end
+
+    it 'allows changing from a ROR-based value to a non-ROR value', js: true do
+      stub_ror_id_lookup(university: 'University of Testing v2')
+      fill_in 'author[affiliation][long_name]', with: 'Testing'
+      first('.ui-menu-item-wrapper', wait: 1).click
+      expect(find('#author_affiliation_ror_id', visible: false).value).to eql('https://ror.org/TEST2')
       fill_in 'author[affiliation][long_name]', with: 'Testing a non-ROR organization'
       expect(find('#author_affiliation_ror_id', visible: false).value).to eql('')
     end

--- a/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
@@ -15,6 +15,7 @@
 		  $( this ).autocomplete( "instance" ).menu.active ) {
 		 event.preventDefault();
              }
+	     $('<%= "##{form_id}" %> #author_affiliation_ror_id').val('') // clear any ROR that was saved previously
 	 })
 	 .autocomplete({
              source: function (request, response) {


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/736

Allows users to update affiliations regardless of whether the previous affiliation had a ROR.

To test: 
- enter the dataset submission system
- enter an affiliation that is associated with a ROR (appears in the autocomplete list)
- change to a different page of the submission system, and return to the Describe page
- change the affiliation to garbage characters (which won't match a ROR)
- change to a different page of the submission system, and return to the Describe page
- verify that the garbage characters still appear, and they have the asterisk appended