### PR TITLE
Require S3 in the resource

### DIFF
--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -1,3 +1,4 @@
+require 'stash/aws/s3'
 # require 'stash/indexer/indexing_resource'
 require 'stash/indexer/solr_indexer'
 # the following is required to make our wonky tests work and may break if we move stuff around


### PR DESCRIPTION
Require the S3 library in the resource, to avoid problems like https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1145

I'm not 100% certain this is needed, since it seems to work fine when the other portions of `s3-main` are in place. Guess I need to learn more about how the Rails loading process interacts with the engines.