### PR TITLE
Don't give 'admin' users edit rights on curation page

### DIFF
--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -55,6 +55,14 @@ RSpec.feature 'Admin', type: :feature do
       expect(page).to have_css('input#user_comment')
     end
 
+    it 'does not allow editing a dataset from the curation page', js: true do
+      visit root_path
+      click_link('Admin')
+      expect(page).to have_text('Admin Dashboard')
+
+      expect(page).not_to have_css('button[title="Edit Dataset"]')
+    end
+
     it 'redirects to the dataset editing page, and the user is logged in, when requesting an edit link', js: true do
       sign_out
       @identifier.edit_code = Faker::Number.number(digits: 4)

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_edit_dataset_button.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_edit_dataset_button.html.erb
@@ -1,7 +1,7 @@
-
-<%= form_with(url: metadata_entry_pages_new_version_path, method: :post, local: true) do -%>
+<% if %w[superuser tenant_curator].include?(current_user.role) %>
+  <%= form_with(url: metadata_entry_pages_new_version_path, method: :post, local: true) do -%>
     <button class="c-admin-edit-icon js-trap-curator-url" title="Edit Dataset"><i class="fa fa-pencil" aria-hidden="true"></i></button>
     <%= hidden_field_tag :resource_id, resource_id, id: "resource_id_#{resource_id}" %>
     <%= hidden_field_tag :return_url, '/stash/dashboard' %>
+  <% end %>
 <% end %>
-


### PR DESCRIPTION
Tweak to the functionality in #332. While `tenant_curator` users should have edit rights on the curation page, `admin` users should not.