### PR TITLE
Improve robustness of stats calculator (and GitHub Actions fix)

### DIFF
--- a/.github/workflows/rspec_features.yml
+++ b/.github/workflows/rspec_features.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   rspec-features:
     name: RSpec Feature Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     env:
       DB_ADAPTER: mysql2
@@ -33,13 +33,13 @@ jobs:
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
 
-    - name: 'Retrieve Cached Gems'
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gem-
+#    - name: 'Retrieve Cached Gems'
+#      uses: actions/cache@v1
+#      with:
+#        path: vendor/bundle
+#        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+#        restore-keys: |
+#          ${{ runner.os }}-gem-
 
     - name: 'Bundle Install'
       run: |

--- a/.github/workflows/rspec_features.yml
+++ b/.github/workflows/rspec_features.yml
@@ -33,13 +33,13 @@ jobs:
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
 
-#    - name: 'Retrieve Cached Gems'
-#      uses: actions/cache@v1
-#      with:
-#        path: vendor/bundle
-#        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-#        restore-keys: |
-#          ${{ runner.os }}-gem-
+    - name: 'Retrieve Cached Gems'
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gem-
 
     - name: 'Bundle Install'
       run: |

--- a/.github/workflows/rspec_features.yml
+++ b/.github/workflows/rspec_features.yml
@@ -37,9 +37,9 @@ jobs:
       uses: actions/cache@v1
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-gem-
+          ${{ runner.os }}-gems-
 
     - name: 'Bundle Install'
       run: |

--- a/.github/workflows/rspec_internal.yml
+++ b/.github/workflows/rspec_internal.yml
@@ -33,13 +33,13 @@ jobs:
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
 
-    - name: 'Retrieve Cached Gems'
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gem-
+#    - name: 'Retrieve Cached Gems'
+#      uses: actions/cache@v1
+#      with:
+#        path: vendor/bundle
+#        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+#        restore-keys: |
+#          ${{ runner.os }}-gem-
 
     - name: 'Bundle Install'
       run: |

--- a/.github/workflows/rspec_internal.yml
+++ b/.github/workflows/rspec_internal.yml
@@ -33,13 +33,13 @@ jobs:
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
 
-#    - name: 'Retrieve Cached Gems'
-#      uses: actions/cache@v1
-#      with:
-#        path: vendor/bundle
-#        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-#        restore-keys: |
-#          ${{ runner.os }}-gem-
+    - name: 'Retrieve Cached Gems'
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gem-
 
     - name: 'Bundle Install'
       run: |

--- a/.github/workflows/rspec_internal.yml
+++ b/.github/workflows/rspec_internal.yml
@@ -37,9 +37,9 @@ jobs:
       uses: actions/cache@v1
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-gem-
+          ${{ runner.os }}-gems-
 
     - name: 'Bundle Install'
       run: |

--- a/.github/workflows/rspec_internal.yml
+++ b/.github/workflows/rspec_internal.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   rspec-internal:
     name: RSpec Internal Tests
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     env:
       DB_ADAPTER: mysql2

--- a/.github/workflows/rspec_internal.yml
+++ b/.github/workflows/rspec_internal.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   rspec-internal:
     name: RSpec Internal Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
 
     env:
       DB_ADAPTER: mysql2

--- a/.github/workflows/rspec_responses.yml
+++ b/.github/workflows/rspec_responses.yml
@@ -33,13 +33,13 @@ jobs:
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
 
-#    - name: 'Retrieve Cached Gems'
-#      uses: actions/cache@v1
-#      with:
-#        path: vendor/bundle
-#        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-#        restore-keys: |
-#          ${{ runner.os }}-gem-
+    - name: 'Retrieve Cached Gems'
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gem-
 
     - name: 'Bundle Install'
       run: |

--- a/.github/workflows/rspec_responses.yml
+++ b/.github/workflows/rspec_responses.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   rspec-resonse:
     name: RSpec Response Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     env:
       DB_ADAPTER: mysql2
@@ -33,13 +33,13 @@ jobs:
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
 
-    - name: 'Retrieve Cached Gems'
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gem-
+#    - name: 'Retrieve Cached Gems'
+#      uses: actions/cache@v1
+#      with:
+#        path: vendor/bundle
+#        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+#        restore-keys: |
+#          ${{ runner.os }}-gem-
 
     - name: 'Bundle Install'
       run: |

--- a/.github/workflows/rspec_responses.yml
+++ b/.github/workflows/rspec_responses.yml
@@ -37,9 +37,9 @@ jobs:
       uses: actions/cache@v1
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-gem-
+          ${{ runner.os }}-gems-
 
     - name: 'Bundle Install'
       run: |


### PR DESCRIPTION
Add handling for crazy data that "should never happen". Guess I'll need to start using a copy of the prod database in my testing, because it always breaks even my simplest assumptions, like "all resources are attached to an identifier". Sigh.

A secondary part of this PR is to fix issues with GitHub Actions. We were using the `ubuntu-latest` tag, which caused problems when GitHub upgraded the "latest" version of Ubuntu. It is now set to Ubuntu 18.04. As a side effect, the key had to be changed for the set of cached gems, so we only load an environment that has gems with the correct Ubuntu support files.