### PR TITLE
Verify any files that are supposed to be present on S3 are available before submission

### DIFF
--- a/spec/models/stash_datacite/completions_spec.rb
+++ b/spec/models/stash_datacite/completions_spec.rb
@@ -533,6 +533,7 @@ module StashDatacite
 
         before(:each) do
           expect(completions.required_completed).to eq(REQUIRED_COUNT) # just to be sure
+          @resource.generic_files.each { |f| f.update(url: 'http://example.com') }
         end
 
         it 'warns on missing title' do

--- a/spec/models/stash_datacite/completions_spec.rb
+++ b/spec/models/stash_datacite/completions_spec.rb
@@ -182,7 +182,7 @@ module StashDatacite
             expect(completions.urls_validated?).to eq(false)
           end
 
-          it 'returns false when at least one Zenodo files has an error' do
+          it 'returns false when at least one Zenodo file has an error' do
             # good uploads for dataset
             resource.data_files.newly_created.find_each do |upload|
               upload.status_code = 200
@@ -201,6 +201,32 @@ module StashDatacite
           it 'returns true for non-manifest uploads' do
             expect(completions.urls_validated?).to eq(true)
           end
+        end
+      end
+
+      describe :s3_error_uploads do
+
+        it 'verifies uploads to s3 are present' do
+          @resource.generic_files.map(&:calc_s3_path).each do |s3_path|
+            allow(Stash::Aws::S3).to receive('exists?').with(s3_key: s3_path).and_return(true)
+          end
+          expect(completions.s3_error_uploads).to eq([])
+        end
+
+        it 'returns missing files when files uploaded to s3 are not present' do
+          @resource.generic_files.map(&:calc_s3_path).each do |s3_path|
+            allow(Stash::Aws::S3).to receive('exists?').with(s3_key: s3_path).and_return(false)
+          end
+          expect(completions.s3_error_uploads).to eq(@resource.generic_files.map(&:upload_file_name))
+        end
+
+        it 'only checks files that are new uploads and are not urls' do
+          @resource.generic_files.first.update(file_state: 'copied')
+          @resource.generic_files.second.update(url: 'http://example.com')
+          @resource.generic_files.map(&:calc_s3_path).each do |s3_path|
+            allow(Stash::Aws::S3).to receive('exists?').with(s3_key: s3_path).and_return(false)
+          end
+          expect(completions.s3_error_uploads).to eq([@resource.generic_files.last.upload_file_name])
         end
       end
 

--- a/spec/responses/stash_datacite/resources_controller_spec.rb
+++ b/spec/responses/stash_datacite/resources_controller_spec.rb
@@ -19,7 +19,7 @@ module StashDatacite
 
       # below will create @identifier, @resource, @user and the basic required things for an initial version of a dataset
       create_basic_dataset! # makes @user, @identifier, @resource with file uploads
-      @resource.generic_files.each { |f| f.update(url: 'http://example.com')} # bypasses S3 file validation by using URL instead
+      @resource.generic_files.each { |f| f.update(url: 'http://example.com') } # bypasses S3 file validation by using URL instead
 
       # HACK: in session because requests specs don't allow session in rails unless you want to request the full login nightmare first
       # https://github.com/rails/rails/issues/23386#issuecomment-178013357

--- a/spec/responses/stash_datacite/resources_controller_spec.rb
+++ b/spec/responses/stash_datacite/resources_controller_spec.rb
@@ -19,6 +19,7 @@ module StashDatacite
 
       # below will create @identifier, @resource, @user and the basic required things for an initial version of a dataset
       create_basic_dataset! # makes @user, @identifier, @resource with file uploads
+      @resource.generic_files.each { |f| f.update(url: 'http://example.com')} # bypasses S3 file validation by using URL instead
 
       # HACK: in session because requests specs don't allow session in rails unless you want to request the full login nightmare first
       # https://github.com/rails/rails/issues/23386#issuecomment-178013357
@@ -34,7 +35,9 @@ module StashDatacite
       it 'shows files for Merritt' do
         @upload = create(:data_file,
                          resource: @resource,
-                         file_state: 'created')
+                         file_state: 'created',
+                         url: 'http://example.com',
+                         status_code: 200)
 
         get StashDatacite::Engine.routes.url_helpers.resources_review_path(id: @resource.id, format: 'js'), xhr: true
         expect(response.body).to include(@upload.upload_file_name)
@@ -43,7 +46,9 @@ module StashDatacite
       it 'outputs files for Zenodo' do
         @upload = create(:software_file,
                          resource: @resource,
-                         file_state: 'created')
+                         file_state: 'created',
+                         url: 'http://example.com',
+                         status_code: 200)
 
         get StashDatacite::Engine.routes.url_helpers.resources_review_path(id: @resource.id, format: 'js'), xhr: true
         expect(response.body).to include(@upload.upload_file_name)

--- a/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'stash/aws/s3'
 
 # basing this structure on that suggested in http://vrybas.github.io/blog/2014/08/15/a-way-to-organize-poros-in-rails/
@@ -190,8 +191,8 @@ module StashDatacite
         messages << 'Authors must have affiliations' unless author_affiliation
         messages << 'Fix or remove upload URLs that were unable to validate' unless urls_validated?
         if error_uploads.present?
-          messages << "Some files can not be submitted because they may have had errors uploading. " \
-            "Please re-upload the following files if you still see this error in a few minutes."
+          messages << 'Some files can not be submitted because they may have had errors uploading. ' \
+            'Please re-upload the following files if you still see this error in a few minutes.'
           messages << "Files with upload errors: #{error_uploads.join(',')}"
         end
 

