### PR TITLE
Workaround for Merritt for another character that requires double-encoding

### DIFF
--- a/spec/models/stash_engine/file_upload_spec.rb
+++ b/spec/models/stash_engine/file_upload_spec.rb
@@ -240,10 +240,17 @@ module StashEngine
         )
       end
 
-      it 'doubly-encodes any # signs in filenames because otherwise they prematurely cut off in Merritt' do
+      it "doubly-encodes any # signs in filenames because otherwise they work in Merritt with standard encoding" do
         @upload.upload_file_name = '#1 in the world'
         expect(@upload.merritt_presign_info_url).to eq(
           'https://merritt.example.com/api/presign-file/ark%3A%2F12345%2F38568/1/producer%2F%25231%20in%20the%20world?no_redirect=true'
+        )
+      end
+
+      it "doubly-encodes any % signs in the filenames because Merritt doesn't accept this in a standards-compliant encoding" do
+        @upload.upload_file_name = 'my%fun-r-file.r'
+        expect(@upload.merritt_presign_info_url).to eq(
+          'https://merritt.example.com/api/presign-file/ark%3A%2F12345%2F38568/1/producer%2Fmy%2525fun-r-file.r?no_redirect=true'
         )
       end
     end

--- a/stash/stash_engine/app/models/stash_engine/file_upload.rb
+++ b/stash/stash_engine/app/models/stash_engine/file_upload.rb
@@ -50,12 +50,13 @@ module StashEngine
     def merritt_presign_info_url
       raise 'Filename may not be blank when creating presigned URL' if upload_file_name.blank?
 
-      # The gsub below ensures and number signs get double-encoded because otherwise Merritt cuts them off early.
-      # We can remove the workaround if it changes in Merritt at some point in the future.
+      # The gsub below ensures and some special characters get double-encoded because otherwise Merritt doesn't work
+      # since it requires double encoding for some characters.  The gsub(//){|i| ..} part takes the list or characters
+      # to encode once before they get encoded again
 
       domain, local_id = resource.merritt_protodomain_and_local_id
       "#{domain}/api/presign-file/#{local_id}/#{resource.stash_version.merritt_version}/" \
-          "producer%2F#{ERB::Util.url_encode(upload_file_name.gsub('#', '%23'))}?no_redirect=true"
+          "producer%2F#{ERB::Util.url_encode(upload_file_name.gsub(/[#%]/){|i| ERB::Util.url_encode(i)})}?no_redirect=true"
     end
 
     # this will do the http request to Merritt to get the presigned URL, putting here instead of other classes since it gets


### PR DESCRIPTION
Can't create presigned URLs for zenodo uploads for items that have a percent symbol in the filename without double-encoding in Merritt.

Putting in another workaround since we already have one for the `#` sign.

When Merritt corrects these issues then we will have to remove our workarounds to revert to standard W3C practices for URL encoding.