### PR TITLE
Journal email -- message parsing

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -265,8 +265,8 @@ production:
     gmail_client_id: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_id] %>
     gmail_client_secret: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_secret] %>
     journal_account_name: journal-submit-app@datadryad.org
-    journal_processing_label: journal-submit
-    journal_error_label: journal-submit-error
+    journal_processing_label: journal-submit-v2
+    journal_error_label: journal-submit-error-v2
 
 # Terminate the if statement from the beginning of this file.
 <% end %>

--- a/documentation/apis/journals.md
+++ b/documentation/apis/journals.md
@@ -22,8 +22,7 @@ Metadata about the journals and their workflows is stored in Dryad's
 Meaning of fields
 -----------------
 
-Some of the fields in `StashEngine::Journal` are being updated as we
-transition journals from older workflows to newer ones.
+Options for processing in `StashEngine::Journal`
 
 - *allow_review_workflow* -- Was previously used to determine whether
   a journal allowed authors to submit data during the manuscript

--- a/spec/factories/stash_engine/journals.rb
+++ b/spec/factories/stash_engine/journals.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
 
     title { Faker::Company.industry }
     issn { "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}" }
-
+    journal_code { Faker::Name.initials(number: 4) }
   end
 
 end

--- a/spec/models/stash_engine/manuscript_spec.rb
+++ b/spec/models/stash_engine/manuscript_spec.rb
@@ -8,21 +8,25 @@ module StashEngine
     end
 
     describe '#from_message_content' do
+      before(:each) do
+        @ms_number = "ms-#{Faker::Number.number(digits: 4)}"
+        @title = Faker::Lorem.sentence
+      end
+
       it 'turns a basic message into a manuscript' do
-        ms_number = "ms-#{Faker::Number.number(digits: 4)}"
-        title = Faker::Lorem.sentence
         content = "Journal Name: #{@journal.title}\n" \
                   "Online ISSN: #{@journal.issn}\n" \
-                  "MS Reference Number: #{ms_number}\n" \
-                  "MS Title: #{title}\n" \
+                  "Article Status: accepted\n" \
+                  "MS Reference Number: #{@ms_number}\n" \
+                  "MS Title: #{@title}\n" \
                   'MS Authors: Lastname, Firstname; McOtherLastname, Somename'
         result = Manuscript.from_message_content(content: content)
         expect(result).not_to be_nil
         expect(result.success?).to be_truthy
         expect(result.payload).not_to be_nil
-        expect(result.payload.manuscript_number).to eq(ms_number)
-        puts("PAYLmmet #{result.payload.metadata} -- #{title}")
-        expect(result.payload.metadata['ms title']).to eq(title)
+        expect(result.payload.manuscript_number).to eq(@ms_number)
+        puts("PAYLmmet #{result.payload.metadata} -- #{@title}")
+        expect(result.payload.metadata['ms title']).to eq(@title)
       end
 
       it 'provides an error when parsing fails' do
@@ -33,6 +37,67 @@ module StashEngine
         expect(result.payload).to be_nil
         expect(result.error).not_to be_nil
       end
+
+      it 'provides an error when journal info missing' do
+        content = "Article Status: accepted\n" \
+                  "MS Reference Number: #{@ms_number}\n" \
+                  "MS Title: #{@title}\n" \
+                  'MS Authors: Lastname, Firstname; McOtherLastname, Somename'
+        result = Manuscript.from_message_content(content: content)
+        expect(result).not_to be_nil
+        expect(result.success?).to be_falsey
+        expect(result.payload).to be_nil
+        expect(result.error).to include('Journal')
+      end
+
+      it 'provides an error when MS Number missing' do
+        content = "Online ISSN: #{@journal.issn}\n" \
+                  "Article Status: accepted\n" \
+                  "MS Title: #{@title}\n" \
+                  'MS Authors: Lastname, Firstname; McOtherLastname, Somename'
+        result = Manuscript.from_message_content(content: content)
+        expect(result).not_to be_nil
+        expect(result.success?).to be_falsey
+        expect(result.payload).to be_nil
+        expect(result.error).to include('MS Reference Number')
+      end
+
+      it 'provides an error when Title missing' do
+        content = "Online ISSN: #{@journal.issn}\n" \
+                  "Article Status: accepted\n" \
+                  "MS Reference Number: #{@ms_number}\n" \
+                  'MS Authors: Lastname, Firstname; McOtherLastname, Somename'
+        result = Manuscript.from_message_content(content: content)
+        expect(result).not_to be_nil
+        expect(result.success?).to be_falsey
+        expect(result.payload).to be_nil
+        expect(result.error).to include('Title')
+      end
+
+      it 'provides an error when Author info missing' do
+        content = "Online ISSN: #{@journal.issn}\n" \
+                  "Article Status: accepted\n" \
+                  "MS Reference Number: #{@ms_number}\n" \
+                  "MS Title: #{@title}\n"
+        result = Manuscript.from_message_content(content: content)
+        expect(result).not_to be_nil
+        expect(result.success?).to be_falsey
+        expect(result.payload).to be_nil
+        expect(result.error).to include('Authors')
+      end
+
+      it 'provides an error when Article Status info missing' do
+        content = "Online ISSN: #{@journal.issn}\n" \
+                  "MS Reference Number: #{@ms_number}\n" \
+                  "MS Title: #{@title}\n" \
+                  'MS Authors: Lastname, Firstname; McOtherLastname, Somename'
+        result = Manuscript.from_message_content(content: content)
+        expect(result).not_to be_nil
+        expect(result.success?).to be_falsey
+        expect(result.payload).to be_nil
+        expect(result.error).to include('Article Status')
+      end
+
     end
   end
 end

--- a/spec/models/stash_engine/manuscript_spec.rb
+++ b/spec/models/stash_engine/manuscript_spec.rb
@@ -25,7 +25,6 @@ module StashEngine
         expect(result.success?).to be_truthy
         expect(result.payload).not_to be_nil
         expect(result.payload.manuscript_number).to eq(@ms_number)
-        puts("PAYLmmet #{result.payload.metadata} -- #{@title}")
         expect(result.payload.metadata['ms title']).to eq(@title)
       end
 

--- a/spec/models/stash_engine/manuscript_spec.rb
+++ b/spec/models/stash_engine/manuscript_spec.rb
@@ -12,7 +12,6 @@ module StashEngine
         ms_number = "ms-#{Faker::Number.number(digits: 4)}"
         title = Faker::Lorem.sentence
         content = "Journal Name: #{@journal.title}\n" \
