### PR TITLE
Convert API uploads to use S3

### DIFF
--- a/spec/mocks/aws.rb
+++ b/spec/mocks/aws.rb
@@ -6,6 +6,7 @@ module Mocks
       mock_s3!
     end
 
+    # rubocop:disable Metrics/AbcSize
     def mock_s3!
       allow_any_instance_of(::Aws::S3::Object).to receive(:delete).and_return(nil)
       allow_any_instance_of(::Aws::S3::Object).to receive(:exists?).and_return(nil)
@@ -13,12 +14,14 @@ module Mocks
       allow_any_instance_of(::Aws::S3::Object).to receive(:presigned_url).and_return(
         "https://somebucket.amazonaws.com/presignedURL-#{Faker::Alphanumeric.alphanumeric(number: 10)}"
       )
+      allow_any_instance_of(::Aws::S3::Object).to receive(:size).and_return(Faker::Number.number(digits: 6))
+      allow_any_instance_of(::Aws::S3::Object).to receive(:upload_stream).and_return(nil)
       allow_any_instance_of(::Aws::S3::ObjectSummary::Collection).to receive(:batch_delete!).and_return(nil)
 
       # Add a default database configuration, which is needed by Resource.s3_dir_name
       allow(Rails).to receive(:configuration).and_return(OpenStruct.new(database_configuration: { 'test' => { 'host' => 'localhost' } }))
     end
-
+    # rubocop:enable Metrics/AbcSize
   end
 
 end

--- a/spec/responses/stash_api/files_controller_spec.rb
+++ b/spec/responses/stash_api/files_controller_spec.rb
@@ -8,6 +8,7 @@ require 'cgi'
 module StashApi
   RSpec.describe FilesController, type: :request do
 
+    include Mocks::Aws
     include Mocks::CurationActivity
     include Mocks::Ror
     include Mocks::RSolr
@@ -24,6 +25,7 @@ module StashApi
       setup_access_token(doorkeeper_application: @doorkeeper_application)
 
       neuter_curation_callbacks!
+      mock_aws!
       mock_ror!
       mock_tenant!
 
@@ -60,11 +62,8 @@ module StashApi
         hsh = response_body_hash
         expect(hsh['_links']['self']['href']).not_to be_nil
         expect(hsh['path']).to eq(::File.basename(@file_path))
-        expect(hsh['size']).to eq(::File.size(@file_path))
         expect(hsh['mimeType']).to eq(@mime_type)
         expect(hsh['status']).to eq('created')
-        expect(hsh['digest']).to eq(Digest::MD5.hexdigest(::File.read(@file_path)))
-        expect(hsh['digestType']).to eq('md5')
       end
 
       it 'will not allow non-logged in to add a file' do
@@ -90,11 +89,8 @@ module StashApi
         expect(response_code).to eq(200)
         hsh = response_body_hash
         expect(hsh['path']).to eq(::File.basename(@file_path))
-        expect(hsh['size']).to eq(::File.size(@file_path))
         expect(hsh['mimeType']).to eq(@mime_type)
         expect(hsh['status']).to eq('created')
-        expect(hsh['digest']).to eq(Digest::MD5.hexdigest(::File.read(@file_path)))
-        expect(hsh['digestType']).to eq('md5')
       end
 
       it "doesn't allow listing a file that should be hidden from the public" do

--- a/stash/stash_engine/lib/stash/aws/s3.rb
+++ b/stash/stash_engine/lib/stash/aws/s3.rb
@@ -18,9 +18,23 @@ module Stash
         object.put(body: contents)
       end
 
+      def self.put_stream(s3_key:, stream:)
+        return unless s3_key && stream
+
+        object = s3_bucket.object(s3_key)
+        object.upload_stream do |write_stream|
+          IO.copy_stream(stream, write_stream)
+        end
+      end
+
       def self.exists?(s3_key:)
         obj = s3_bucket.object(s3_key)
         obj.exists?
+      end
+
+      def self.size(s3_key:)
+        obj = s3_bucket.object(s3_key)
+        obj.size
       end
 
       def self.presigned_download_url(s3_key:)


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1111

Allows file uploads through the API to go directly through S3.