### PR TITLE
Only show asterisks to superusers

### DIFF
--- a/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_landing_related_works.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_landing_related_works.html.erb
@@ -3,7 +3,7 @@
   <h3 class="o-heading__level3-related-works"><%= (my_ids.count > 1 ? wt.work_type_friendly_plural : wt.work_type_friendly) %></h3>
   <ul class="o-list-related">
     <% my_ids.each do |r| %>
-      <% bad_asterisk = ( r.verified? ? '' : ' *') %>
+      <% bad_asterisk = ( (current_user&.role == 'superuser' && !r.verified?) ? ' *' : '') %>
       <li>
         <% if r.work_type == 'undefined' %>
           This dataset <%= r.relation_name_english %>

--- a/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_show.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_show.html.erb
@@ -3,7 +3,7 @@
   <ul class="o-list">
     <% related_identifiers.each do |r| %>
       <% if r.work_type == 'undefined' %>
-        <% bad_asterisk = ( r.verified? ? '' : ' *') %>
+	 <% bad_asterisk = ( (current_user&.role == 'superuser' && !r.verified?) ? ' *' : '') %>
         <li>This dataset <%= r.relation_name_english %>
           <%= display_id(type: r.related_identifier_type,
                          my_id: r.related_identifier) %><%= bad_asterisk %></li>


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1125

When a user is not logged in, or the user is not a superuser, suppress the asterisks for Related Works.