-                  "Journal Code: RSOS\n" \
                   "Online ISSN: #{@journal.issn}\n" \
                   "MS Reference Number: #{ms_number}\n" \
                   "MS Title: #{title}\n" \

--- a/spec/models/stash_engine/manuscript_spec.rb
+++ b/spec/models/stash_engine/manuscript_spec.rb
@@ -1,0 +1,25 @@
+require 'webmock/rspec'
+require 'byebug'
+
+module StashEngine
+  describe Manuscript, type: :model do
+    before(:each) do
+    
+    end
+
+    describe '#from_message_content' do
+      it 'turns a basic message into a manuscript' do
+        content = "Journal Name: Royal Society Open Science\n" \
+                  "Journal Code: RSOS\n" \
+                  "Online ISSN: 2054-5703" \
+                  "MS Reference Number: abc123" \
+                  "MS Title: Some great title" \
+                  "MS Authors: "
+      end
+
+      it 'provides an error when parsing fails' do
+        assert(false)
+      end
+    end
+  end
+end

--- a/spec/models/stash_engine/manuscript_spec.rb
+++ b/spec/models/stash_engine/manuscript_spec.rb
@@ -4,21 +4,35 @@ require 'byebug'
 module StashEngine
   describe Manuscript, type: :model do
     before(:each) do
-    
+      @journal = create(:journal)
     end
 
     describe '#from_message_content' do
       it 'turns a basic message into a manuscript' do
-        content = "Journal Name: Royal Society Open Science\n" \
+        ms_number = "ms-#{Faker::Number.number(digits: 4)}"
+        title = Faker::Lorem.sentence
+        content = "Journal Name: #{@journal.title}\n" \
                   "Journal Code: RSOS\n" \
-                  "Online ISSN: 2054-5703" \
-                  "MS Reference Number: abc123" \
-                  "MS Title: Some great title" \
-                  "MS Authors: "
+                  "Online ISSN: #{@journal.issn}\n" \
+                  "MS Reference Number: #{ms_number}\n" \
+                  "MS Title: #{title}\n" \
+                  'MS Authors: Lastname, Firstname; McOtherLastname, Somename'
+        result = Manuscript.from_message_content(content: content)
+        expect(result).not_to be_nil
+        expect(result.success?).to be_truthy
+        expect(result.payload).not_to be_nil
+        expect(result.payload.manuscript_number).to eq(ms_number)
+        puts("PAYLmmet #{result.payload.metadata} -- #{title}")
+        expect(result.payload.metadata['ms title']).to eq(title)
       end
 
       it 'provides an error when parsing fails' do
-        assert(false)
+        content = 'abc'
+        result = Manuscript.from_message_content(content: content)
+        expect(result).not_to be_nil
+        expect(result.success?).to be_falsey
+        expect(result.payload).to be_nil
+        expect(result.error).not_to be_nil
       end
     end
   end

--- a/spec/services/stash_engine/email_parser_spec.rb
+++ b/spec/services/stash_engine/email_parser_spec.rb
@@ -17,7 +17,7 @@ module StashEngine
         parser = EmailParser.new(content: content)
         hash = parser.metadata_hash
 
-        expect(hash['journal code']).to eq('RSOS')
+        expect(hash['journal code']).to eq('rsos')
       end
 
       it 'turns an HTML message into a hash' do
@@ -25,7 +25,7 @@ module StashEngine
         parser = EmailParser.new(content: content)
         hash = parser.metadata_hash
 
-        expect(hash['journal code']).to eq('RSOS')
+        expect(hash['journal code']).to eq('rsos')
       end
 
       it 'ignores content after the EndDryadContent tag' do

--- a/spec/services/stash_engine/email_parser_spec.rb
+++ b/spec/services/stash_engine/email_parser_spec.rb
@@ -3,7 +3,7 @@ module StashEngine
     before(:each) do
     end
 
-    describe '#metadata_hash' do
+    describe '#metadata_basics' do
       it 'does not return content when there are no parseable values' do
         content = "Journal: Royal Society Open Science\nSome other garbage"
         parser = EmailParser.new(content: content)
@@ -35,69 +35,111 @@ module StashEngine
 
         expect(hash['journal code']).to be_nil
       end
+    end
 
-      describe 'author parsing' do
-        it 'parses authors with "last, first", separated by semicolons' do
-          content = 'MS Authors: last, first; last2, first2'
-          parser = EmailParser.new(content: content)
-          hash = parser.metadata_hash
-
-          expect(hash['ms authors']).not_to be_nil
-          expect(hash['ms authors'].size).to eq(2)
-          expect(hash['ms authors'][0]['family_name']).to eq('last')
-        end
-
-        it 'parses authors with "first last, first last", separated by commas' do
-          content = 'MS Authors: first last, first2 last2, first3 last3'
-          parser = EmailParser.new(content: content)
-          hash = parser.metadata_hash
-
-          expect(hash['ms authors']).not_to be_nil
-          expect(hash['ms authors'].size).to eq(3)
-          expect(hash['ms authors'][0]['family_name']).to eq('last')
-          expect(hash['ms authors'][1]['family_name']).to eq('last2')
-          expect(hash['ms authors'][2]['family_name']).to eq('last3')
-        end
-
-        it 'parses authors with "first last, first last", with "and" at the end' do
-          content = 'MS Authors: first last, first2 last2 and first3 last3'
-          parser = EmailParser.new(content: content)
-          hash = parser.metadata_hash
-
-          expect(hash['ms authors']).not_to be_nil
-          expect(hash['ms authors'].size).to eq(3)
-          expect(hash['ms authors'][0]['family_name']).to eq('last')
-          expect(hash['ms authors'][1]['family_name']).to eq('last2')
-          expect(hash['ms authors'][2]['family_name']).to eq('last3')
-        end
-
-        it 'parses authors with "first last", keeping suffixes and dropping titles' do
-          content = 'MS Authors: first last, Jr.; first2 last2, PhD; Ms. first3 last3'
-          parser = EmailParser.new(content: content)
-          hash = parser.metadata_hash
-
-          expect(hash['ms authors']).not_to be_nil
-          expect(hash['ms authors'].size).to eq(3)
-          expect(hash['ms authors'][0]['family_name']).to eq('last, Jr.')
-          expect(hash['ms authors'][1]['family_name']).to eq('last2')
-          expect(hash['ms authors'][2]['given_name']).to eq('first3')
-          expect(hash['ms authors'][2]['family_name']).to eq('last3')
-        end
-
-        it 'parses authors with a single name' do
-          content = 'MS Authors: Elvis Presley and Cher'
-          parser = EmailParser.new(content: content)
-          hash = parser.metadata_hash
-
-          expect(hash['ms authors']).not_to be_nil
-          expect(hash['ms authors'].size).to eq(2)
-          expect(hash['ms authors'][0]['family_name']).to eq('Presley')
-          expect(hash['ms authors'][1]['given_name']).to eq('')
-          expect(hash['ms authors'][1]['family_name']).to eq('Cher')
-        end
-
+    describe '#identifier' do
+      it 'finds identifier from data DOI' do
+        ident = create(:identifier)
+        content = "Dryad Data DOI: doi:#{ident.identifier}"
+        parser = EmailParser.new(content: content)
+        expect(parser.identifier).to eq(ident)
       end
 
