### PR TITLE
Fixes for minifying ES6 and deployment to stage/production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'therubyracer', platforms: :ruby
 gem 'turbolinks'
 
-gem 'uglifier', '~> 3.0.4'
+gem 'uglifier', '~> 4.2.0'
 gem 'yui-compressor'
 
 # ############################################################

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -819,7 +819,7 @@ GEM
     typesafe_enum (0.1.9)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    uglifier (3.0.4)
+    uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
@@ -914,7 +914,7 @@ DEPENDENCIES
   stripe
   therubyracer
   turbolinks
-  uglifier (~> 3.0.4)
+  uglifier (~> 4.2.0)
   web-console
   webdrivers
   webmock

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   config.assets.css_compressor = :yui
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   config.public_file_server.enabled = true					
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   config.assets.css_compressor = :yui
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
After trying a lot of different things (because of terrible error messages), this is what fixed the deploy problems.

The uglifier gem needed to be updated to the latest version and needed to use the `harmony: true` flag on initialization.

I hope ES6 works for most browsers.  I think one of the things used is promises https://caniuse.com/promises (show by date relative).    Seems like most browser released since 2014 support them.  Probably major security problems for people running 7 year old browsers, also.

I tried installing a transpiler for older versions and it just made the precompilation time out and get killed instead.  :-/
