### PR TITLE
Improve files returned for published versions in the API

### DIFF
--- a/spec/responses/stash_api/files_controller_spec.rb
+++ b/spec/responses/stash_api/files_controller_spec.rb
@@ -202,8 +202,8 @@ module StashApi
         expect(response_code).to eq(404)
       end
 
-      it 'only shows files from a version where the files are visible' do
-        # force @resources[1] to published, but mark the file_view as false
+      it 'shows files from a previously-published version when the files of the given version are invisible' do
+        # force @resources[1] to status published, but mark the file_view as false
         @curation_activities << [create(:curation_activity, resource: @resources[1], status: 'curation'),
                                  create(:curation_activity, resource: @resources[1], status: 'published')]
         @resources[1].current_resource_state.update(resource_state: 'submitted')

--- a/spec/responses/stash_api/files_controller_spec.rb
+++ b/spec/responses/stash_api/files_controller_spec.rb
@@ -201,6 +201,21 @@ module StashApi
         response_code = get "/api/v2/versions/#{@resources[1].id}/files", headers: default_authenticated_headers
         expect(response_code).to eq(404)
       end
+
+      it 'only shows files from a version where the files are visible' do
+        # force @resources[1] to published, but mark the file_view as false
+        @curation_activities << [create(:curation_activity, resource: @resources[1], status: 'curation'),
+                                 create(:curation_activity, resource: @resources[1], status: 'published')]
+        @resources[1].current_resource_state.update(resource_state: 'submitted')
+        @resources[0].update(file_view: true)
+        @resources[1].update(file_view: false)
+        # retrieve the files
+        response_code = get "/api/v2/versions/#{@resources[1].id}/files", headers: default_authenticated_headers
+        hsh = response_body_hash
+        expect(response_code).to eq(200)
+        # check that they are the files from the visible version @resources[0]
+        expect(hsh['total']).to eq(25)
+      end
     end
 
     describe '#destroy' do


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1095

When a published resource does not have the files changed from a previously-published version of the resource, the files will be marked as `file_view: false`. This change allows the API to look up the previously-published version of the resource, so the visible version of the files can be accessed through the API.

To test: 
- Find or create a dataset where the most recently-published resource has `file_view: false`. This is easily accomplished by making a new version of a dataset and only changing the metadata.
- Using the API, get the list of files for this resource, like `curl -L "https://datadryad.org/api/v2/versions/<resource_id>/files"`
- The file identifiers should correspond to the files for the previous resource which had viewable files.
- The files should be downloadable through the API with no authentication, like `curl -L "https://datadryad.org/api/v2/files/<file_id>/download"`