+      it 'finds identifier from manuscript number' do
+        ident = create(:identifier)
+        journal = create(:journal)
+        ms_number = "ms-#{Faker::Number.number(digits: 4)}"
+        create(:internal_data, identifier_id: ident.id, data_type: 'manuscriptNumber', value: ms_number)
+        create(:internal_data, identifier_id: ident.id, data_type: 'publicationISSN', value: journal.issn)
+        content = "Online ISSN: #{journal.issn}\nMS Reference Number: #{ms_number}"
+        parser = EmailParser.new(content: content)
+        expect(parser.identifier).to eq(ident)
+      end
+    end
+
+    describe '#journal' do
+      before(:each) do
+        @journal = create(:journal)
+      end
+
+      it 'finds journal from print ISSN' do
+        content = "Print ISSN: #{@journal.issn}"
+        parser = EmailParser.new(content: content)
+        expect(parser.journal).to eq(@journal)
+      end
+
+      it 'finds journal from online ISSN' do
+        content = "Print ISSN: 1234-1234\nOnline ISSN: #{@journal.issn}"
+        parser = EmailParser.new(content: content)
+        expect(parser.journal).to eq(@journal)
+      end
+
+      it 'finds journal from journal code' do
+        content = "Journal Code: #{@journal.code}"
+        parser = EmailParser.new(content: content)
+        expect(parser.journal).to eq(@journal)
+      end
+    end
+
+    describe '#authors' do
+      it 'parses authors with "last, first", separated by semicolons' do
+        content = 'MS Authors: last, first; last2, first2'
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+
+        expect(hash['ms authors']).not_to be_nil
+        expect(hash['ms authors'].size).to eq(2)
+        expect(hash['ms authors'][0]['family_name']).to eq('last')
+      end
+
+      it 'parses authors with "first last, first last", separated by commas' do
+        content = 'MS Authors: first last, first2 last2, first3 last3'
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+
+        expect(hash['ms authors']).not_to be_nil
+        expect(hash['ms authors'].size).to eq(3)
+        expect(hash['ms authors'][0]['family_name']).to eq('last')
+        expect(hash['ms authors'][1]['family_name']).to eq('last2')
+        expect(hash['ms authors'][2]['family_name']).to eq('last3')
+      end
+
+      it 'parses authors with "first last, first last", with "and" at the end' do
+        content = 'MS Authors: first last, first2 last2 and first3 last3'
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+
+        expect(hash['ms authors']).not_to be_nil
+        expect(hash['ms authors'].size).to eq(3)
+        expect(hash['ms authors'][0]['family_name']).to eq('last')
+        expect(hash['ms authors'][1]['family_name']).to eq('last2')
+        expect(hash['ms authors'][2]['family_name']).to eq('last3')
+      end
+
+      it 'parses authors with "first last", keeping suffixes and dropping titles' do
+        content = 'MS Authors: first last, Jr.; first2 last2, PhD; Ms. first3 last3'
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+
+        expect(hash['ms authors']).not_to be_nil
+        expect(hash['ms authors'].size).to eq(3)
+        expect(hash['ms authors'][0]['family_name']).to eq('last, Jr.')
+        expect(hash['ms authors'][1]['family_name']).to eq('last2')
+        expect(hash['ms authors'][2]['given_name']).to eq('first3')
+        expect(hash['ms authors'][2]['family_name']).to eq('last3')
+      end
+
+      it 'parses authors with a single name' do
+        content = 'MS Authors: Elvis Presley and Cher'
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+
+        expect(hash['ms authors']).not_to be_nil
+        expect(hash['ms authors'].size).to eq(2)
+        expect(hash['ms authors'][0]['family_name']).to eq('Presley')
+        expect(hash['ms authors'][1]['given_name']).to eq('')
+        expect(hash['ms authors'][1]['family_name']).to eq('Cher')
+      end
     end
   end
 end

--- a/spec/services/stash_engine/email_parser_spec.rb
+++ b/spec/services/stash_engine/email_parser_spec.rb
@@ -1,0 +1,42 @@
+module StashEngine
+  describe EmailParser do
+    before(:each) do
+    end
+
+    describe '#metadata_hash' do
+      it 'does not return content when there are no parseable values' do
+        content = "Journal: Royal Society Open Science\nSome other garbage"
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+        
+        expect(hash.size).to eq(0)
+      end
+     
+      it 'turns a basic message into a hash' do
+        content = "Journal Name: Royal Society Open Science\nJournal Code: RSOS\nOnline ISSN: 2054-5703"
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+
+        expect(hash['journal code']).to eq('RSOS')
+      end
+
+      it 'turns an HTML message into a hash' do
+        content = "Journal Name: Royal Society Open Science<br/>Journal Code: RSOS<br />Online ISSN: 2054-5703"
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+        
+        expect(hash['journal code']).to eq('RSOS')
+      end
+
+      it 'ignores content after the EndDryadContent tag' do
+        content = "Journal Name: Royal Society Open Science<br/>EndDryadContent<br/>Journal Code: RSOS<br />Online ISSN: 2054-5703"
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+        
+        expect(hash['journal code']).to eq(nil)
+      end
+      
+    end
+  end
+end
+

--- a/spec/services/stash_engine/email_parser_spec.rb
+++ b/spec/services/stash_engine/email_parser_spec.rb
@@ -75,7 +75,7 @@ module StashEngine
       end
 
       it 'finds journal from journal code' do
-        content = "Journal Code: #{@journal.code}"
+        content = "Journal Code: #{@journal.journal_code}"
         parser = EmailParser.new(content: content)
         expect(parser.journal).to eq(@journal)
       end

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -11,21 +11,40 @@ module StashEngine
       return result unless content
 
       parser = EmailParser.new(content: content)
