### PR TITLE
Don't make files "visible" if they are all deleted

### DIFF
--- a/stash/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -191,7 +191,7 @@ module StashEngine
     end
 
     # Triggered on a status change
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def email_status_change_notices
       return if previously_published?
 
@@ -276,8 +276,9 @@ module StashEngine
         end
       end
       resource.update_column(:file_view, false) unless changed # if nothing changed between previous published and this, don't view same files again
+      resource.update_column(:file_view, false) unless resource.current_file_uploads.present?
     end
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     # Helper methods
     # ------------------------------------------

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -416,6 +416,7 @@ module StashEngine
           res.update_column(:file_view, false) if unchanged
           unchanged = true
         end
+        res.update_column(:file_view, false) unless res.current_file_uploads.present?
       end
     end
     # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1113

When a user mistakenly deletes all of the (data) files in a resource, the curators sometimes want to publish it anyway, but they don't want that resource to be listed as a visible version.

Note for the future: The file visibility code is incredibly similar in the `identifier` model and the `curation_activity` model. It would be good to consolidate these whenever we're doing more intensive work in this area.