### PR TITLE
Add delayed_job for supplemental info

### DIFF
--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -141,6 +141,7 @@ namespace :dev_ops do
     puts 'Re-enqueuing Zenodo replication jobs that were deferred'
     StashEngine::ZenodoCopyJob.enqueue_deferred
     StashEngine::ZenodoSoftwareJob.enqueue_deferred
+    StashEngine::ZenodoSuppJob.enqueue_deferred
   end
 
   desc 'Gets Counter token for submitting a report'

--- a/spec/features/stash_datacite/review_dataset_spec.rb
+++ b/spec/features/stash_datacite/review_dataset_spec.rb
@@ -1,3 +1,6 @@
+
+
+
 require 'rails_helper'
 require 'pry-remote'
 

--- a/spec/features/stash_datacite/review_dataset_spec.rb
+++ b/spec/features/stash_datacite/review_dataset_spec.rb
@@ -1,6 +1,3 @@
-
-
-
 require 'rails_helper'
 require 'pry-remote'
 

--- a/spec/jobs/stash_engine/zenodo_supp_job_spec.rb
+++ b/spec/jobs/stash_engine/zenodo_supp_job_spec.rb
@@ -1,0 +1,65 @@
+require 'byebug'
+
+require 'rails_helper'
+require 'fileutils'
+
+RSpec.configure(&:infer_spec_type_from_file_location!)
+
+module StashEngine
+  RSpec.describe ZenodoSuppJob do
+
+    before(:each) do
+      @resource = create(:resource)
+      @new_zen = double('newZenodo')
+      allow(Stash::ZenodoSoftware::Copier).to receive(:new).and_return(@new_zen)
+    end
+
+    describe '#perform' do
+
+      it 'calls to add to zenodo' do
+        zc = create(:zenodo_copy, state: 'enqueued', copy_type: 'supp', identifier_id: @resource.identifier_id, resource_id: @resource.id)
+        expect(@new_zen).to receive(:add_to_zenodo)
+        zsj = ZenodoSuppJob.new
+        zsj.perform(zc.id)
+      end
+    end
+
+    describe 'self.should_defer?(resource:)' do
+      before(:each) do
+        FileUtils.rm(ZenodoCopyJob::DEFERRED_TOUCH_FILE) if File.exist?(ZenodoCopyJob::DEFERRED_TOUCH_FILE)
+        @zsj = ZenodoSuppJob.new
+        @zc = create(:zenodo_copy, state: 'enqueued', copy_type: 'supp', identifier_id: @resource.identifier_id, resource_id: @resource.id)
+        @zsj.job_entry = @zc
+      end
+
+      it 'returns true and sets deferred if defer file exists' do
+        FileUtils.touch(ZenodoCopyJob::DEFERRED_TOUCH_FILE)
+        expect(@zsj.should_defer?).to eq(true)
+        expect(@zc.state).to eq('deferred')
+        FileUtils.rm(ZenodoCopyJob::DEFERRED_TOUCH_FILE)
+      end
+
+      it "returns false and doesn't defer if defer file doesn't exist" do
+        expect(@zsj.should_defer?).to eq(false)
+        expect(@zc.state).to eq('enqueued')
+      end
+    end
+
+    describe 'self.enqueue_deferred' do
+      include ActiveJob::TestHelper
+
+      it 're-enqueues the deferred items' do
+        zc = create(:zenodo_copy, state: 'deferred', copy_type: 'supp', identifier_id: @resource.identifier_id, resource_id: @resource.id)
+        ZenodoSuppJob.enqueue_deferred
+        @resource.reload
+        expect(@resource.zenodo_copies.supp.first.state).to eq('enqueued')
+        expect(enqueued_jobs).to eq([{ job: StashEngine::ZenodoSuppJob, args: [zc.id], queue: 'zenodo_supp' }])
+      end
+
+      after(:each) do
+        clear_enqueued_jobs
+      end
+    end
+
+  end
+end

--- a/spec/models/stash_engine/curation_activity_spec.rb
+++ b/spec/models/stash_engine/curation_activity_spec.rb
@@ -160,9 +160,10 @@ module StashEngine
         @curation_activity = create(:curation_activity, resource: @resource)
       end
 
-      it 'calls both zenodo methods to copy software and data (3rd copy)' do
+      it 'calls three zenodo methods to copy software, supplemental and data (3rd copy)' do
         expect(@resource).to receive(:send_to_zenodo).and_return('test1')
         expect(@resource).to receive(:send_software_to_zenodo).with(publish: true).and_return('test2')
+        expect(@resource).to receive(:send_supp_to_zenodo).with(publish: true).and_return('test3')
         @curation_activity.copy_to_zenodo
       end
     end

--- a/spec/models/stash_engine/identifier_spec.rb
+++ b/spec/models/stash_engine/identifier_spec.rb
@@ -933,5 +933,25 @@ module StashEngine
         expect(@identifier.has_zenodo_software?).to eq(false)
       end
     end