+      parsing_error = check_parsing_errors(parser)
 
-      manu = Manuscript.create(journal: parser.journal,
-                               identifier: parser.identifier,
-                               manuscript_number: parser.manuscript_number,
-                               status: parser.article_status,
-                               metadata: parser.metadata_hash)
+      if !parsing_error
+        manu = Manuscript.create(journal: parser.journal,
+                                 identifier: parser.identifier,
+                                 manuscript_number: parser.manuscript_number,
+                                 status: parser.article_status,
+                                 metadata: parser.metadata_hash)
 
-      if manu.present? && manu.id.present?
-        result.delete_field('error')
-        result[:success?] = true
-        result[:payload] = manu
+        if manu.present? && manu.id.present?
+          result.delete_field('error')
+          result[:success?] = true
+          result[:payload] = manu
+        end
+      else
+        result[:error] = parsing_error
       end
 
       result
     end
 
+    def self.check_parsing_errors(parser)
+      return 'Unable to locate Journal -- either through Journal Code or an ISSN' unless parser.journal
+      return 'Article Status not found' unless parser.article_status
+      unless parser.manuscript_number || parser.identifier
+        return 'Unable to identify manuscript -- either through MS Reference Number or Dryad Data DOI'
+      end
+
+      hash = parser.metadata_hash
+      return 'Unable to create metadata hash' unless hash.present?
+      return 'Unable to parse MS Authors' unless hash['ms authors'].present?
+      return 'Unable to locate MS Title' unless hash['ms title'].present?
+
+      nil
+    end
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -9,7 +9,41 @@ module StashEngine
       result = OpenStruct.new(success?: false, error: 'No content')
       return result unless content
 
-      # convert into lines
+      lines = content_to_lines(content)
+
+      # convert the lines to a hash
+      hash = lines_to_hash(lines)
+      puts "HASH #{hash}"
+      
+      # clean authors (and any other parts of the hash that need cleaning)
+      # TODO clean_authors(hash)      
+
+      # TODO j = find_journal(hash)
+
+      # TODO ident = find_associated_identifier(hash)
+      
+#      mn = Manuscript.new(journal: j,
+#                          identififier: ident,
+#                          manuscript_number: hash['ms reference number'],
+#                          status: hash['article status'],
+#                          metadata: hash)
+
+      if lines.present?
+        result.delete_field('error')
+        result[:success?] = true
+#        result[:payload] = lines
+      end
+
+#      puts "RESULT #{result}"
+      result
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    private
+
+    # Breaks a large string of content into an array of lines,
+    # stripping any material after the ending tag
+    def self.content_to_lines(content)
       lines = content.split(%r{\n+|\r+|<br/>|<br />})
       puts "LIN #{lines}"
       # remove any lines after EndDryadContent
@@ -21,20 +55,39 @@ module StashEngine
           break
         end
       end
-      lines = lines[0..last_dryad_line] if last_dryad_line > 0
-
-      # determine the journal
-      # make a manuscript object for that journal
-
-      if lines.present?
-        result.delete_field('error')
-        result[:success?] = true
-        result[:payload] = lines
-      end
-
-      puts "RESULT #{result}"
-      result
+      lines = lines[0..last_dryad_line - 1] if last_dryad_line > 0
+      lines
     end
-    # rubocop:enable Metrics/MethodLength
+
+    def self.lines_to_hash(lines)
+      # Although journal emails may contain many fields, we only use the fields that are listed here
+      allowed_tags = ["journal code", "journal name", "ms reference number", "ms title", "ms authors", "article status",
+                      "publication doi", "keywords", "dryad data doi"]
+      hash = {}
+      lines.each_with_index do |line, index|
+        puts "-- ln #{index} -- #{line}"
+        next unless line.include?(':')
+        colon_index = line.index(':')
+        tag = line[0..colon_index-1].downcase
+        # if the line starts with a valid tag, add it to the hash
+        if allowed_tags.include?(tag)
+          value = line[colon_index+1..].strip
+          puts "  -- tag |#{tag}|#{value}|"
+          hash[tag] = value
+        end
+        # if the line starts the abstract, add all of the remaining lines, and break from the loop
+        if tag == "abstract"
+          value = line[colon_index+1..]
+          remaining_lines = lines[index+1..]
+          value += ' ' + remaining_lines.join(' ') if remaining_lines.present?
+          puts "  -- tag |#{tag}|#{value}|"
+          hash[tag] = value.strip
+          break
+        end
+        
+      end
+      hash
+    end
+    
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -3,5 +3,38 @@ module StashEngine
     belongs_to :journal
     belongs_to :identifier, optional: true
 
+    # rubocop:disable Metrics/MethodLength
+    def self.from_message_content(content:)
+      puts("CON #{content}")
+      result = OpenStruct.new(success?: false, error: 'No content')
+      return result unless content
+
+      # convert into lines
+      lines = content.split(%r{\n+|\r+|<br/>|<br />})
+      puts "LIN #{lines}"
+      # remove any lines after EndDryadContent
+      last_dryad_line = 0
+      lines.each_with_index do |val, index|
+        puts "#{val} => #{index}"
+        if val.include?('EndDryadContent')
+          last_dryad_line = index
+          break
+        end
+      end
+      lines = lines[0..last_dryad_line] if last_dryad_line > 0
+
+      # determine the journal
+      # make a manuscript object for that journal
+
+      if lines.present?
+        result.delete_field('error')
+        result[:success?] = true
+        result[:payload] = lines
+      end
+
+      puts "RESULT #{result}"
+      result
+    end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -3,90 +3,27 @@ module StashEngine
     belongs_to :journal
     belongs_to :identifier, optional: true
 
-    # rubocop:disable Metrics/MethodLength
+    # Create a new Manuscript from the content of an email message
     def self.from_message_content(content:)
       puts("CON #{content}")
       result = OpenStruct.new(success?: false, error: 'No content')
       return result unless content
-
-      lines = content_to_lines(content)
-
-      # convert the lines to a hash
-      hash = lines_to_hash(lines)
-      puts "HASH #{hash}"
       
-      # clean authors (and any other parts of the hash that need cleaning)
-      # TODO clean_authors(hash)      
-
-      # TODO j = find_journal(hash)
-
-      # TODO ident = find_associated_identifier(hash)
+      parser = EmailParser.new(content: content)
       
