### PR TITLE
Adding experimental Counter CoP tracking on production

### DIFF
--- a/stash/stash_engine/app/views/layouts/stash_engine/application.html.erb
+++ b/stash/stash_engine/app/views/layouts/stash_engine/application.html.erb
@@ -21,6 +21,11 @@
 
   <%= render 'layouts/stash_engine/google_analytics' %>
 
+  <% if Rails.env == 'production' %>
+    <!-- for experimental tracking of Counter Code of Practice stats on production -->
+    <script async defer data-domain="datadryad.org" src="https://plausible.io/js/plausible.js"></script>
+  <% end %>
+
   <%= csrf_meta_tags %>
 
   <%= favicon_link_tag 'favicon.ico' %>


### PR DESCRIPTION
This just allow Counter CoP stats tracking from the service DataCite is developing.