### PR TITLE
Removes related work for zenodo software if all files removed

### DIFF
--- a/spec/models/stash_datacite/related_identifier_spec.rb
+++ b/spec/models/stash_datacite/related_identifier_spec.rb
@@ -102,6 +102,48 @@ module StashDatacite
       end
     end
 
+    describe 'self.remove_zenodo_relation' do
+      it 'removes a record from the database for a zenodo doi' do
+        test_doi = "#{rand.to_s[2..6]}/zenodo#{rand.to_s[2.11]}"
+        StashDatacite::RelatedIdentifier.create(related_identifier: test_doi,
+               related_identifier_type: 'doi',
+               relation_type: 'isderivedfrom',
+               work_type: 'software',
+               verified: true,
+               resource_id: @resource.id)
+        @resource.reload
+        expect(@resource.related_identifiers.count).to eq(1)
+
+        StashDatacite::RelatedIdentifier.remove_zenodo_relation(resource_id: @resource.id, doi: test_doi)
+        @resource.reload
+        expect(@resource.related_identifiers.count).to eq(0)
+      end
+
+      it "only removes the appropriate related identifier" do
+        test_doi = "#{rand.to_s[2..6]}/zenodo#{rand.to_s[2.11]}"
+        test_doi2 = "#{rand.to_s[2..6]}/zenodo#{rand.to_s[2.11]}"
+        StashDatacite::RelatedIdentifier.create(related_identifier: test_doi,
+                                                related_identifier_type: 'doi',
+                                                relation_type: 'isderivedfrom',
+                                                work_type: 'software',
+                                                verified: true,
+                                                resource_id: @resource.id)
+
+        StashDatacite::RelatedIdentifier.create(related_identifier: test_doi,
+                                                related_identifier_type: 'doi',
+                                                relation_type: 'isderivedfrom',
+                                                work_type: 'software',
+                                                verified: true,
+                                                resource_id: @resource.id)
+        @resource.reload
+        expect(@resource.related_identifiers.count).to eq(2)
+
+        StashDatacite::RelatedIdentifier.remove_zenodo_relation(resource_id: @resource.id, doi: test_doi)
+        @resource.reload
+        expect(@resource.related_identifiers.count).to eq(1)
+      end
+    end
+
     describe '#work_type_friendly' do
       before(:each) do
         @related_identifier = create(:related_identifier, resource_id: @resource.id)

--- a/spec/models/stash_datacite/related_identifier_spec.rb
+++ b/spec/models/stash_datacite/related_identifier_spec.rb
@@ -106,11 +106,11 @@ module StashDatacite
       it 'removes a record from the database for a zenodo doi' do
         test_doi = "#{rand.to_s[2..6]}/zenodo#{rand.to_s[2.11]}"
         StashDatacite::RelatedIdentifier.create(related_identifier: test_doi,
-               related_identifier_type: 'doi',
-               relation_type: 'isderivedfrom',
-               work_type: 'software',
-               verified: true,
-               resource_id: @resource.id)
+                                                related_identifier_type: 'doi',
+                                                relation_type: 'isderivedfrom',
+                                                work_type: 'software',
+                                                verified: true,
+                                                resource_id: @resource.id)
         @resource.reload
         expect(@resource.related_identifiers.count).to eq(1)
 
@@ -119,7 +119,7 @@ module StashDatacite
         expect(@resource.related_identifiers.count).to eq(0)
       end
 
-      it "only removes the appropriate related identifier" do
+      it 'only removes the appropriate related identifier' do
         test_doi = "#{rand.to_s[2..6]}/zenodo#{rand.to_s[2.11]}"
         test_doi2 = "#{rand.to_s[2..6]}/zenodo#{rand.to_s[2.11]}"
         StashDatacite::RelatedIdentifier.create(related_identifier: test_doi,
@@ -129,7 +129,7 @@ module StashDatacite
                                                 verified: true,
                                                 resource_id: @resource.id)
 
-        StashDatacite::RelatedIdentifier.create(related_identifier: test_doi,
+        StashDatacite::RelatedIdentifier.create(related_identifier: test_doi2,
                                                 related_identifier_type: 'doi',
                                                 relation_type: 'isderivedfrom',
                                                 work_type: 'software',
@@ -141,6 +141,7 @@ module StashDatacite
         StashDatacite::RelatedIdentifier.remove_zenodo_relation(resource_id: @resource.id, doi: test_doi)
         @resource.reload
         expect(@resource.related_identifiers.count).to eq(1)
+        expect(@resource.related_identifiers.first.related_identifier).to eq(test_doi2)
       end
     end
 

--- a/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
@@ -145,6 +145,13 @@ module StashDatacite
       end
     end
 
+    def self.remove_zenodo_relation(resource_id:, doi:)
+      doi = standardize_doi(doi)
+      existing_item = where(resource_id: resource_id).where(related_identifier_type: 'doi')
+                                                     .where(related_identifier: doi).last
+      existing_item.destroy! if existing_item
+    end
+
     def valid_doi_format?
       RelatedIdentifier.valid_doi_format?(related_identifier)
     end

--- a/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
@@ -148,7 +148,7 @@ module StashDatacite
     def self.remove_zenodo_relation(resource_id:, doi:)
       doi = standardize_doi(doi)
       existing_item = where(resource_id: resource_id).where(related_identifier_type: 'doi')
-                                                     .where(related_identifier: doi).last
+        .where(related_identifier: doi).last
       existing_item.destroy! if existing_item
     end
 

--- a/stash/stash_engine/lib/stash/zenodo_software/copier.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/copier.rb
@@ -85,7 +85,7 @@ module Stash
         @copy.update(deposition_id: @resp[:id], software_doi: @resp[:metadata][:prereserve_doi][:doi],
                      conceptrecid: @resp[:conceptrecid])
 
-        StashDatacite::RelatedIdentifier.add_zenodo_relation(resource_id: @resource.id, doi: @copy.software_doi)
+        update_zenodo_relation
 
         return publish_dataset if @copy.copy_type == 'software_publish'
 
@@ -187,6 +187,15 @@ module Stash
 
       def submitted_before?
         !@previous_copy.nil?
+      end
+
+      def update_zenodo_relation
+        # only add link to zenodo software if they have any files left that they haven't deleted
+        if @resource.software_uploads.where(file_state: %w[created copied]).count.positive?
+          StashDatacite::RelatedIdentifier.add_zenodo_relation(resource_id: @resource.id, doi: @copy.software_doi)
+        else
+          StashDatacite::RelatedIdentifier.remove_zenodo_relation(resource_id: @resource.id, doi: @copy.software_doi)
+        end
       end
     end
   end


### PR DESCRIPTION
This removes the related work for software if all software was removed and adds it again if it's added.

We keep the records staged at zenodo and add and remove files there as they add and remove them in our UI.  Not published at zenodo until we publish at Dryad.

PS.  It's a bit annoying to test with delayed job, but i deployed and tested on dev and it works.

Before with software:

![Screen Shot 2021-02-17 at 4 22 32 PM](https://user-images.githubusercontent.com/105433/108286078-49cc4680-713d-11eb-88d9-68d77b29d71c.png)


After with software files removed from zenodo.

![Screen Shot 2021-02-17 at 4 24 26 PM](https://user-images.githubusercontent.com/105433/108286111-581a6280-713d-11eb-9def-bb8079973e56.png)