-#      mn = Manuscript.new(journal: j,
-#                          identififier: ident,
-#                          manuscript_number: hash['ms reference number'],
-#                          status: hash['article status'],
-#                          metadata: hash)
-
-      if lines.present?
+      manu = Manuscript.create(journal: parser.journal,
+                               identifier: parser.identifier,
+                               manuscript_number: parser.manuscript_number,
+                               status: parser.article_status,
+                               metadata: parser.metadata_hash)
+      
+      if manu.present?
         result.delete_field('error')
         result[:success?] = true
-#        result[:payload] = lines
+        result[:payload] = manu
       end
-
-#      puts "RESULT #{result}"
+      
       result
-    end
-    # rubocop:enable Metrics/MethodLength
-
-    private
-
-    # Breaks a large string of content into an array of lines,
-    # stripping any material after the ending tag
-    def self.content_to_lines(content)
-      lines = content.split(%r{\n+|\r+|<br/>|<br />})
-      puts "LIN #{lines}"
-      # remove any lines after EndDryadContent
-      last_dryad_line = 0
-      lines.each_with_index do |val, index|
-        puts "#{val} => #{index}"
-        if val.include?('EndDryadContent')
-          last_dryad_line = index
-          break
-        end
-      end
-      lines = lines[0..last_dryad_line - 1] if last_dryad_line > 0
-      lines
-    end
-
-    def self.lines_to_hash(lines)
-      # Although journal emails may contain many fields, we only use the fields that are listed here
-      allowed_tags = ["journal code", "journal name", "ms reference number", "ms title", "ms authors", "article status",
-                      "publication doi", "keywords", "dryad data doi"]
-      hash = {}
-      lines.each_with_index do |line, index|
-        puts "-- ln #{index} -- #{line}"
-        next unless line.include?(':')
-        colon_index = line.index(':')
-        tag = line[0..colon_index-1].downcase
-        # if the line starts with a valid tag, add it to the hash
-        if allowed_tags.include?(tag)
-          value = line[colon_index+1..].strip
-          puts "  -- tag |#{tag}|#{value}|"
-          hash[tag] = value
-        end
-        # if the line starts the abstract, add all of the remaining lines, and break from the loop
-        if tag == "abstract"
-          value = line[colon_index+1..]
-          remaining_lines = lines[index+1..]
-          value += ' ' + remaining_lines.join(' ') if remaining_lines.present?
-          puts "  -- tag |#{tag}|#{value}|"
-          hash[tag] = value.strip
-          break
-        end
-        
-      end
-      hash
     end
     
   end

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -1,0 +1,7 @@
+module StashEngine
+  class Manuscript < ApplicationRecord
+    belongs_to :journal
+    belongs_to :identifier, optional: true
+
+  end
+end

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -2,29 +2,30 @@ module StashEngine
   class Manuscript < ApplicationRecord
     belongs_to :journal
     belongs_to :identifier, optional: true
+    serialize :metadata
 
     # Create a new Manuscript from the content of an email message
     def self.from_message_content(content:)
       puts("CON #{content}")
       result = OpenStruct.new(success?: false, error: 'No content')
       return result unless content
-      
+
       parser = EmailParser.new(content: content)
-      
+
       manu = Manuscript.create(journal: parser.journal,
                                identifier: parser.identifier,
                                manuscript_number: parser.manuscript_number,
                                status: parser.article_status,
                                metadata: parser.metadata_hash)
-      
-      if manu.present?
+
+      if manu.present? && manu.id.present?
         result.delete_field('error')
         result[:success?] = true
         result[:payload] = manu
       end
-      
+
       result
     end
-    
+
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -6,7 +6,6 @@ module StashEngine
 
     # Create a new Manuscript from the content of an email message
     def self.from_message_content(content:)
-      puts("CON #{content}")
       result = OpenStruct.new(success?: false, error: 'No content')
       return result unless content
 

--- a/stash/stash_engine/app/services/stash_engine/email_parser.rb
+++ b/stash/stash_engine/app/services/stash_engine/email_parser.rb
@@ -1,30 +1,20 @@
 module StashEngine
 
+  # rubocop:disable Metrics/ClassLength, Metrics/MethodLength
   class EmailParser
+    attr_reader :journal, :identifier
 
     def initialize(content:)
       @content = content
       parse
-    end      
-
-    def journal
-      #TODO
-      nil
-    end
-
-    def identifier
-      #TODO
-      nil
     end
 
     def manuscript_number
-      #TODO
-      nil
+      @hash['ms reference number']
     end
 
     def article_status
-      #TODO
-      nil
+      @hash['article status']
     end
 
     def metadata_hash
@@ -32,71 +22,71 @@ module StashEngine
     end
 
     private
-    
+
     def parse
-      @lines = content_to_lines
-      
-      # convert the lines to a hash
-      @hash = lines_to_hash
-      puts "HASH #{hash}"
-      
+      parse_content_to_lines
+      lines_to_hash
+      puts "HASH #{@hash}"
+
+      find_journal
+      puts "JOURNAL #{@journal}"
+
       # clean authors (and any other parts of the hash that need cleaning)
-      # TODO clean_authors(hash)      
-      
-      j = find_journal
-      puts "JOURNAL #{j}"
-      
-      # TODO ident = find_associated_identifier(hash)
+      clean_authors
+      puts "AUTH #{@hash['ms authors']}"
+
+      # TODO: ident = find_associated_identifier(hash)
     end
 
     # Breaks a large string of content into an array of lines,
     # stripping any material after the ending tag
-    def content_to_lines
-      lines = @content.split(%r{\n+|\r+|<br/>|<br />|<BR/>|<BR />})
-      puts "LIN #{lines}"
+    def parse_content_to_lines
+      @lines = @content.split(%r{\n+|\r+|<br/>|<br />|<BR/>|<BR />})
+      puts "LIN #{@lines}"
       # remove any lines after EndDryadContent
       last_dryad_line = 0
-      lines.each_with_index do |val, index|
+      @lines.each_with_index do |val, index|
         puts "#{val} => #{index}"
         if val.include?('EndDryadContent')
           last_dryad_line = index
           break
         end
       end
-      lines = lines[0..last_dryad_line - 1] if last_dryad_line > 0
-      @lines = lines
+      @lines = @lines[0..last_dryad_line - 1] if last_dryad_line > 0
+      @lines
     end
-    
+
     def lines_to_hash
       # Although journal emails may contain many fields, we only use the fields that are listed here
