### PR TITLE
Quick one-off task for checking DataONE collection to see what items download

### DIFF
--- a/.github/workflows/rspec_features.yml
+++ b/.github/workflows/rspec_features.yml
@@ -29,12 +29,12 @@ jobs:
         echo "BUNDLER_VERSION=`cat ./Gemfile.lock | grep -A 1 'BUNDLED WITH' | grep -oE '[0-9]\.[0-9]'`" >> $GITHUB_ENV
 
     - name: 'Install Ruby'
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1.68.0
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
 
     - name: 'Retrieve Cached Gems'
-      uses: actions/cache@v1
+      uses: actions/cache@v2.1.5
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/rspec_internal.yml
+++ b/.github/workflows/rspec_internal.yml
@@ -29,12 +29,12 @@ jobs:
         echo "BUNDLER_VERSION=`cat ./Gemfile.lock | grep -A 1 'BUNDLED WITH' | grep -oE '[0-9]\.[0-9]'`" >> $GITHUB_ENV
 
     - name: 'Install Ruby'
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1.68.0
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
 
     - name: 'Retrieve Cached Gems'
-      uses: actions/cache@v1
+      uses: actions/cache@v2.1.5
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/rspec_responses.yml
+++ b/.github/workflows/rspec_responses.yml
@@ -29,12 +29,12 @@ jobs:
         echo "BUNDLER_VERSION=`cat ./Gemfile.lock | grep -A 1 'BUNDLED WITH' | grep -oE '[0-9]\.[0-9]'`" >> $GITHUB_ENV
 
     - name: 'Install Ruby'
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1.68.0
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
 
     - name: 'Retrieve Cached Gems'
-      uses: actions/cache@v1
+      uses: actions/cache@v2.1.5
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -16,12 +16,12 @@ jobs:
 
     # Install Ruby - using the version found in the Gemfile.lock
     - name: 'Install Ruby'
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1.68.0
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
 
     - name: 'Retrieve Cached Gems'
-      uses: actions/cache@v1
+      uses: actions/cache@v2.1.5
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}

