### PR TITLE
Adds email errors for zenodo replication problems

### DIFF
--- a/spec/models/stash_engine/mailers/user_mailer_spec.rb
+++ b/spec/models/stash_engine/mailers/user_mailer_spec.rb
@@ -168,6 +168,22 @@ module StashEngine
 
     end
 
+    describe 'zenodo_error' do
+
+      before(:each) do
+        @res = create(:resource)
+        @zen = create(:zenodo_copy, identifier: @res.identifier, resource: @res, state: 'error', error_info: 'Something bad just happened',
+                                    software_doi: '10.2837/zenodo.bad_test', conceptrecid: '123345')
+      end
+
+      it 'send a zenodo error report' do
+        UserMailer.zenodo_error(@zen).deliver_now
+        deliveries = ActionMailer::Base.deliveries
+        expect(deliveries.size).to eq(1)
+        expect(deliveries[0].body.to_s).to include('Something bad just happened')
+      end
+    end
+
     private
 
     def assert_email(expected_subject)

--- a/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
+++ b/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
@@ -115,6 +115,18 @@ module StashEngine
            subject: "#{rails_env} Need assistance: \"#{@resource.title}\" (doi:#{@resource.identifier_value})")
     end
 
+    def zenodo_error(zenodo_copy_obj)
+      @zen = zenodo_copy_obj
+      logger.warn('Unable to report zenodo error, no zenodo copy object') unless @zen.present?
+      return unless @zen.present?
+
+      @bcc_emails = APP_CONFIG['submission_bc_emails'] || [@helpdesk_email]
+      @submission_error_emails = APP_CONFIG['submission_error_email'] || [@helpdesk_email]
+
+      mail(to: @submission_error_emails, bcc: @bcc_emails,
+           subject: "#{rails_env} Failed to update Zenodo for #{@zen.identifier} for event type #{@zen.copy_type}")
+    end
+
     private
 
     # rubocop:disable Style/NestedTernaryOperator

--- a/stash/stash_engine/app/views/stash_engine/user_mailer/zenodo_error.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/user_mailer/zenodo_error.html.erb
@@ -1,0 +1,51 @@
+<% # @zen is the zenodo_copy_object (stash_engine_zenodo_copies)
+   # It should have the information about the error written to the database at @zen.error_info before calling this email.
+   # It also may contain the deposition id (id that zenodo assigns), the state of the submission and relations to resource,
+   # identifier, and teh type of replication event taking place (data replication, software or software_publish)
+%>
+
+<p>Replication of files from Dryad to Zenodo failed. The error and further information follows.</p>
+
+<pre>
+<%= @zen.error_info %>
+</pre>
+
+<p>Further information for troubleshooting:</p>
+<dl>
+  <dt>Zenodo database copy id</dt>
+  <dd><%= @zen.id %></dd>
+
+  <dt>Replication type</dt>
+  <dd><%= @zen.copy_type %></dd>
+
+  <dt>Zenodo deposition id</dt>
+  <dd><%= @zen.deposition_id %></dd>
+
+  <dt>Identitifier id</dt>
+  <dd><%= @zen.identifier_id %></dd>
+
+  <dt>Identifier DOI</dt>
+  <dd><%= @zen.identifier&.to_s %></dd>
+
+  <dt>Resource id</dt>
+  <dd><%= @zen.resource_id %></dd>
+
+  <dt>Title</dt>
+  <dd><%= @zen.resource&.title %></dd>
+
+  <dt>Zenodo's DOI</dt>
+  <dd><%= @zen.software_doi %></dd>
+
+  <dt>Zenodo's concept id</dt>
+  <dd><%= @zen.conceptrecid %></dd>
+</dl>
+
+<p>The code is at <i>/stash/stash_engine/lib/stash/zenodo_replicate</i> or <i>/stash/stash_engine/lib/stash/zenodo_software</i>
+  (depending on the type of replication which may be an additional copy of data or a unique software submission on behalf of zenodo).</p>
+
+<p>
+  For temporary problems with the zenodo service such as network or service outages, they may automatically correct
+  themselves since failed items may be retried up to three times over the course of a few days.
+</p>
+
+<p>Other types of errors will probably need to be examined and corrected manually.</p>

--- a/stash/stash_engine/lib/stash/zenodo_replicate/copier.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/copier.rb
@@ -58,6 +58,8 @@ module Stash
       rescue Stash::MerrittDownload::DownloadError, Stash::ZenodoReplicate::ZenodoError, HTTP::Error => e
         # log this in the database so we can track it
         @copy.update(state: 'error', error_info: "#{e.class}\n#{e}")
+        @copy.reload
+        StashEngine::UserMailer.zenodo_error(@copy).deliver_now
       ensure
         @file_collection.cleanup_files
       end

--- a/stash/stash_engine/lib/stash/zenodo_software/copier.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/copier.rb
@@ -111,6 +111,8 @@ module Stash
         @file_collection.cleanup_files # only cleanup files after success and finished, keep on fs so we have them otherwise
       rescue Stash::ZenodoReplicate::ZenodoError, HTTP::Error => e
         @copy.update(state: 'error', error_info: "#{e.class}\n#{e}")
+        @copy.reload
+        StashEngine::UserMailer.zenodo_error(@copy).deliver_now
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 


### PR DESCRIPTION
The errors are saved in the database, but now we get error reports when they fail.

I tested on development and got this email.

```
[development] Failed to update Zenodo for doi:10.7959/dryad.00000000 for event type software
```

Replication of files from Dryad to Zenodo failed. The error and further information follows.

Stash::ZenodoReplicate::ZenodoError
identifier_id 3001: Cannot replicate a version while a previous version is replicating or has an error
Further information for troubleshooting:

Zenodo database copy id
241

Replication type
software

Zenodo deposition id

Identitifier id
3001

Identifier DOI
doi:10.7959/dryad.00000000

Resource id
3277

Title
Hoping for errors

Zenodo's DOI

Zenodo's concept id

The code is at /stash/stash_engine/lib/stash/zenodo_replicate or /stash/stash_engine/lib/stash/zenodo_software (depending on the type of replication which may be an additional copy of data or a unique software submission on behalf of zenodo).

For temporary problems with the zenodo service such as network or service outages, they may automatically correct themselves since failed items may be retried up to three times over the course of a few days.

Other types of errors will probably need to be examined and corrected manually.

Please do not reply to this email.

The Dryad Team

https://datadryad.org