-      allowed_tags = ["journal code", "journal name", "ms reference number", "ms title", "ms authors", "article status",
-                      "publication doi", "keywords", "dryad data doi", "print issn", "online issn"]
-      @hash = {}
+      allowed_tags = ['journal code', 'journal name', 'ms reference number', 'ms title', 'ms authors', 'article status',
+                      'publication doi', 'keywords', 'dryad data doi', 'print issn', 'online issn']
+      @hash = {}.with_indifferent_access
       @lines.each_with_index do |line, index|
         puts "-- ln #{index} -- #{line}"
         next unless line.include?(':')
+
         colon_index = line.index(':')
-        tag = line[0..colon_index-1].downcase
+        tag = line[0..colon_index - 1].downcase
         # if the line starts with a valid tag, add it to the hash
         if allowed_tags.include?(tag)
-          value = line[colon_index+1..].strip
+          value = line[colon_index + 1..].strip
           puts "  -- tag |#{tag}|#{value}|"
           @hash[tag] = value
         end
         # if the line starts the abstract, add all of the remaining lines, and break from the loop
-        if tag == "abstract"
-          value = line[colon_index+1..]
-          remaining_lines = @lines[index+1..]
-          value += ' ' + remaining_lines.join(' ') if remaining_lines.present?
-          puts "  -- tag |#{tag}|#{value}|"
-          @hash[tag] = value.strip
-          break
-        end
-        
+        next unless tag == 'abstract'
+
+        value = line[colon_index + 1..]
+        remaining_lines = @lines[index + 1..]
+        value += " #{remaining_lines.join(' ')}" if remaining_lines.present?
+        puts "  -- tag |#{tag}|#{value}|"
+        @hash[tag] = value.strip
+        break
+
       end
       @hash
     end
-    
+
     def find_journal
       puts "HASH #{@hash}"
       @journal = nil
@@ -104,11 +94,11 @@ module StashEngine
       @journal = StashEngine::Journal.where(journal_code: @hash['journal code'].downcase).first if @hash['journal code']
       puts "    -- j1 #{@journal}"
       return if @journal
-            
+
       @journal = StashEngine::Journal.where(issn: @hash['print issn']).first if @hash['print issn']
       puts "    -- j2 #{@journal}"
       return if @journal
-      
+
       @journal = StashEngine::Journal.where(issn: @hash['online issn']).first if @hash['online issn']
       puts "    -- j3 #{@journal}"
       return if @journal
@@ -119,5 +109,81 @@ module StashEngine
       @journal
     end
 
+    # Convert the author string into an array of names
+    # Author lists generally come as either "last, first; last, first"
+    # or as "first last, first last and first last" (sometimes with the Oxford comma before the 'and' token)
+    def clean_authors
+      author_string = @hash['ms authors']
+      return unless author_string
+
+      authors = []
+
+      # first check to see if the authors are semicolon-separated
+      split_string = author_string.split(';')
+      puts "SPLIT #{split_string}"
+
+      # if it didn't have semicolons, it must have commas
+      if split_string.size == 1
+        split_string = author_string.split(',')
+
+        # although, if there was only one author and it was listed as lastname, firstname, it would have a comma too...
+        if split_string.length == 2 && !split_string[1].include?(' and ')
+          authors << [split_string[0], split_string[1]]
+          split_string = []
+        end
+      end
+
+      split_string.each do |auth|
+        if auth.include?(' and ')
+          # It's the end of the list, so we parse both names
+          two_auths = auth.split(' and ')
+          authors << parse_author_name(two_auths[0])
+          authors << parse_author_name(two_auths[1])
+        else
+          authors << parse_author_name(auth)
+        end
+      end
+
+      @hash['ms authors'] = authors
+    end
+
+    # Parse the name of a single author
+    # @return {family_name:, given_name:}]
+    def parse_author_name(auth)
+      # Remove any leading title, like Dr., Mrs.
+      auth.strip!
+      auth.gsub!(/^[DM]+r*s*\.*\s+/, '')
+      suffix = ''
+
+      # is there a comma in the name?
+      # it could either be lastname, firstname, or firstname lastname, title
+      # rubocop:disable Style/CaseLikeIf
+      comma_match = auth.match(/^(.+),\s*(.+)$/)
+      if comma_match
+        if comma_match[2].match(/(Jr\.*|Sr\.*|III)/)
+          # if it's a suffix situation, then part 1 is "firstname lastname"
+          # the last name will be the last word in group 1 + ", " + suffix
+          suffix = ", #{comma_match[2].strip}"
+          auth = comma_match[1]
+        elsif comma_match[2].match(/(Ph|J)\.*D\.*|M\.*[DAS]c*\.*/)
+          # if it's a title situation, throw the title away and assume the part before is "firstname lastname"
+          auth = comma_match[1]
+        else
+          # it's simply "lastname, firstname", so return it in that order
+          return { family_name: comma_match[1], given_name: comma_match[2] }.with_indifferent_access
+        end
+      end
+      # rubocop:enable Style/CaseLikeIf
+
+      space_match = auth.match(/^(.+) +(.*)$/)
+      if space_match
+        { family_name: "#{space_match[2]}#{suffix}", given_name: space_match[1] }.with_indifferent_access
+      else
+        # there is only one word in the name: assign it to the familyName
+        { family_name: auth, given_name: '' }.with_indifferent_access
+      end
+    end
+
   end
 end
+# rubocop:enable Metrics/ClassLength, Metrics/MethodLength

