### PR TITLE
Don't upload zero length to zenodo

### DIFF
--- a/stash/stash_engine/lib/stash/zenodo_software/file_collection.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/file_collection.rb
@@ -32,6 +32,8 @@ module Stash
 
       def upload_files(zenodo_bucket_url:)
         @file_change_list.upload_list.each do |upload|
+          next if upload.upload_file_size.nil? || upload.upload_file_size == 0
+
           streamer = Streamer.new(file_model: upload, zenodo_bucket_url: zenodo_bucket_url)
           digests = ['md5']
           digests.push(upload.digest_type) if upload.digest_type.present? && upload.digest.present?

--- a/stash/stash_engine/lib/stash/zenodo_software/streamer.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/streamer.rb
@@ -39,7 +39,8 @@ module Stash
         read_pipe.define_singleton_method(:rewind) { nil }
         write_pipe.binmode
 
-        http = HTTP.timeout(connect: 30, read: 60).timeout(6.hours.to_i).follow(max_hops: 10)
+        http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
+          .timeout(connect: 30, read: 60).timeout(6.hours.to_i).follow(max_hops: 10)
         response = http.get(@file_model.zenodo_replication_url)
 
         put_response = nil


### PR DESCRIPTION
If a file has nothing in the body and is zero length then Zenodo will reject the entire submission, so in that case leave the file out.

Also added a test and a fix for an encoding mangling issue with our http client in some circumstances.