### PR TITLE
Prevent bad file submission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ stash/script/counter-uploader/tmp/*.json
 # JS library files from node/react
 node_modules
 public/packs
+public/packs-test
 
 # ######################################################
 

--- a/spec/models/stash_datacite/completions_spec.rb
+++ b/spec/models/stash_datacite/completions_spec.rb
@@ -181,6 +181,20 @@ module StashDatacite
             upload.save!
             expect(completions.urls_validated?).to eq(false)
           end
+
+          it 'returns false when at least one Zenodo files has an error' do
+            # good uploads for dataset
+            resource.file_uploads.newly_created.find_each do |upload|
+              upload.status_code = 200
+              upload.save!
+            end
+
+            #bad upload for zenodo
+            resource.software_uploads << create(:software_upload, status_code: 411, url: 'https://happy.clown.example.com')
+
+            @completions = Completions.new(resource) # refresh the completions object since I changed it
+            expect(completions.urls_validated?).to eq(false)
+          end
         end
 
         describe 'file uploads' do

--- a/spec/models/stash_datacite/completions_spec.rb
+++ b/spec/models/stash_datacite/completions_spec.rb
@@ -189,7 +189,7 @@ module StashDatacite
               upload.save!
             end
 
-            #bad upload for zenodo
+            # bad upload for zenodo
             resource.software_uploads << create(:software_upload, status_code: 411, url: 'https://happy.clown.example.com')
 
             @completions = Completions.new(resource) # refresh the completions object since I changed it

--- a/spec/models/stash_engine/url_validator_spec.rb
+++ b/spec/models/stash_engine/url_validator_spec.rb
@@ -124,7 +124,7 @@ module StashEngine
 
       it 'records redirects' do
         headers = instance_double(HTTP::Message::Headers)
-        allow(headers).to receive(:[]) { |arg| {'Content-Length' => 3}[arg] }
+        allow(headers).to receive(:[]) { |arg| { 'Content-Length' => 3}[arg] }
 
         response = instance_double(HTTP::Message)
         allow(response).to receive(:header).and_return(headers)

--- a/spec/models/stash_engine/url_validator_spec.rb
+++ b/spec/models/stash_engine/url_validator_spec.rb
@@ -11,11 +11,18 @@ module StashEngine
     end
 
     it 'retrieves a url' do
-      stub_request(:any, 'http://www.blahstackfood.com')
+      stub_request(:head, 'http://www.blahstackfood.com').to_return(headers: { 'Content-Length' => 3 })
       success = uv.validate
       # [ uv.mime_type, uv.size, uv.url, uv.status_code, uv.redirected_to, uv.timed_out?, uv.redirected?, uv.correctly_formatted_url? ]
       expect(success).to eq(true)
       expect(uv.status_code).to eq(200)
+    end
+
+    it 'sets a 411 for a url with no content-length' do
+      stub_request(:head, 'http://www.blahstackfood.com')
+      success = uv.validate
+      expect(success).to eq(false)
+      expect(uv.status_code).to eq(411)
     end
 
     describe :mime_type_from do
@@ -117,7 +124,7 @@ module StashEngine
 
       it 'records redirects' do
         headers = instance_double(HTTP::Message::Headers)
-        allow(headers).to receive(:[]).and_return([])
+        allow(headers).to receive(:[]) { |arg| {'Content-Length' => 3}[arg] }
 
         response = instance_double(HTTP::Message)
         allow(response).to receive(:header).and_return(headers)
@@ -163,7 +170,7 @@ module StashEngine
     describe :upload_attributes_from do
       before(:each) do
         stub_request(:head, 'http://ftp.datadryad.org/InCuration/test-sfisher/My%20cAT%20hAS%20FlEaS.jpg')
-          .to_return(status: 200, body: '', headers: {})
+          .to_return(status: 200, body: 'abc', headers: { 'Content-Length' => 3 })
       end
 
       it 'decodes and also makes prettier filenames with urlencoding' do

--- a/spec/models/stash_engine/url_validator_spec.rb
+++ b/spec/models/stash_engine/url_validator_spec.rb
@@ -124,7 +124,7 @@ module StashEngine
 
       it 'records redirects' do
         headers = instance_double(HTTP::Message::Headers)
-        allow(headers).to receive(:[]) { |arg| { 'Content-Length' => 3}[arg] }
+        allow(headers).to receive(:[]) { |arg| { 'Content-Length' => 3 }[arg] }
 
         response = instance_double(HTTP::Message)
         allow(response).to receive(:header).and_return(headers)

--- a/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
@@ -80,7 +80,7 @@ module StashDatacite
       end
 
       def urls_validated?
-        if @resource.upload_type == :manifest && @resource.file_uploads.newly_created.errors.count > 0
+        if @resource.file_uploads.newly_created.errors.count > 0 || @resource.software_uploads.newly_created.errors.count > 0
           false
         else
           true

--- a/stash/stash_engine/app/models/stash_engine/concerns/model_uploadable.rb
+++ b/stash/stash_engine/app/models/stash_engine/concerns/model_uploadable.rb
@@ -34,6 +34,8 @@ module StashEngine
           'The URL was not found.'
         when 410
           'The requested URL is no longer available.'
+        when 411
+          'The Content-Length header is required from the remote server'
         when 414
           "The server will not accept the request, because the URL #{url} is too long."
         when 408, 499

--- a/stash/stash_engine/app/models/stash_engine/url_validator.rb
+++ b/stash/stash_engine/app/models/stash_engine/url_validator.rb
@@ -2,6 +2,7 @@ require 'httpclient'
 require 'net/http'
 require 'fileutils'
 require 'cgi'
+require 'byebug'
 
 # getting cert errors, maybe https://www.engineyard.com/blog/ruby-ssl-error-certificate-verify-failed fixes it ?
 
@@ -49,7 +50,7 @@ module StashEngine
         init_from(response)
         # the follow is for google drive which doesn't respond to head requests correctly
         fix_by_get_request(redirected_to || url) if google_drive_redirect?(status_code, redirected_to)
-        return true
+        return true unless @status_code > 399
       rescue HTTPClient::TimeoutError
         @timed_out = true
         @status_code = 408
@@ -135,13 +136,13 @@ module StashEngine
     end
 
     def init_from(response)
-      @status_code = if @size == 0
+      @size = size_from(response)
+      @status_code = if @size == 0 && response.status_code < 400
                        411 # length required, which we'll require from now on
                      else
                        response.status_code
                      end
       @mime_type = mime_type_from(response)
-      @size = size_from(response)
       @redirected = !response.previous.nil?
       @redirected_to = response.previous.header['Location'].first if @redirected
       @filename = filename_from(response, @redirected_to, @url)
@@ -199,7 +200,7 @@ module StashEngine
       response = get_without_download(URI.parse(u))
       return unless response.code == '200'
       size = size_from(response)
-      @status_code = if @size == 0
+      @status_code = if size == 0 && response.status_code < 400
                        411 # length required
                      else
                        200

--- a/stash/stash_engine/app/models/stash_engine/url_validator.rb
+++ b/stash/stash_engine/app/models/stash_engine/url_validator.rb
@@ -199,6 +199,7 @@ module StashEngine
     def fix_by_get_request(u)
       response = get_without_download(URI.parse(u))
       return unless response.code == '200'
+
       size = size_from(response)
       @status_code = if size == 0 && response.status_code < 400
                        411 # length required

--- a/stash/stash_engine/app/models/stash_engine/url_validator.rb
+++ b/stash/stash_engine/app/models/stash_engine/url_validator.rb
@@ -135,7 +135,11 @@ module StashEngine
     end
 
     def init_from(response)
-      @status_code = response.status_code
+      @status_code = if @size == 0
+                       411 # length required, which we'll require from now on
+                     else
+                       response.status_code
+                     end
       @mime_type = mime_type_from(response)
       @size = size_from(response)
       @redirected = !response.previous.nil?
@@ -194,8 +198,12 @@ module StashEngine
     def fix_by_get_request(u)
       response = get_without_download(URI.parse(u))
       return unless response.code == '200'
-
-      @status_code = 200
+      size = size_from(response)
+      @status_code = if @size == 0
+                       411 # length required
+                     else
+                       200
+                     end
       @mime_type = mime_type_from(response)
       @size = size_from(response)
       @filename = filename_from(response, u, u)


### PR DESCRIPTION
This puts in code that considers Content-Length: 0 or missing to be a bad URL if the server can't give us the length up front.  This is mostly only the case for dynamic content and if people upload static files then the content length is set.

It also adds the zenodo software urls to the validator in addition to the dataset URLs.

Adds an error message for the 411 status code which we manually generate if zero-length and so it's displayed to the user as an error for these items.



