### PR TITLE
Delete S3 files when deleting from user dashboard

### DIFF
--- a/spec/features/stash_engine/curation_activity_spec.rb
+++ b/spec/features/stash_engine/curation_activity_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 
 RSpec.feature 'CurationActivity', type: :feature do
 
+  include Mocks::Aws
   include Mocks::Stripe
   include Mocks::Ror
   include Mocks::Tenant
@@ -148,6 +149,7 @@ RSpec.feature 'CurationActivity', type: :feature do
     context :curating_dataset, js: true do
 
       before(:each) do
+        mock_aws!
         mock_stripe!
         mock_ror!
         mock_repository!

--- a/spec/models/stash_engine/identifier_spec.rb
+++ b/spec/models/stash_engine/identifier_spec.rb
@@ -3,6 +3,7 @@ require 'byebug'
 
 module StashEngine
   describe Identifier, type: :model do
+    include Mocks::Aws
     include Mocks::CurationActivity
     include Mocks::Datacite
     include Mocks::Ror
@@ -11,6 +12,7 @@ module StashEngine
     include Mocks::Tenant
 
     before(:each) do
+      mock_aws!
       mock_ror!
       mock_solr!
       mock_datacite!

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -100,6 +100,13 @@ module StashEngine
         dir_name = @resource.s3_dir_name(type: 'data')
         expect(%r{[0-9a-fA-F]{8}-#{@resource.id}/data}).to match(dir_name)
       end
+
+      it 'removes the S3 resources when the resource is destroyed' do
+        allow(Stash::Aws::S3).to receive(:delete_dir)
+        s3_dir = @resource.s3_dir_name(type: 'base')
+        @resource.destroy
+        expect(Stash::Aws::S3).to have_received(:delete_dir).with(s3_key: s3_dir)
+      end
     end
 
     describe :title do

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -101,7 +101,7 @@ module StashEngine
         expect(%r{[0-9a-fA-F]{8}-#{@resource.id}/data}).to match(dir_name)
       end
 
-      it 'removes the S3 resources when the resource is destroyed' do
+      it 'removes the S3 temporary files when the resource is destroyed' do
         allow(Stash::Aws::S3).to receive(:delete_dir)
         s3_dir = @resource.s3_dir_name(type: 'base')
         @resource.destroy

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -107,9 +107,14 @@ module StashEngine
       Identifier.destroy(identifier_id)
     end
 
+    def remove_s3_temp_files
+      Stash::Aws::S3.delete_dir(s3_key: s3_dir_name(type: 'base'))
+    end
+
     after_create :init_state_and_version, :update_stash_identifier_last_resource
     # for some reason, after_create not working, so had to add after_update
     after_update :update_stash_identifier_last_resource
+    before_destroy :remove_s3_temp_files
     after_destroy :remove_identifier_with_no_resources, :update_stash_identifier_last_resource
 
     # shouldn't be necessary but we have some stale data floating around
@@ -722,7 +727,7 @@ module StashEngine
     end
 
     # type can currently be data, software or supplemental
-    ALLOWED_UPLOAD_TYPES = { data: '/data', software: '/sfw',
+    ALLOWED_UPLOAD_TYPES = { base: '', data: '/data', software: '/sfw',
                              supplemental: '/supp', manifest: '/manifest' }.with_indifferent_access.freeze
 
     # this is long and wonky because it creates unique bucket "directories" even if running multiple different


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1119

Clean up temporary S3 files when a resource is destroyed, either from the `Delete` button on the user dashboard or through other means.

This *does* include files that were slated to go to Zenodo. It is assumed that if the resource is no longer needed, we do not want to send its files to Zenodo either.