--- a/dataone.csv
+++ b/dataone.csv
@@ -1,0 +1,445 @@
+doi,resource,file,dl_uri,error
+10.15146/R3C300,30757,teste.docx,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5dg1n6v,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5dg1n6v/3/producer%2Fteste.docx?no_redirect=true
+Http status code: 401"
+10.15146/R3GW2M,30758,resumos_FEBRACE_-_trecho.odt,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm50c9rrj,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm50c9rrj/2/producer%2Fresumos_FEBRACE_-_trecho.odt?no_redirect=true
+Http status code: 401"
+10.15146/R3MK5W,30759,Raw_Dataset.csv,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5kx0c3v,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5kx0c3v/2/producer%2FRaw_Dataset.csv?no_redirect=true
+Http status code: 401"
+10.15146/R30W28,30760,DataSetQuestionCSV.csv,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5j72cwq,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5j72cwq/2/producer%2FDataSetQuestionCSV.csv?no_redirect=true
+Http status code: 401"
+10.15146/R34K5J,30762,Aves_com_m?dia_-_WikiAves_Brasil_-_P?gina1.csv,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5z36vrk,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5z36vrk/3/producer%2FAves_com_m%3Fdia_-_WikiAves_Brasil_-_P%3Fgina1.csv?no_redirect=true
+Http status code: 401"
+10.15146/R38C7G,30763,Reclama??es_do_consumidor_-_Jan2015.csv,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5n063hh,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5n063hh/2/producer%2FReclama%3F%3Fes_do_consumidor_-_Jan2015.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3D309,30764,ptu_data_may_2013-ptu_data_may_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5dc2xv1,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5dc2xv1/2/producer%2Fptu_data_may_2013-ptu_data_may_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3HS38,30765,ZeroOrder.dat,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5mw7d5s,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5mw7d5s/3/producer%2FZeroOrder.dat?no_redirect=true
+Http status code: 401"
+10.15146/R3NK56,30766,yellow_fever_24-09-2016.txt,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5vj0jt1,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5vj0jt1/2/producer%2Fyellow_fever_24-09-2016.txt?no_redirect=true
+Http status code: 401"
+10.15146/R3T88S,30767,pcs_5031_baseadult.csv,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5bg7k1f,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5bg7k1f/5/producer%2Fpcs_5031_baseadult.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3X30Z,30769,Bartomeus_Ntw_nceas.txt,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5421t2h,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5421t2h/2/producer%2FBartomeus_Ntw_nceas.txt?no_redirect=true
+Http status code: 401"
+10.15146/R31S3X,30770,Data_set_Mauricio.csv,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm50912b5,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm50912b5/2/producer%2FData_set_Mauricio.csv?no_redirect=true
+Http status code: 401"
+10.15146/R39884,30771,Praticagem.xlsx,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5p034nw,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5p034nw/2/producer%2FPraticagem.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R3F30M,30772,Movimentacao_navios.xlsx,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm57m54zv,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm57m54zv/2/producer%2FMovimentacao_navios.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R3PK5H,30773,PIBMunicipal_2010_2013.xls,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm57x185s,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm57x185s/2/producer%2FPIBMunicipal_2010_2013.xls?no_redirect=true
+Http status code: 401"
+10.15146/R32S37,30774,CarParameters.tsv,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5m66g94,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5m66g94/2/producer%2FCarParameters.tsv?no_redirect=true
+Http status code: 401"
+10.15146/R3QG65,30776,resistance_analysis.sas7bdat,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5rj9fjp,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5rj9fjp/2/producer%2Fresistance_analysis.sas7bdat?no_redirect=true
+Http status code: 401"
+10.15146/R3V883,30778,VariableDescriptions.docx,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5qp13r8,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5qp13r8/2/producer%2FVariableDescriptions.docx?no_redirect=true
+Http status code: 401"
+10.15146/R3RG6G,30779,A_Zebrafish_Model_for_Studies_on_Esophageal_Epithelial_Biology.PDF,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm52v7c4m,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm52v7c4m/2/producer%2FA_Zebrafish_Model_for_Studies_on_Esophageal_Epithelial_Biology.PDF?no_redirect=true
+Http status code: 401"
+10.15146/R31017,30780,paper.pdf,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm53v4d63,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm53v4d63/2/producer%2Fpaper.pdf?no_redirect=true
+Http status code: 401"
+10.15146/R34S3V,30781,Zinc-deficiency-induces-apoptosis-via-mitochondrial-p53-and-caspase-dependent-pathways-in-human-neuronal-precursor-cells_2015_Journal-of-Trace-Element__1_.pdf,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5353gcw,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5353gcw/2/producer%2FZinc-deficiency-induces-apoptosis-via-mitochondrial-p53-and-caspase-dependent-pathways-in-human-neuronal-precursor-cells_2015_Journal-of-Trace-Element__1_.pdf?no_redirect=true
+Http status code: 401"
+10.15146/R3D59D,30782,LC0211.txt,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5g789q9,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5g789q9/2/producer%2FLC0211.txt?no_redirect=true
+Http status code: 401"
+10.15146/R3NP4V,30783,spec.rtf,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5rr6v63,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5rr6v63/3/producer%2Fspec.rtf?no_redirect=true
+Http status code: 401"
+10.15146/R3201J,30784,Britten_et_al_2016.zip,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm53r5pzm,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm53r5pzm/2/producer%2FBritten_et_al_2016.zip?no_redirect=true
+Http status code: 401"
+10.15146/R39G6F,30785,Academic_Libraries_RDSFollow_Up_2014.xlsx,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5wm69d1,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5wm69d1/3/producer%2FAcademic_Libraries_RDSFollow_Up_2014.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R3PP45,30787,readme.txt,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm58q0whk,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm58q0whk/4/producer%2Freadme.txt?no_redirect=true
+Http status code: 401"
+10.15146/R3TG63,30788,ds_dataone.xlsx,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5m092dk,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5m092dk/4/producer%2Fds_dataone.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R36P4T,30789,survey_Q11-23_sensors_platforms.R,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm55x75x2,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm55x75x2/3/producer%2Fsurvey_Q11-23_sensors_platforms.R?no_redirect=true
+Http status code: 401"
+10.15146/R3G591,30790,Thesis_title_and_abstract_v5.docx,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5q005v5,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5q005v5/3/producer%2FThesis_title_and_abstract_v5.docx?no_redirect=true
+Http status code: 401"
+10.15146/R3KW2J,30791,SICO2_FL_Aboveground_C_N_and_15N.csv,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5xh4n60,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5xh4n60/3/producer%2FSICO2_FL_Aboveground_C_N_and_15N.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3059P,30792,Lai_AGU2013.pdf,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5qz76z7,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5qz76z7/2/producer%2FLai_AGU2013.pdf?no_redirect=true
+Http status code: 401"
+10.15146/R33W26,30794,WVIA_WindRiver_2012_CTLai.xlsx,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5033njk,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5033njk/2/producer%2FWVIA_WindRiver_2012_CTLai.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R3CC7D,30795,Ale_Ebrahim-2015.pdf,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5cc5wr3,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5cc5wr3/2/producer%2FAle_Ebrahim-2015.pdf?no_redirect=true
+Http status code: 401"
+10.15146/R3MW2V,30796,Part-Shelflist.xlsx,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5wb0662,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5wb0662/2/producer%2FPart-Shelflist.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R3RP4S,30797,10kV.JPG,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm56x471d,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm56x471d/2/producer%2F10kV.JPG?no_redirect=true
+Http status code: 401"
+10.15146/R3B011,30798,rainhail_data_april_2013-rainhail_data_april_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1416v1p,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1416v1p/3/producer%2Frainhail_data_april_2013-rainhail_data_april_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R33K57,30799,File-metadata.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1f769jn,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1f769jn/6/producer%2FFile-metadata.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3S012,30800,rainhail_data_april_2013-rainhail_data_april_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1p26w2v,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1p26w2v/3/producer%2Frainhail_data_april_2013-rainhail_data_april_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R35C7J,30801,wind_data_january_2013-wind_data_january_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq18p5xgr,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq18p5xgr/3/producer%2Fwind_data_january_2013-wind_data_january_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3GP49,30803,rainhail_data_january_2013-rainhail_data_january_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1zc80t9,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1zc80t9/3/producer%2Frainhail_data_january_2013-rainhail_data_january_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3HC7N,30804,PLoS_dodder_Shahla_Farzan-Sheet1.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1v122q4,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1v122q4/5/producer%2FPLoS_dodder_Shahla_Farzan-Sheet1.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3C01B,30805,ptu_data_december_2013-ptu_data_december_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1348h9m,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1348h9m/3/producer%2Fptu_data_december_2013-ptu_data_december_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3D01N,30806,rainhail_data_july_2013-rainhail_data_july_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1251g5s,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1251g5s/3/producer%2Frainhail_data_july_2013-rainhail_data_july_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3BS3Q,30807,ptu_data_september_2013-ptu_data_september_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1k935gw,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1k935gw/3/producer%2Fptu_data_september_2013-ptu_data_september_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3WK5C,30808,Eaffinis_2008experiments-Eaffinis_2008experiments.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq13j39xf,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq13j39xf/10/producer%2FEaffinis_2008experiments-Eaffinis_2008experiments.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3488K,30809,ptu_data_march_2013-ptu_data_march_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1br8q5p,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1br8q5p/4/producer%2Fptu_data_march_2013-ptu_data_march_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3R30D,30810,ptu_data_december_2013-ptu_data_december_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1610x80,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1610x80/3/producer%2Fptu_data_december_2013-ptu_data_december_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R30K59,30811,ptu_data_february2013-ptu_data_february2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1gh9fw0,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1gh9fw0/4/producer%2Fptu_data_february2013-ptu_data_february2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3HP4M,30812,rainhail_data_august_2013-rainhail_data_august_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1xd0znn,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1xd0znn/3/producer%2Frainhail_data_august_2013-rainhail_data_august_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3QW2S,30813,Sediment-core-7.xlsx,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq18k771c,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq18k771c/6/producer%2FSediment-core-7.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R31C79,30814,MLA.xlsx,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq17m05w4,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq17m05w4/7/producer%2FMLA.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R3CS31,30816,rainhail_data_february_2013-rainhail_data_february_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1xg9p38,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1xg9p38/3/producer%2Frainhail_data_february_2013-rainhail_data_february_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3759V,30817,ptu_data_november_2013-ptu_data_november_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq16t0jmv,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq16t0jmv/3/producer%2Fptu_data_november_2013-ptu_data_november_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3PC76,30818,wind_data_april_2013-wind_data_april_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1wd3xjq,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1wd3xjq/3/producer%2Fwind_data_april_2013-wind_data_april_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R32P4K,30820,wind_data_july_2013-wind_data_july_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1cf9n23,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1cf9n23/3/producer%2Fwind_data_july_2013-wind_data_july_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3M598,30821,env short-env short.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1tx3cbz,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1tx3cbz/4/producer%2Fenv%20short-env%20short.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3ZW2Z,30822,File-metadata.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1sf2t5k,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1sf2t5k/7/producer%2FFile-metadata.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3588W,30823,rainhail_data_july_2013-rainhail_data_july_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq18s4mvm,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq18s4mvm/3/producer%2Frainhail_data_july_2013-rainhail_data_july_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3T594,30824,wind_data_may_2013-wind_data_may_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1mw2f32,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1mw2f32/3/producer%2Fwind_data_may_2013-wind_data_may_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R38302,30825,ptu_data_april_2013-ptu_data_april_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1707zdt,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1707zdt/4/producer%2Fptu_data_april_2013-ptu_data_april_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3R59H,30826,rainhail_data_march_2013-rainhail_data_march_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1pv6hbt,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1pv6hbt/3/producer%2Frainhail_data_march_2013-rainhail_data_march_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3ZP4N,30827,ptu_data_october_2013-ptu_data_october_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1bk1994,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1bk1994/3/producer%2Fptu_data_october_2013-ptu_data_october_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3GK5N,30828,ptu_data_october_2013-ptu_data_october_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1fj2dr5,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1fj2dr5/3/producer%2Fptu_data_october_2013-ptu_data_october_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3459X,30829,Chapter 3 Data December 13-Chapter 3 Data December 13.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1jm27kg,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1jm27kg/5/producer%2FChapter%203%20Data%20December%2013-Chapter%203%20Data%20December%2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3730R,30831,ptu_data_august_2013-ptu_data_august_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1pz56sk,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1pz56sk/3/producer%2Fptu_data_august_2013-ptu_data_august_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3KG6X,30833,ptu_data_june_2013-ptu_data_june_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1vm497c,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1vm497c/3/producer%2Fptu_data_june_2013-ptu_data_june_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3XW2N,30834,wind_data_june_2013-wind_data_june_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1h41pd3,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1h41pd3/3/producer%2Fwind_data_june_2013-wind_data_june_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R31P48,30835,rainhail_data_december_2013-rainhail_data_december_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1db7zsr,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1db7zsr/3/producer%2Frainhail_data_december_2013-rainhail_data_december_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3FS3N,30836,ptu_data_may_2013-ptu_data_may_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq10c4sq8,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq10c4sq8/3/producer%2Fptu_data_may_2013-ptu_data_may_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3T01C,30837,rainhail_data_december_2013-rainhail_data_december_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1n29tx2,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1n29tx2/3/producer%2Frainhail_data_december_2013-rainhail_data_december_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3XK5P,30838,wind_data_may_2013-wind_data_may_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1rx991r,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1rx991r/4/producer%2Fwind_data_may_2013-wind_data_may_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3XS30,30839,ptu_data_january_2013-ptu_data_january_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1h9935p,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1h9935p/3/producer%2Fptu_data_january_2013-ptu_data_january_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3MG67,30840,rainhail_data_february_2013-rainhail_data_february_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1tm7830,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1tm7830/3/producer%2Frainhail_data_february_2013-rainhail_data_february_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R30P4Z,30841,ptu_data_april_2013-ptu_data_april_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1fb50w2,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1fb50w2/3/producer%2Fptu_data_april_2013-ptu_data_april_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R35304,30842,wind_data_january_2013-wind_data_january_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq19021qd,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq19021qd/3/producer%2Fwind_data_january_2013-wind_data_january_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3Q596,30843,ptu_data_july_2013-ptu_data_july_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1qv3jhn,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1qv3jhn/3/producer%2Fptu_data_july_2013-ptu_data_july_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3VS3C,30844,ptu_data_january_2013-ptu_data_january_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1m61h6z,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1m61h6z/5/producer%2Fptu_data_january_2013-ptu_data_january_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R34G6W,30846,rainhail_data_may_2013-rainhail_data_may_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq19k4866,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq19k4866/3/producer%2Frainhail_data_may_2013-rainhail_data_may_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3M88X,30848,ptu_data_november_2013-ptu_data_november_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq19s1p0d,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq19s1p0d/3/producer%2Fptu_data_november_2013-ptu_data_november_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3CP4C,30849,alpine removal expt.xlsx,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1t151m6,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1t151m6/6/producer%2Falpine%20removal%20expt.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R3959G,30850,wind_data_february_2013-wind_data_february_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq14x55sv,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq14x55sv/3/producer%2Fwind_data_february_2013-wind_data_february_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3630F,30851,wind_data_december_2013-wind_data_december_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1vq30m7,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1vq30m7/3/producer%2Fwind_data_december_2013-wind_data_december_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3HG69,30852,rainhail_data_january_2013-rainhail_data_january_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq12805jn,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq12805jn/3/producer%2Frainhail_data_january_2013-rainhail_data_january_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3V30B,30853,month.xlsx,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1k0727x,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1k0727x/3/producer%2Fmonth.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R3DK51,30854,wind_data_july_2013-wind_data_july_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1hd7sm2,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1hd7sm2/3/producer%2Fwind_data_july_2013-wind_data_july_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3KK5K,30855,wind_data_november_2013-wind_data_november_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1vd6wdb,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1vd6wdb/3/producer%2Fwind_data_november_2013-wind_data_november_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3RW23,30856,CogLabEx6_ana_allSubs-CogLabEx6_ana_allSubs.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1zs2tf5,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1zs2tf5/5/producer%2FCogLabEx6_ana_allSubs-CogLabEx6_ana_allSubs.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3FW29,30857,wind_data_october_2013-wind_data_october_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1057cwm,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1057cwm/3/producer%2Fwind_data_october_2013-wind_data_october_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R30C70,30858,Chapter 2 Raw Data-Chapter 2 Raw Data.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1dv1gt9,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1dv1gt9/5/producer%2FChapter%202%20Raw%20Data-Chapter%202%20Raw%20Data.csv?no_redirect=true
+Http status code: 401"
+10.15146/R36C7V,30859,wind_data_august_2013-wind_data_august_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq17p8wct,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq17p8wct/3/producer%2Fwind_data_august_2013-wind_data_august_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3N30G,30862,Verbs and Parameters-Verbs and Parameters.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1xs5sb7,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1xs5sb7/5/producer%2FVerbs%20and%20Parameters-Verbs%20and%20Parameters.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3TS32,30863,ptu_data_may_2013-ptu_data_may_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq13776pg,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq13776pg/3/producer%2Fptu_data_may_2013-ptu_data_may_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3WW2B,30864,rainhail_data_november_2013-rainhail_data_november_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1j38qg1,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1j38qg1/3/producer%2Frainhail_data_november_2013-rainhail_data_november_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3JP4X,30865,wind_data_may_2013-wind_data_may_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1rn35tc,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1rn35tc/3/producer%2Fwind_data_may_2013-wind_data_may_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3V01P,30866,ptu_data_august_2013-ptu_data_august_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1m32srs,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1m32srs/3/producer%2Fptu_data_august_2013-ptu_data_august_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3901Q,30867,rainhail_data_august_2013-rainhail_data_august_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1513w4m,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1513w4m/3/producer%2Frainhail_data_august_2013-rainhail_data_august_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R39W22,30868,wind_data_november_2013-wind_data_november_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq10g3h3j,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq10g3h3j/3/producer%2Fwind_data_november_2013-wind_data_november_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3N887,30869,rainhail_data_march_2013-rainhail_data_march_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1sq8xcj,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1sq8xcj/3/producer%2Frainhail_data_march_2013-rainhail_data_march_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3P88J,30870,rainhail_data_october_2013-rainhail_data_october_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1wh2mz1,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1wh2mz1/3/producer%2Frainhail_data_october_2013-rainhail_data_october_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3DW20,30871,wind_data_march_2013-wind_data_march_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1154f1d,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1154f1d/3/producer%2Fwind_data_march_2013-wind_data_march_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3FK5B,30872,wind_data_february_2013-wind_data_february_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1571903,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1571903/4/producer%2Fwind_data_february_2013-wind_data_february_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3B59S,30873,wind_data_september_2013-wind_data_september_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq13x84m1,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq13x84m1/3/producer%2Fwind_data_september_2013-wind_data_september_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R33888,30874,ptu_data_july_2013-ptu_data_july_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1tq5zgg,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1tq5zgg/3/producer%2Fptu_data_july_2013-ptu_data_july_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3W010,30877,rainhail_data_april_2013-rainhail_data_april_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1k35rmd,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1k35rmd/3/producer%2Frainhail_data_april_2013-rainhail_data_april_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3Q303,30878,DI-DirInfo.csv,https://merritt.cdlib.org/d/ark%3a%2f90135%2fq1z0367g,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3a%2f90135%2fq1z0367g/1/producer%2FDI-DirInfo.csv?no_redirect=true
+Http status code: 404"
+10.15146/R31G6Z,30879,rainhail_data_june_2013-rainhail_data_june_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1dj5ckb,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1dj5ckb/3/producer%2Frainhail_data_june_2013-rainhail_data_june_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3QC7H,30880,wind_data_december_2013-wind_data_december_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1qn64p0,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1qn64p0/3/producer%2Fwind_data_december_2013-wind_data_december_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3NC7W,30881,rainhail_data_september_2013-rainhail_data_september_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1sn06x9,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1sn06x9/3/producer%2Frainhail_data_september_2013-rainhail_data_september_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R33G6K,30882,ptu_data_september_2013-ptu_data_september_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1gb221v,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1gb221v/3/producer%2Fptu_data_september_2013-ptu_data_september_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3K88M,30883,wind_data_april_2013-wind_data_april_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1wq01rm,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1wq01rm/4/producer%2Fwind_data_april_2013-wind_data_april_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3DS3B,30884,rainhail_data_september_2013-rainhail_data_september_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq11834fq,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq11834fq/3/producer%2Frainhail_data_september_2013-rainhail_data_september_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R32G68,30885,ptu_data_february2013-ptu_data_february2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1cj8bfz,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1cj8bfz/3/producer%2Fptu_data_february2013-ptu_data_february2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R38595,30886,rainhail_data_june_2013-rainhail_data_june_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq15x26ws,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq15x26ws/3/producer%2Frainhail_data_june_2013-rainhail_data_june_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R32C7M,30887,wind_data_march_2013-wind_data_march_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq11g0j7x,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq11g0j7x/4/producer%2Fwind_data_march_2013-wind_data_march_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3S59T,30888,rainhail_data_october_2013-rainhail_data_october_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1nv9g6f,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1nv9g6f/3/producer%2Frainhail_data_october_2013-rainhail_data_october_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3JC7Z,30889,wind_data_august_2013-wind_data_august_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1cr5r92,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1cr5r92/3/producer%2Fwind_data_august_2013-wind_data_august_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3ZK50,30890,ptu_data_june_2013-ptu_data_june_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1zg6q66,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1zg6q66/3/producer%2Fptu_data_june_2013-ptu_data_june_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3WS3P,30893,rainhail_data_may_2013-rainhail_data_may_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1j964bh,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1j964bh/3/producer%2Frainhail_data_may_2013-rainhail_data_may_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R36886,30894,ptu_data_march_2013-ptu_data_march_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq17s7kq7,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq17s7kq7/3/producer%2Fptu_data_march_2013-ptu_data_march_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R37W2F,30895,EVAWF1Package-EVAWF1Package.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1kk98q9,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1kk98q9/5/producer%2FEVAWF1Package-EVAWF1Package.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3VP4Q,30896,CFNAP_Data_2009-2010_v1-CFNAP_Data_2009-2010_v1.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1930r39,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1930r39/5/producer%2FCFNAP_Data_2009-2010_v1-CFNAP_Data_2009-2010_v1.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3SW2D,30897,wind_data_september_2013-wind_data_september_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq18050k1,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq18050k1/3/producer%2Fwind_data_september_2013-wind_data_september_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3P30S,30898,wind_data_october_2013-wind_data_october_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq14747tv,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq14747tv/3/producer%2Fwind_data_october_2013-wind_data_october_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3JG6M,30899,rainhail_data_november_2013-rainhail_data_november_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1rv0kn1,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1rv0kn1/3/producer%2Frainhail_data_november_2013-rainhail_data_november_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R38W2R,30900,wind_data_june_2013-wind_data_june_2013.csv,https://merritt.cdlib.org/d/ark%3A%2F90135%2Fq1n58j9b,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F90135%2Fq1n58j9b/3/producer%2Fwind_data_june_2013-wind_data_june_2013.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3GC7B,30904,icos.tsv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5zd2zxn,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5zd2zxn/3/producer%2Ficos.tsv?no_redirect=true
+Http status code: 401"
+10.15146/R36W24,30912,retinopatia_cc.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5tr0xjr,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5tr0xjr/1/producer%2Fretinopatia_cc.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3359M,30914,bilhetagem_rastreamento.zip,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm59k978x,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm59k978x/1/producer%2Fbilhetagem_rastreamento.zip?no_redirect=true
+Http status code: 401"
+10.15146/R3ZC7P,30924,port_data.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5jx39xm,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5jx39xm/1/producer%2Fport_data.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3TP4D,30925,abstracts2.txt,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm51883jw,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm51883jw/1/producer%2Fabstracts2.txt?no_redirect=true
+Http status code: 401"
+10.15146/R3PW2G,30926,alugueEscarpas.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5n63hd2,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5n63hd2/1/producer%2FalugueEscarpas.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3K59Z,30928,Abu Dhabi Blue Carbon Project_Ecological Applications.xlsx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5x97780,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5x97780/1/producer%2FAbu%20Dhabi%20Blue%20Carbon%20Project_Ecological%20Applications.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R3FG6P,30931,AcademicLibraries_RDS_Survey.xlsx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5h46njq,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5h46njq/1/producer%2FAcademicLibraries_RDS_Survey.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R39P4R,30959,hyy15_chflux_20170213.zip,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5vb354k,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5vb354k/2/producer%2Fhyy15_chflux_20170213.zip?no_redirect=true
+Http status code: 401"
+10.15146/R3QS34,30970,Agarico_MOTU.txt,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5hf2rqs,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5hf2rqs/1/producer%2FAgarico_MOTU.txt?no_redirect=true
+Http status code: 401"
+10.15146/R3F88C,30977,hypothyroid.arff,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5bc8vhc,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5bc8vhc/1/producer%2Fhypothyroid.arff?no_redirect=true
+Http status code: 401"
+10.15146/R39K53,30978,diabetes.arff,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5ps2rzx,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5ps2rzx/1/producer%2Fdiabetes.arff?no_redirect=true
+Http status code: 401"
+10.15146/R34S47,30979,vehicle.arff,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5bp4zss,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5bp4zss/1/producer%2Fvehicle.arff?no_redirect=true
+Http status code: 401"
+10.15146/R3VC84,30982,agenda.pdf,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5ns5qzb,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5ns5qzb/2/producer%2Fagenda.pdf?no_redirect=true
+Http status code: 401"
+10.15146/R3QK5T,30983,rachelalbrecht.7.2.zip,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5ff8pbp,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5ff8pbp/1/producer%2Frachelalbrecht.7.2.zip?no_redirect=true
+Http status code: 401"
+10.15146/R3KW3X,30984,wds2.5.2.zip,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5k12196,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5k12196/2/producer%2Fwds2.5.2.zip?no_redirect=true
+Http status code: 401"
+10.15146/R3G30X,30985,wds.tde,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm56m83tg,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm56m83tg/2/producer%2Fwds.tde?no_redirect=true
+Http status code: 401"
+10.15146/R3BC8G,30987,gabrielperez.6.1.zip,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm58m263n,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm58m263n/2/producer%2Fgabrielperez.6.1.zip?no_redirect=true
+Http status code: 401"
+10.15146/R36K6J,30993,vote.arff,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5wh7m15,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5wh7m15/2/producer%2Fvote.arff?no_redirect=true
+Http status code: 401"
+10.15146/R32W2W,30995,hypothyroid.arff,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5k69f2d,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5k69f2d/3/producer%2Fhypothyroid.arff?no_redirect=true
+Http status code: 401"
+10.15146/R3Z31N,30998,credit-an.arff,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5pp42q7,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5pp42q7/4/producer%2Fcredit-an.arff?no_redirect=true
+Http status code: 401"
+10.15146/R3TC7F,30999,Wanderley - Algoritmos de Classificação.docx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5130pnh,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5130pnh/1/producer%2FWanderley%20-%20Algoritmos%20de%20Classifica%C3%A7%C3%A3o.docx?no_redirect=true
+Http status code: 404"
+10.15146/R3PK6W,31000,diabetes.arff,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5j1507q,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5j1507q/1/producer%2Fdiabetes.arff?no_redirect=true
+Http status code: 401"
+10.15146/R3JW27,31002,soybean.arff,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5rv5jr6,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5rv5jr6/1/producer%2Fsoybean.arff?no_redirect=true
+Http status code: 401"
+10.15146/R3F60N,31004,vote.arff,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5sr3wg8,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5sr3wg8/1/producer%2Fvote.arff?no_redirect=true
+Http status code: 401"
+10.15146/R38C8V,31006,titanic.arff,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm54v1fcx,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm54v1fcx/1/producer%2Ftitanic.arff?no_redirect=true
+Http status code: 401"
+10.15146/R34P46,31010,dataset_reorganizado.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5cg4m3x,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5cg4m3x/2/producer%2Fdataset_reorganizado.csv?no_redirect=true
+Http status code: 401"
+10.15146/R30029,31035,LFE-Hikurangi.txt,http://merritt.cdlib.org/d/ark%3a%2f13030%2fm5m955nj,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3a%2f13030%2fm5m955nj/2/producer%2FLFE-Hikurangi.txt?no_redirect=true
+Http status code: 401"
+10.15146/R3909R,31042,Readme.txt,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5256f7h,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5256f7h/1/producer%2FReadme.txt?no_redirect=true
+Http status code: 401"
+10.15146/R30M3W,31056,eq_5_140.882_39.043_7.510,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5z948dc,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5z948dc/3/producer%2Feq_5_140.882_39.043_7.510?no_redirect=true
+Http status code: 401"
+10.15146/R3Q37R,31087,FeatureData.mat,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5qg3pws,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5qg3pws/2/producer%2FFeatureData.mat?no_redirect=true
+Http status code: 401"
+10.15146/R3DM3M,31103,README.md,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5qr9t35,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5qr9t35/1/producer%2FREADME.md?no_redirect=true
+Http status code: 401"
+10.15146/R3467H,31117,mxm_dataset_train.txt.zip,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5450hgt,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5450hgt/1/producer%2Fmxm_dataset_train.txt.zip?no_redirect=true
+Http status code: 401"
+10.15146/R30D46,31120,sp156solicitacoes-detalhadas1sem2017.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm56t5hq1,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm56t5hq1/1/producer%2Fsp156solicitacoes-detalhadas1sem2017.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3VQ29,31122,Test.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5324rxq,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5324rxq/2/producer%2FTest.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3QX0C,31124,maoaip1ogrenM1.s1.20131211.143743.cdf,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5g49mbf,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5g49mbf/1/producer%2Fmaoaip1ogrenM1.s1.20131211.143743.cdf?no_redirect=true
+Http status code: 401"
+10.15146/R3M66G,31127,cepea_boi gordo_SP.xls,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5v74fnz,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5v74fnz/1/producer%2Fcepea_boi%20gordo_SP.xls?no_redirect=true
+Http status code: 401"
+10.15146/R3GD4J,31129,data.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm54z04tp,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm54z04tp/2/producer%2Fdata.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3BQ18,31131,Human development index (HDI).csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5gf5qhh,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5gf5qhh/2/producer%2FHuman%20development%20index%20%28HDI%29.csv?no_redirect=true
+Http status code: 401"
+10.15146/R36X0Q,31132,eml.xml,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5h75brb,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5h75brb/1/producer%2Feml.xml?no_redirect=true
+Http status code: 401"
+10.15146/R3ZD4W,31133,tables_1-15_6a_dashboard1_dashboard2_online_version.xlsx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5tf4tcp,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5tf4tcp/1/producer%2Ftables_1-15_6a_dashboard1_dashboard2_online_version.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R3TQ1M,31134,sp156solicitacoes-detalhadas1sem2017.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm59p7xmz,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm59p7xmz/1/producer%2Fsp156solicitacoes-detalhadas1sem2017.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3J66V,31143,Bass Harbor High Impact Data 7-26.xlsx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5cp20z0,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5cp20z0/1/producer%2FBass%20Harbor%20High%20Impact%20Data%207-26.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R37T00,31149,sjm2013_leaf_data_20180510.zip,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5f52k4q,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5f52k4q/3/producer%2Fsjm2013_leaf_data_20180510.zip?no_redirect=true
+Http status code: 401"
+10.15146/R3408T,31151,Replies-2017-10-18.rar,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm55t8ghr,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm55t8ghr/2/producer%2FReplies-2017-10-18.rar?no_redirect=true
+Http status code: 401"
+10.15146/R3Z96M,75380,MappingSiteFile_forR.txt,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5227qqf,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5227qqf/2/producer%2FMappingSiteFile_forR.txt?no_redirect=true
+Http status code: 401"
+10.15146/R3NT0Q,31170,input.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5dg1n3h,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5dg1n3h/2/producer%2Finput.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3J38K,31173,dataset_seaturtles.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm58q0wd7,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm58q0wd7/3/producer%2Fdataset_seaturtles.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3CD50,31186,1496295494_01-06-2017.pdf,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5741mvz,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5741mvz/2/producer%2F1496295494_01-06-2017.pdf?no_redirect=true
+Http status code: 401"
+10.15146/R37M2P,31190,RawDataset_Figure 1_ImageFile3.TIF,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5d84799,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5d84799/2/producer%2FRawDataset_Figure%201_ImageFile3.TIF?no_redirect=true
+Http status code: 401"
+10.15146/R32X0G,31197,Williams et al. T1 data.xlsx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5qc50fd,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5qc50fd/1/producer%2FWilliams%20et%20al.%20T1%20data.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R3SD4B,31199,TRPV1_BAT_IJO_BASKI.pdf,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5867cdh,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5867cdh/2/producer%2FTRPV1_BAT_IJO_BASKI.pdf?no_redirect=true
+Http status code: 401"
+10.15146/R3H09M,31212,Fig1b_RvsH.txt,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5zh1p6k,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5zh1p6k/3/producer%2FFig1b_RvsH.txt?no_redirect=true
+Http status code: 401"
+10.15146/R3X09B,31246,d126 2018 13 087 payer behaviours project 62825 01 accounts,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5dc2z41,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5dc2z41/6/producer%2Fd126%202018%2013%20087%20payer%20behaviours%20project%2062825%2001%20accounts?no_redirect=true
+Http status code: 401"
+10.15146/R3S962,31247,final data for submission3-21-18.xlsx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm58m26c7,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm58m26c7/1/producer%2Ffinal%20data%20for%20submission3-21-18.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R3MM4V,31258,cocoliAbundTable.tab,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5jm76xs,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5jm76xs/1/producer%2FcocoliAbundTable.tab?no_redirect=true
+Http status code: 401"
+10.15146/R3B37B,31269,d078 2018 14 093 3 1 8 21 post 0000 0001 5537 0824 c felker.txt,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5k40qwc,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5k40qwc/5/producer%2Fd078%202018%2014%20093%203%201%208%2021%20post%200000%200001%205537%200824%20c%20felker.txt?no_redirect=true
+Http status code: 401"
+10.15146/R31M36,31281,F2loci_depthfile.R,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5m9560f,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5m9560f/4/producer%2FF2loci_depthfile.R?no_redirect=true
+Http status code: 401"
+10.15146/R3R68G,31298,2018 20 135 dsd045 dimension sdmx data structure definition valuation method.txt,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5j43pws,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5j43pws/6/producer%2F2018%2020%20135%20dsd045%20dimension%20sdmx%20data%20structure%20definition%20valuation%20method.txt?no_redirect=true
+Http status code: 401"
+10.15146/R3FQ16,31370,Article_Ershov.PDF,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5h17z9n,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5h17z9n/1/producer%2FArticle_Ershov.PDF?no_redirect=true
+Http status code: 401"
+10.15146/R3566F,31384,TEACHING_AID_Ershov_2018.PDF,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm53f9m13,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm53f9m13/1/producer%2FTEACHING_AID_Ershov_2018.PDF?no_redirect=true
+Http status code: 401"
+10.15146/R3VT1Z,31426,WCH_DiscreteSamplesAll.xlsx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5f8193m,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5f8193m/1/producer%2FWCH_DiscreteSamplesAll.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R3K966,31428,Graph_Raw_Data.xlsx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5c876rj,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5c876rj/2/producer%2FGraph_Raw_Data.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R38T09,31485,Geary_sampleDMP_3may2018.docx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5qg3qfc,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5qg3qfc/4/producer%2FGeary_sampleDMP_3may2018.docx?no_redirect=true
+Http status code: 401"
+10.15146/R3539J,31487,data_for_figures.zip,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm52n9zsv,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm52n9zsv/1/producer%2Fdata_for_figures.zip?no_redirect=true
+Http status code: 401"
+10.15146/R3VM28,31517,AmostraDados_Repositorio.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5cg4n1f,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5cg4n1f/1/producer%2FAmostraDados_Repositorio.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3QX1R,31519,Indicadores de Transporte.xlsx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm57q3wcm,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm57q3wcm/1/producer%2FIndicadores%20de%20Transporte.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R3PX02,31520,15-07-2018a15-09-2018.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5x9787z,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5x9787z/1/producer%2F15-07-2018a15-09-2018.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3K398,31523,25_Markov.xlsx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5sj6hh7,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5sj6hh7/2/producer%2F25_Markov.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R3FD47,31525,AcessibilidadeEmpregos_RMSP_SelecaoDadosPCS5031.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5ns5rwv,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5ns5rwv/1/producer%2FAcessibilidadeEmpregos_RMSP_SelecaoDadosPCS5031.csv?no_redirect=true
+Http status code: 401"
+10.15146/R39M3P,31526,banco_teses_dissertacoes.xls,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5j15157,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5j15157/1/producer%2Fbanco_teses_dissertacoes.xls?no_redirect=true
+Http status code: 401"
+10.15146/R35X0D,31527,Cartão de Pagamento do Governo Federal (CPGF).csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5dc2zsj,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5dc2zsj/1/producer%2FCart%C3%A3o%20de%20Pagamento%20do%20Governo%20Federal%20%28CPGF%29.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3239M,31529,saopauloln1_links.txt,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm58m2715,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm58m2715/1/producer%2Fsaopauloln1_links.txt?no_redirect=true
+Http status code: 401"
+10.15146/R3XD4K,31530,WSP-WMS-JULHO2018 - Modificado.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm54v1g9f,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm54v1g9f/1/producer%2FWSP-WMS-JULHO2018%20-%20Modificado.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3DD4X,31533,teste-1.txt,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm54j5c2g,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm54j5c2g/2/producer%2Fteste-1.txt?no_redirect=true
+Http status code: 401"
+10.15146/R33X2J,31535,All_plasmids.fna,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5741nwt,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5741nwt/2/producer%2FAll_plasmids.fna?no_redirect=true
+Http status code: 401"
+10.15146/R3TH6F,75118,AAAS_CEFP_Advocacy_Programs_Survey_Questions.txt,https://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5qp14q7,"Merritt couldn't create presigned URL for https://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5qp14q7/4/producer%2FAAAS_CEFP_Advocacy_Programs_Survey_Questions.txt?no_redirect=true
+Http status code: 401"
+10.15146/R3J09X,31595,WeakestLink_UnpairedAnalysis_Data_7.26.xlsx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5s80df2,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5s80df2/3/producer%2FWeakestLink_UnpairedAnalysis_Data_7.26.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/R37H65,31604,base-od-cargas-08022017-1-.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5qk2fg5,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5qk2fg5/1/producer%2Fbase-od-cargas-08022017-1-.csv?no_redirect=true
+Http status code: 401"
+10.15146/R33T14,31607,2015_2017_SP_Brazil_pollutant_respiratory_admissions.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5pp43vf,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5pp43vf/1/producer%2F2015_2017_SP_Brazil_pollutant_respiratory_admissions.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3Z40M,31663,JOURNAL SHINTA NOVIANTI 03-02-2019.pdf,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm58m27kb,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm58m27kb/1/producer%2FJOURNAL%20SHINTA%20NOVIANTI%2003-02-2019.pdf?no_redirect=true
+Http status code: 401"
+10.15146/R3NM3S,31694,AFP.eas,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm56f0rkf,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm56f0rkf/1/producer%2FAFP.eas?no_redirect=true
+Http status code: 401"
+10.15146/R3C39D,31718,OCEANS_StationData_LCDM_RVersion_1.10.19.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm50g8hsr,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm50g8hsr/1/producer%2FOCEANS_StationData_LCDM_RVersion_1.10.19.csv?no_redirect=true
+Http status code: 401"
+10.15146/R32Q3J,31724,Movie S1 (Converted).mov,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5qv8k68,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5qv8k68/3/producer%2FMovie%20S1%20%28Converted%29.mov?no_redirect=true
+Http status code: 401"
+10.15146/R3S68S,45800,raw_data_Liu.csv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm59k98xv,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm59k98xv/2/producer%2Fraw_data_Liu.csv?no_redirect=true
+Http status code: 401"
+10.15146/R3GQ38,31750,Article_Ershov_2019.pdf,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5fv3jq6,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5fv3jq6/6/producer%2FArticle_Ershov_2019.pdf?no_redirect=true
+Http status code: 401"
+10.15146/R36975,31780,SbS Emissions Data Transmittal.zip,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm52z647q,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm52z647q/1/producer%2FSbS%20Emissions%20Data%20Transmittal.zip?no_redirect=true
+Http status code: 401"
+10.15146/R3WT2N,31793,Example plume measurements.kmz,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5dn93vh,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5dn93vh/1/producer%2FExample%20plume%20measurements.kmz?no_redirect=true
+Http status code: 401"
+10.15146/R3M97W,67694,PanamaTreeBIENError.tsv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5g78chf,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5g78chf/2/producer%2FPanamaTreeBIENError.tsv?no_redirect=true
+Http status code: 401"
+10.15146/R3QX24,31817,dib_data_Liu et al..docx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5v74hkw,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5v74hkw/2/producer%2Fdib_data_Liu%20et%20al..docx?no_redirect=true
+Http status code: 401"
+10.15146/R3FH61,72028,Condit_TaxaHistoryBCI.tsv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5p60mht,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5p60mht/6/producer%2FCondit_TaxaHistoryBCI.tsv?no_redirect=true
+Http status code: 401"
+10.15146/R3509H,31824,Full data set.xlsx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5zd31xv,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5zd31xv/1/producer%2FFull%20data%20set.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/5xcp-0d46,31849,BCIelev.tsv,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm58q0zk9,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm58q0zk9/3/producer%2FBCIelev.tsv?no_redirect=true
+Http status code: 401"
+10.15146/tavf-rm36,31858,dib_data_stratification_Liu et al..docx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5547mqt,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5547mqt/3/producer%2Fdib_data_stratification_Liu%20et%20al..docx?no_redirect=true
+Http status code: 401"
+10.15146/r2qr-1b50,31868,source data.xlsx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5wh7q90,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5wh7q90/1/producer%2Fsource%20data.xlsx?no_redirect=true
+Http status code: 401"
+10.15146/mdpr-pm59,31895,marena_tree_17Jul2019.zip,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm58s9s7v,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm58s9s7v/1/producer%2Fmarena_tree_17Jul2019.zip?no_redirect=true
+Http status code: 401"
+10.15146/zf0j-5m50,58376,ERS-GL-24339-4666-24840-5167.shx,http://merritt.cdlib.org/d/ark%3A%2F13030%2Fm5cc640h,"Merritt couldn't create presigned URL for http://merritt.cdlib.org/api/presign-file/ark%3A%2F13030%2Fm5cc640h/6/producer%2FERS-GL-24339-4666-24840-5167.shx?no_redirect=true
+Http status code: 401"