--- a/stash/stash_engine/app/services/stash_engine/email_parser.rb
+++ b/stash/stash_engine/app/services/stash_engine/email_parser.rb
@@ -1,0 +1,123 @@
+module StashEngine
+
+  class EmailParser
+
+    def initialize(content:)
+      @content = content
+      parse
+    end      
+
+    def journal
+      #TODO
+      nil
+    end
+
+    def identifier
+      #TODO
+      nil
+    end
+
+    def manuscript_number
+      #TODO
+      nil
+    end
+
+    def article_status
+      #TODO
+      nil
+    end
+
+    def metadata_hash
+      @hash
+    end
+
+    private
+    
+    def parse
+      @lines = content_to_lines
+      
+      # convert the lines to a hash
+      @hash = lines_to_hash
+      puts "HASH #{hash}"
+      
+      # clean authors (and any other parts of the hash that need cleaning)
+      # TODO clean_authors(hash)      
+      
+      j = find_journal
+      puts "JOURNAL #{j}"
+      
+      # TODO ident = find_associated_identifier(hash)
+    end
+
+    # Breaks a large string of content into an array of lines,
+    # stripping any material after the ending tag
+    def content_to_lines
+      lines = @content.split(%r{\n+|\r+|<br/>|<br />})
+      puts "LIN #{lines}"
+      # remove any lines after EndDryadContent
+      last_dryad_line = 0
+      lines.each_with_index do |val, index|
+        puts "#{val} => #{index}"
+        if val.include?('EndDryadContent')
+          last_dryad_line = index
+          break
+        end
+      end
+      lines = lines[0..last_dryad_line - 1] if last_dryad_line > 0
+      @lines = lines
+    end
+    
+    def lines_to_hash
+      # Although journal emails may contain many fields, we only use the fields that are listed here
+      allowed_tags = ["journal code", "journal name", "ms reference number", "ms title", "ms authors", "article status",
+                      "publication doi", "keywords", "dryad data doi", "print issn", "online issn"]
+      @hash = {}
+      @lines.each_with_index do |line, index|
+        puts "-- ln #{index} -- #{line}"
+        next unless line.include?(':')
+        colon_index = line.index(':')
+        tag = line[0..colon_index-1].downcase
+        # if the line starts with a valid tag, add it to the hash
+        if allowed_tags.include?(tag)
+          value = line[colon_index+1..].strip
+          puts "  -- tag |#{tag}|#{value}|"
+          @hash[tag] = value
+        end
+        # if the line starts the abstract, add all of the remaining lines, and break from the loop
+        if tag == "abstract"
+          value = line[colon_index+1..]
+          remaining_lines = @lines[index+1..]
+          value += ' ' + remaining_lines.join(' ') if remaining_lines.present?
+          puts "  -- tag |#{tag}|#{value}|"
+          @hash[tag] = value.strip
+          break
+        end
+        
+      end
+      @hash
+    end
+    
+    def find_journal
+      puts "HASH #{@hash}"
+      @journal = nil
+      # prefer finding by journal code, fallback to ISSN or title
+      @journal = StashEngine::Journal.where(journal_code: @hash['journal code'].downcase).first if @hash['journal code']
+      puts "    -- j1 #{@journal}"
+      return if @journal
+            
+      @journal = StashEngine::Journal.where(issn: @hash['print issn']).first if @hash['print issn']
+      puts "    -- j2 #{@journal}"
+      return if @journal
+      
+      @journal = StashEngine::Journal.where(issn: @hash['online issn']).first if @hash['online issn']
+      puts "    -- j3 #{@journal}"
+      return if @journal
+
+      @journal = StashEngine::Journal.where(title: @hash['journal name']).first if @hash['journal name']
+
+      puts "    -- j4 #{@journal}"
+      @journal
+    end
+
+  end
+end

--- a/stash/stash_engine/app/services/stash_engine/email_parser.rb
+++ b/stash/stash_engine/app/services/stash_engine/email_parser.rb
@@ -60,6 +60,7 @@ module StashEngine
       # Although journal emails may contain many fields, we only use the fields that are listed here
       allowed_tags = ['journal code', 'journal name', 'ms reference number', 'ms title', 'ms authors', 'article status',
                       'publication doi', 'keywords', 'dryad data doi', 'print issn', 'online issn']
+      downcase_tags = ['journal code', 'article status', 'publication doi', 'dryad data doi']
       @hash = {}.with_indifferent_access
       @lines.each_with_index do |line, index|
         puts "-- ln #{index} -- #{line}"
@@ -70,6 +71,7 @@ module StashEngine
         # if the line starts with a valid tag, add it to the hash
         if allowed_tags.include?(tag)
           value = line[colon_index + 1..].strip
+          value.downcase! if downcase_tags.include?(tag)
           puts "  -- tag |#{tag}|#{value}|"
           @hash[tag] = value
         end
@@ -152,7 +154,7 @@ module StashEngine
 
         # although, if there was only one author and it was listed as lastname, firstname, it would have a comma too...
         if split_string.length == 2 && !split_string[1].include?(' and ')
-          authors << [split_string[0], split_string[1]]
+          authors << [split_string[0].strip, split_string[1].strip]
           split_string = []
         end
       end
@@ -194,14 +196,14 @@ module StashEngine
           auth = comma_match[1]
         else
           # it's simply "lastname, firstname", so return it in that order
-          return { family_name: comma_match[1], given_name: comma_match[2] }.with_indifferent_access
+          return { family_name: comma_match[1].strip, given_name: comma_match[2].strip }.with_indifferent_access
         end
       end
       # rubocop:enable Style/CaseLikeIf
 
       space_match = auth.match(/^(.+) +(.*)$/)
       if space_match
-        { family_name: "#{space_match[2]}#{suffix}", given_name: space_match[1] }.with_indifferent_access
+        { family_name: "#{space_match[2].strip}#{suffix}", given_name: space_match[1].strip }.with_indifferent_access
       else
         # there is only one word in the name: assign it to the familyName
         { family_name: auth, given_name: '' }.with_indifferent_access

--- a/stash/stash_engine/app/services/stash_engine/email_parser.rb
+++ b/stash/stash_engine/app/services/stash_engine/email_parser.rb
@@ -42,11 +42,9 @@ module StashEngine
     # stripping any material after the ending tag
     def parse_content_to_lines
       @lines = @content.split(%r{\n+|\r+|<br/>|<br />|<BR/>|<BR />})
-      puts "LIN #{@lines}"
       # remove any lines after EndDryadContent
       last_dryad_line = 0
       @lines.each_with_index do |val, index|
-        puts "#{val} => #{index}"
         if val.include?('EndDryadContent')
           last_dryad_line = index
           break
@@ -63,7 +61,6 @@ module StashEngine
       downcase_tags = ['journal code', 'article status', 'publication doi', 'dryad data doi']
       @hash = {}.with_indifferent_access
       @lines.each_with_index do |line, index|
-        puts "-- ln #{index} -- #{line}"
         next unless line.include?(':')
 
         colon_index = line.index(':')
@@ -72,7 +69,6 @@ module StashEngine
         if allowed_tags.include?(tag)
           value = line[colon_index + 1..].strip
           value.downcase! if downcase_tags.include?(tag)
-          puts "  -- tag |#{tag}|#{value}|"
           @hash[tag] = value
         end
         # if the line starts the abstract, add all of the remaining lines, and break from the loop
@@ -81,7 +77,6 @@ module StashEngine
         value = line[colon_index + 1..]
         remaining_lines = @lines[index + 1..]
         value += " #{remaining_lines.join(' ')}" if remaining_lines.present?
-        puts "  -- tag |#{tag}|#{value}|"
         @hash[tag] = value.strip
         break
 
@@ -90,24 +85,19 @@ module StashEngine
     end
 
     def find_journal
