### PR TITLE
Prevent Merritt problem with empty string mimetype

### DIFF
--- a/stash/stash-wrapper/lib/stash/wrapper/stash_file.rb
+++ b/stash/stash-wrapper/lib/stash/wrapper/stash_file.rb
@@ -47,7 +47,7 @@ module Stash
       private
 
       def to_mime_type(value)
-        return nil unless value
+        return nil unless value.present?
         return value if value.is_a?(MIME::Type)
 
         mt_string = value.to_s


### PR DESCRIPTION
If the mimetype gets set to "", treat it as if it were null.