+
+    describe '#has_zenodo_supp' do
+      before(:each) do
+        @supp_file = SuppFile.create(upload_file_name: 'test', file_state: 'created')
+      end
+
+      it 'correctly detects current zenodo supplemental' do
+        @res3.supp_files << @supp_file
+        expect(@identifier.has_zenodo_supp?).to eq(true)
+      end
+
+      it 'correctly detects former zenodo supplemental' do
+        @res1.supp_files << @supp_file
+        expect(@identifier.has_zenodo_supp?).to eq(true)
+      end
+
+      it 'correctly detects no zenodo supplemental' do
+        expect(@identifier.has_zenodo_supp?).to eq(false)
+      end
+    end
   end
 end

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -61,6 +61,23 @@ module StashEngine
       end
     end
 
+    describe :send_supp_to_zenodo do
+      before(:each) do
+        @resource = create(:resource, identifier: create(:identifier))
+        @identifier = @resource.identifier
+        @resource.supp_files << create(:supp_file)
+      end
+
+      it 'sends the supplemental to zenodo' do
+        expect(@identifier).to receive(:'has_zenodo_supp?').and_call_original
+        expect(StashEngine::ZenodoSuppJob).to receive(:perform_later)
+        @resource.send_supp_to_zenodo
+        copy_record = @resource.zenodo_copies.supp.first
+        expect(copy_record.resource_id).to eq(@resource.id)
+        expect(copy_record.state).to eq('enqueued')
+      end
+    end
+
     describe :s3_dir_name do
 
       before(:each) do

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -361,6 +361,7 @@ module StashApi
       check_patch_prerequisites { yield }
       check_dataset_completions { yield }
       @resource.send_software_to_zenodo # this only does anything if software needs to be sent (new sfw or sfw in the past)
+      @resource.send_supp_to_zenodo
 
       case @json.first['path']
       when '/versionStatus'

--- a/stash/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
@@ -72,6 +72,7 @@ module StashDatacite
       resource.reload
 
       resource.send_software_to_zenodo # this only does anything if software needs to be sent (new sfw or sfw in the past)
+      resource.send_supp_to_zenodo
 
       # There is a return URL for a simple case and backwards compatibility (only for for whole user and for journals).
       # There is also one for curators and need to return back to different pages/filter setting for each dataset they

--- a/stash/stash_engine/app/jobs/stash_engine/zenodo_supp_job.rb
+++ b/stash/stash_engine/app/jobs/stash_engine/zenodo_supp_job.rb
@@ -1,0 +1,34 @@
+require 'stash/zenodo_software'
+
+module StashEngine
+  class ZenodoSuppJob < ::ActiveJob::Base
+    queue_as :zenodo_supp
+
+    attr_accessor :job_entry
+
+    # unlike the zenodo_copy_job, this one takes a ZenodoCopy.id instead of a resource_id since it needs a little more info
+    # and may do multiple actions on the same resource (such as sending and then publishing the same resource)
+    def perform(*args)
+      @job_entry = StashEngine::ZenodoCopy.where(id: args[0]).first
+      return if @job_entry.nil? || should_defer?
+
+      zr = Stash::ZenodoSoftware::Copier.new(copy_id: @job_entry.id, dataset_type: :supp)
+      zr.add_to_zenodo
+    end
+
+    def should_defer?
+      if File.exist?(ZenodoCopyJob::DEFERRED_TOUCH_FILE) # use same touch file for both software and replication for Zenodo
+        @job_entry.update(state: 'deferred')
+        return true
+      end
+      false
+    end
+
+    def self.enqueue_deferred
+      StashEngine::ZenodoCopy.supp.where(state: 'deferred').each do |zc|
+        zc.update(state: 'enqueued')
+        perform_later(zc.id)
+      end
+    end
+  end
+end

--- a/stash/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -183,6 +183,7 @@ module StashEngine
     def copy_to_zenodo
       resource.send_to_zenodo
       resource.send_software_to_zenodo(publish: true)
+      resource.send_supp_to_zenodo(publish: true)
     end
 
     def remove_peer_review

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -430,6 +430,10 @@ module StashEngine
     def has_zenodo_software?
       SoftwareFile.joins(:resource).where(stash_engine_resources: { identifier_id: id }).count.positive?
     end
+
+    def has_zenodo_supp?
+      SuppFile.joins(:resource).where(stash_engine_resources: { identifier_id: id }).count.positive?
+    end
     # rubocop:enable Naming/PredicateName
 
     # gets the resources which are in zenodo and have viewable files for the context, used by the landing page.


### PR DESCRIPTION
This is treated the same way as software for delayed_job and so certain events can trigger supplemental (submitting, publishing) just like software.

Added tests for it like the tests software has.

This makes it ready to work once supplemental files show up and are uploaded to work on.

We don't have a really easy way to add and test manually yet until we dont have the UI to add supplemental files.