-      puts "HASH #{@hash}"
       @journal = nil
       # prefer finding by journal code, fallback to ISSN or title
       @journal = StashEngine::Journal.where(journal_code: @hash['journal code'].downcase).first if @hash['journal code']
-      puts "    -- j1 #{@journal}"
       return if @journal
 
       @journal = StashEngine::Journal.where(issn: @hash['print issn']).first if @hash['print issn']
-      puts "    -- j2 #{@journal}"
       return if @journal
 
       @journal = StashEngine::Journal.where(issn: @hash['online issn']).first if @hash['online issn']
-      puts "    -- j3 #{@journal}"
       return if @journal
 
       @journal = StashEngine::Journal.where(title: @hash['journal name']).first if @hash['journal name']
 
-      puts "    -- j4 #{@journal}"
       @journal
     end
 
@@ -115,7 +105,6 @@ module StashEngine
       @identifier = nil
       # prefer finding by data doi
       data_doi = @hash['dryad data doi']
-      puts "DATA DOI #{data_doi}"
       if data_doi
         data_doi.downcase!
         data_doi.sub!(/^doi:/, '')
@@ -146,7 +135,6 @@ module StashEngine
 
       # first check to see if the authors are semicolon-separated
       split_string = author_string.split(';')
-      puts "SPLIT #{split_string}"
 
       # if it didn't have semicolons, it must have commas
       if split_string.size == 1

--- a/stash/stash_engine/app/services/stash_engine/email_parser.rb
+++ b/stash/stash_engine/app/services/stash_engine/email_parser.rb
@@ -52,7 +52,7 @@ module StashEngine
     # Breaks a large string of content into an array of lines,
     # stripping any material after the ending tag
     def content_to_lines
-      lines = @content.split(%r{\n+|\r+|<br/>|<br />})
+      lines = @content.split(%r{\n+|\r+|<br/>|<br />|<BR/>|<BR />})
       puts "LIN #{lines}"
       # remove any lines after EndDryadContent
       last_dryad_line = 0

--- a/stash/stash_engine/db/migrate/20210412142929_create_stash_engine_manuscripts.rb
+++ b/stash/stash_engine/db/migrate/20210412142929_create_stash_engine_manuscripts.rb
@@ -1,0 +1,12 @@
+class CreateStashEngineManuscripts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :stash_engine_manuscripts do |t|
+      t.belongs_to :journal
+      t.belongs_to :identifier, optional: true
+      t.string :manuscript_number
+      t.string :status
+      t.text :metadata, limit: 16.megabytes - 1
+      t.timestamps
+    end
+  end
+end

--- a/stash/stash_engine/db/migrate/20210415204844_add_code_to_journals.rb
+++ b/stash/stash_engine/db/migrate/20210415204844_add_code_to_journals.rb
@@ -1,0 +1,5 @@
+class AddCodeToJournals < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stash_engine_journals, :journal_code, :string
+  end
+end

--- a/stash/stash_engine/lib/stash/google/journal_gmail.rb
+++ b/stash/stash_engine/lib/stash/google/journal_gmail.rb
@@ -110,10 +110,10 @@ module Stash
           result = StashEngine::Manuscript.from_message_content(content: content)
           if result.success?
             puts "-- created #{result.payload}"
-          # TODO-reinstate-when-tested  remove_processing_label(message: m)
+            remove_processing_label(message: m)
           else
             puts "-- ERROR #{result.error} -- Adding error label to #{m.id}"
-            # TODO-reinstate add_error_label(message: m)
+            add_error_label(message: m)
           end
         end
       end

--- a/stash/stash_engine/lib/tasks/migration.rake
+++ b/stash/stash_engine/lib/tasks/migration.rake
@@ -23,8 +23,13 @@ namespace :dryad_migration do
     end
   end
 
-  desc 'Migrate content from the v1 journal module'
+  desc 'DEPRECATED -- Migrate content from the v1 journal module'
   task migrate_journal_metadata: :environment do
+    puts 'WARNING! This task is deprecated --- data in the v1 server is no longer up to date, ' \
+         'so please do not import it into a current Dryad production system! ' \
+         'You will have 1 minute to cancel before this script proceeds.'
+    sleep(1.minute)
+
     File.foreach('journalISSNs.txt') do |issn|
       issn = issn.strip
       url = "#{APP_CONFIG.old_dryad_url}/api/v1/journals/#{issn}"

--- a/stash/stash_engine/lib/tasks/migration.rake
+++ b/stash/stash_engine/lib/tasks/migration.rake
@@ -7,6 +7,22 @@ require 'database_cleaner'
 
 # rubocop:disable Metrics/BlockLength
 namespace :dryad_migration do
+  desc 'Import journal codes from a local file'
+  task import_journal_codes: :environment do
+    File.foreach('journal_codes.csv') do |line|
+      code, issn = line.split(',')
+      code.downcase!
+      issn.chomp!
+      puts "code=#{code} issn=#{issn}"
+      journal = StashEngine::Journal.where(issn: issn).first
+      if journal
+        journal.journal_code = code
+        journal.save
+        puts "  -- #{code} saved to #{journal.title}"
+      end
+    end
+  end
+
   desc 'Migrate content from the v1 journal module'
   task migrate_journal_metadata: :environment do
     File.foreach('journalISSNs.txt') do |issn|

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -355,6 +355,11 @@ namespace :journal_email do
   task validate_gmail_connection: :environment do
     Stash::Google::JournalGMail.validate_gmail_connection
   end
+
+  desc 'Process all messages in the GMail account that have the target label'
+  task process: :environment do
+    Stash::Google::JournalGMail.process
+  end
 end
 
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1190 and https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1189

This PR adds a `Manuscript` model to Dryad, and parses messages from GMail to populate the Manuscript objects. It does not yet do anything with the resultant Manuscript objects.

To test:
- Run the database migration
- Update the Journals table to include journal codes: Copy the file journal_codes.csv from the /tmp directory on any Dryad server into the directory where you run rake tasks, and run `rails dryad_migration:import_journal_codes` (I decided to deprecate the old journal import process, since the journal metadata in the v1 server is no longer correct, and we do not want to overwrite the entirety of the journal table)
- Ensure that a GMail token is present, by running `rails journal_email:validate_gmail_connection` (as described in https://github.com/CDL-Dryad/dryad-app/pull/432)
- Run the parsing process with `rails journal_email:process`. This process will only read messages in journal-submit-app@datadryad.org that are flagged with the `dev-journal-submit` label.
- Inspect the resultant `Manuscript` objects to ensure they contain the correct metadata.