### PR TITLE
Fixing deprecation error that just appeared on Wednesday night

### DIFF
--- a/.github/workflows/rspec_features.yml
+++ b/.github/workflows/rspec_features.yml
@@ -45,7 +45,8 @@ jobs:
       run: |
         gem install bundler -v ${{ env.BUNDLER_VERSION }}
         bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3 --without pgsql rollbar aws
+        bundle config set without 'pgsql rollbar aws'
+        bundle install --jobs 4 --retry 3
 
     - name: 'Start MySQL'
       run: sudo systemctl start mysql

--- a/.github/workflows/rspec_internal.yml
+++ b/.github/workflows/rspec_internal.yml
@@ -45,7 +45,8 @@ jobs:
       run: |
         gem install bundler -v ${{ env.BUNDLER_VERSION }}
         bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3 --without pgsql rollbar aws
+        bundle config set without 'pgsql rollbar aws'
+        bundle install --jobs 4 --retry 3
 
     - name: 'Start MySQL'
       run: sudo systemctl start mysql

--- a/.github/workflows/rspec_responses.yml
+++ b/.github/workflows/rspec_responses.yml
@@ -45,7 +45,8 @@ jobs:
       run: |
         gem install bundler -v ${{ env.BUNDLER_VERSION }}
         bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3 --without pgsql rollbar aws
+        bundle config set without 'pgsql rollbar aws'
+        bundle install --jobs 4 --retry 3
 
     - name: 'Start MySQL'
       run: sudo systemctl start mysql

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -32,7 +32,8 @@ jobs:
       run: |
         gem install bundler -v ${{ env.BUNDLER_VERSION }}
         bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3 --without pgsql rollbar aws
+        bundle config set without 'pgsql rollbar aws'
+        bundle install --jobs 4 --retry 3
 
     - name: 'Run Rubocop'
       run: bin/rubocop


### PR DESCRIPTION
Something changed to from a deprecation warning to an error in our tests on Wednesday night with bundler on github actions.  Now all tests fail because of the change.

I'm doing a PR so we can get test working again and accept pull requests again.