### PR TITLE
Modifications to DataONE tenant info

### DIFF
--- a/config/tenants/dataone.yml
+++ b/config/tenants/dataone.yml
@@ -49,7 +49,7 @@ production:
   manager_email: ["Daniella.Lowenberg@ucop.edu"]
   repository:
     domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
+    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/dataone_dash"
     username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
     password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:


### PR DESCRIPTION
We met with the Merritt team yesterday and it turns out the DataONE merritt collections are already using the Dryad S3 bucket on their side for storage.  However it is still a separate collection in Merritt.  They were understandably reluctant to move those datasets into the Merritt Dryad collection since that involves a bunch of work for no real difference in storage underneath.

We talked over the reasons for the migration of the UC collections as twofold 1) moving storage to be under Dryad for billing and 2) to simplify management  of all the separate Merritt accounts for different tenants into one account.

Eric was able to give the standard Dryad user access to DataONE content so we can still use the same user credentials, though the collection (endpoint) is still different than all the other tenants which is annoying but probably workable.

