### PR TITLE
Adding method to list objects for convenience

### DIFF
--- a/spec/lib/stash/aws/s3_spec.rb
+++ b/spec/lib/stash/aws/s3_spec.rb
@@ -25,6 +25,14 @@ module Stash
         end
       end
 
+      describe '#objects' do
+        it 'calls s3 to get list of objects' do
+          # Basic test that the bucket receives an objects message. "send" bypasses it being a private method, so can test
+          expect(Stash::Aws::S3.send(:s3_bucket)).to receive(:objects).with(prefix: '12xu')
+          Stash::Aws::S3.objects(starts_with: '12xu')
+        end
+      end
+
     end
   end
 end

--- a/stash/stash_engine/lib/stash/aws/s3.rb
+++ b/stash/stash_engine/lib/stash/aws/s3.rb
@@ -65,6 +65,12 @@ module Stash
         s3_bucket.objects(prefix: "#{s3_key}/").batch_delete!
       end
 
+      def self.objects(starts_with:)
+        return unless starts_with
+
+        s3_bucket.objects(prefix: starts_with)
+      end
+
       class << self
         private
 


### PR DESCRIPTION
Hi Cassiano,

This will help you list what is in a version (resource).

Example in rails console.  You'd just want to replace the resource_id with yours (based on URL at top).

This shows the key name and size for each of them, but you could return whatever you like.

```
require 'stash/aws/s3'
resource = StashEngine::Resource.find(3381)
prefix = resource.s3_dir_name(type: 'base')
Stash::Aws::S3.objects(starts_with: prefix).map{|i| [i.key, i.size]}
```

If you want the full info for a single object you could do this instead and it shows you the fields for a single object. (you could change the map above to return the fields you wanted.)
```
require 'stash/aws/s3'
resource = StashEngine::Resource.find(3381)
prefix = resource.s3_dir_name(type: 'base')
Stash::Aws::S3.objects(starts_with: prefix).first
```