--- a/lib/tasks/download_check.rake
+++ b/lib/tasks/download_check.rake
@@ -1,0 +1,17 @@
+require_relative 'download_check/merritt'
+
+namespace :download_check do
+
+  # checks one download from each of the published datasets to see if they seem downloadable
+  desc "check merritt datasets to be sure they're able to download"
+  task merritt: :environment do
+    sql = 'SELECT * FROM stash_engine_identifiers ids ' \
+          'WHERE ids.pub_state = "published" ' \
+          'AND id IN (SELECT DISTINCT identifier_id FROM stash_engine_resources WHERE tenant_id = "dataone")'
+
+    ids = StashEngine::Identifier.find_by_sql(sql)
+    dl_merritt = DownloadCheck::Merritt.new(identifiers: ids)
+    dl_merritt.check_a_download
+    dl_merritt.output_csv(filename: 'dataone.csv')
+  end
+end

--- a/lib/tasks/download_check/merritt.rb
+++ b/lib/tasks/download_check/merritt.rb
@@ -1,0 +1,41 @@
+require 'http'
+require 'byebug'
+module DownloadCheck
+  class Merritt
+
+    def initialize(identifiers:)
+      @identifiers = identifiers
+    end
+
+    def check_a_download
+      @accumulator = []
+      @identifiers.each_with_index do |identifier, idx|
+        res = identifier.latest_resource_with_public_metadata
+        puts "#{idx + 1}/#{@identifiers.count} checking #{identifier.identifier}, resource: #{res.id}"
+        file = res.data_files.present_files.first
+        next if file.nil?
+
+        begin
+          file.merritt_s3_presigned_url
+          @accumulator.push(
+            { doi: identifier.identifier, resource: res.id, file: file.upload_file_name,
+              dl_uri: res.download_uri, error: false }
+          )
+        rescue Stash::Download::MerrittError, HTTP::Error => e
+          @accumulator.push(
+            { doi: identifier.identifier, resource: res.id, file: file.upload_file_name,
+              dl_uri: res.download_uri, error: e.to_s }
+          )
+        end
+        sleep 0.5
+      end
+    end
+
+    def output_csv(filename:)
+      CSV.open(filename, 'w') do |writer|
+        writer << @accumulator.first.keys
+        @accumulator.each { |i| writer << i.values }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This just does a query to get published DataONE items and checks one file in each dataset to see if it downloads and outputs to a CSV.

Useful for getting list for Merritt.  Because this is a quick one-off for Merritt I haven't added tests.  It mostly just reuses our already existing method for creating presigned URLs and then save the results to output as CSV.