--- a/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'stash/aws/s3'
 
 # basing this structure on that suggested in http://vrybas.github.io/blog/2014/08/15/a-way-to-organize-poros-in-rails/
 
@@ -87,6 +88,15 @@ module StashDatacite
         end
       end
 
+      def s3_error_uploads
+        files = @resource.generic_files.newly_created.file_submission
+        errored_uploads = []
+        files.each do |f|
+          errored_uploads.push(f.upload_file_name) unless Stash::Aws::S3.exists?(s3_key: f.calc_s3_path)
+        end
+        errored_uploads
+      end
+
       def over_manifest_file_size?(size_limit)
         @resource.data_files.present_files.sum(:upload_file_size) > size_limit
       end
@@ -171,6 +181,7 @@ module StashDatacite
 
       def all_warnings
         messages = []
+        error_uploads = s3_error_uploads
         messages << 'Add a dataset title' unless title
         messages << 'Add an abstract' unless abstract
         messages << 'For data related to a journal article, you must supply a manuscript number or DOI' unless article_id
@@ -178,6 +189,12 @@ module StashDatacite
         messages << 'The first author must have an email supplied' unless author_email
         messages << 'Authors must have affiliations' unless author_affiliation
         messages << 'Fix or remove upload URLs that were unable to validate' unless urls_validated?
+        if error_uploads.present?
+          messages << "Some files can not be submitted because they may have had errors uploading. " \
+            "Please re-upload the following files if you still see this error in a few minutes."
+          messages << "Files with upload errors: #{error_uploads.join(',')}"
+        end
+
         # do not require strict related works identifier checking right now
         # messages << 'At least one of your Related Works DOIs are not formatted correctly' unless good_related_works_formatting?
         # messages << 'At least one of your Related Works DOIs did not validate from https://doi.org' unless good_related_works_validation?

--- a/stash/stash_engine/app/views/stash_engine/data_files/_evaporate.js.erb
+++ b/stash/stash_engine/app/views/stash_engine/data_files/_evaporate.js.erb
@@ -91,6 +91,8 @@ function evaporateIt(key, complexFileObj) {
             allDone.resolve();
           },
           error: result => {
+            var myObj = JSON.parse(result.responseText)
+            console.log(myObj["msg"]);
             allDone.reject();
           },
           dataType: 'json'

--- a/stash/stash_engine/app/views/stash_engine/data_files/_preview_to_page.js.erb
+++ b/stash/stash_engine/app/views/stash_engine/data_files/_preview_to_page.js.erb
@@ -70,8 +70,14 @@ $("#upload_bg").on("drop", function(event) {
   event.preventDefault();
   event.stopPropagation();
   stageToPage(event.originalEvent.dataTransfer.files);
+  // remove upload messages from last try
+  $('#upload_message').removeClass();
+  $('#upload_message').hide();
 });
 
 $("#upload_upload").on("change", function(event) {
   stageToPage(event.target.files);
+  // remove upload messages from last try
+  $('#upload_message').removeClass();
+  $('#upload_message').hide();
 });

--- a/stash/stash_engine/app/views/stash_engine/data_files/_s3_upload.js.erb
+++ b/stash/stash_engine/app/views/stash_engine/data_files/_s3_upload.js.erb
@@ -19,7 +19,7 @@ function uploadListToS3() {
     sequence = sequence.then(function() {
       return evaporateIt(k, v);
     }).catch(function() {
-      failArr.push(k["sanitized"]);
+      failArr.push(v["sanitized"]);
     });
   })
 
@@ -41,7 +41,7 @@ function uploadListToS3() {
     }else{
       $('#upload_message').removeClass();
       $('#upload_message').addClass('c-upload__upload-error-text');
-      $('#upload_message').html(`<p>The following files had problems uploading, please upload them again:<br/>${failArr.join(", ")}</p>`);
+      $('#upload_message').html(`<p>The following files had errors while uploading, please upload them again:<br/>${failArr.join(", ")}</p>`);
       $('#upload_message').show();
     }
     failArr = [];


### PR DESCRIPTION
We had 3 cases over the past few weeks or a month where files uploaded and written to our DB were missing from S3 after submission.  I suspect this may be an upload or other issue from Evaporate.js or Amazon, even though Evaporate.js triggered the callback that marks a file complete and writes it into our database.

It could also be that the assembly of one file from many parts at S3 failed.  Two of the files were large ones ( > 10GB ) and one was some random small file.  Non-present files make Merritt submissions fail and then we have to tell users "Sorry, upload again or use the FTP server."  Lots of variables here with the user's browser and connection, so IDK what goes wrong and can't reproduce it.  I don't believe it's because files are being deleted that shouldn't be since I looked over all that code carefully.

Anyway. This adds a validation that all files that should be on S3 actually exist on the review page before allowing submission.  It tells them to re-upload a file (if the problem persists past a few minutes).

You can manually test the error by uploading some files to S3 and then going into the S3 UI, finding a file or two that you just uploaded and either rename or delete in S3.  Then go to the review page and it will show you the error.

PS.  I originally tried doing the validation immediately after each upload completion, but that triggered a race condition where the file didn't exist on S3 yet since it takes some amount of time for the parts to assemble into a full file, even though Evaporate notifies it as complete.  The race condition only notifies on larger files since small files assemble almost instantly.  I'm hoping delaying this error to the review page will be sufficient time.  I'll try with a 10GB+ file on the dev server.

