### PR TITLE
React uploads remove files

### DIFF
--- a/spec/features/stash_engine/review_and_submit_spec.rb
+++ b/spec/features/stash_engine/review_and_submit_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature 'ReviewAndSubmit', type: :feature, js: true do
 
     it 'shows right links to edit files' do
       click_link('Review and Submit')
+      sleep 3
       expect(page).to have_link('Edit Files', href: '/stash/resources/1/upload', count: 2)
     end
   end

--- a/spec/features/stash_engine/review_and_submit_spec.rb
+++ b/spec/features/stash_engine/review_and_submit_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.feature 'ReviewAndSubmit', type: :feature, js: true do
+
+  include MerrittHelper
+  include DatasetHelper
+  include DatabaseHelper
+  include Mocks::Datacite
+  include Mocks::Repository
+  include Mocks::RSolr
+  include Mocks::Ror
+  include Mocks::Stripe
+  include Mocks::Aws
+
+  before(:each) do
+    mock_repository!
+    mock_solr!
+    mock_ror!
+    mock_datacite!
+    mock_stripe!
+    mock_aws!
+    ignore_zenodo!
+    @author = create(:user, tenant_id: 'dryad')
+
+    ActionMailer::Base.deliveries = []
+
+    # Sign in and create a new dataset
+    sign_in(@author)
+    visit root_path
+    click_link 'My Datasets'
+    start_new_dataset
+    # fill_required_fields # don't need this if we're not checking metadata and just files
+  end
+
+  describe 'Review Files' do
+    before(:each) do
+      navigate_to_upload
+      @resource_id = page.current_path.match(%r{resources/(\d+)/up})[1].to_i
+      @resource = StashEngine::Resource.find(@resource_id)
+      @file1 = create_data_file(@resource_id)
+      @file2 = create_software_file(@resource_id)
+      click_link('Upload Files') # click on it to refresh the page and show the table with the file
+    end
+
+    it 'shows right links to edit files' do
+      click_link('Review and Submit')
+      expect(page).to have_link('Edit Files', href: '/stash/resources/1/upload', count: 2)
+    end
+  end
+
+end

--- a/spec/features/stash_engine/upload_files_spec.rb
+++ b/spec/features/stash_engine/upload_files_spec.rb
@@ -177,7 +177,6 @@ RSpec.feature 'UploadFiles', type: :feature, js: true do
       expect(page).to have_content(/^\b#{@file_name1}\b/, count: 2)
     end
 
-
     it 'shows only non-deleted files after validating URLs' do
       @manifest_deleted = create_data_file(@resource_id)
       @manifest_deleted.update(

--- a/spec/fixtures/funbar.txt
+++ b/spec/fixtures/funbar.txt
@@ -1,0 +1,1 @@
+Text file

--- a/spec/responses/stash_engine/software_files_controller_spec.rb
+++ b/spec/responses/stash_engine/software_files_controller_spec.rb
@@ -54,7 +54,10 @@ module StashEngine
 
     describe '#validate_urls' do
       before(:each) do
-        create_stub_requests
+        @valid_manifest_url = 'http://example.org/funbar.txt'
+        @invalid_manifest_url = 'http://example.org/foobar.txt'
+        create_valid_stub_request(@valid_manifest_url)
+        create_invalid_stub_request(@invalid_manifest_url)
       end
 
       it 'returns json when request with format html to validate urls' do

--- a/spec/responses/stash_engine/supp_files_controller_spec.rb
+++ b/spec/responses/stash_engine/supp_files_controller_spec.rb
@@ -54,7 +54,10 @@ module StashEngine
 
     describe '#upload_manifest' do
       before(:each) do
-        create_stub_requests
+        @valid_manifest_url = 'http://example.org/funbar.txt'
+        @invalid_manifest_url = 'http://example.org/foobar.txt'
+        create_valid_stub_request(@valid_manifest_url)
+        create_invalid_stub_request(@invalid_manifest_url)
       end
 
       it 'returns json when request with format html to validate urls' do

--- a/spec/support/helpers/database_helper.rb
+++ b/spec/support/helpers/database_helper.rb
@@ -19,4 +19,46 @@ module DatabaseHelper
     new_res.curation_activities.update_all(user_id: user.id) if user
     new_res.save!
   end
+
+  def create_data_file(resource_id)
+    StashEngine::DataFile.create(
+      {
+        original_filename: Faker::File.file_name(dir: '', directory_separator: ''),
+        resource_id: resource_id,
+        upload_file_name: 'example_data_file.csv',
+        upload_content_type: 'text/plain',
+        upload_file_size: 31_726,
+        status_code: 200,
+        file_state: 'created'
+      }
+    )
+  end
+
+  def create_software_file(resource_id)
+    StashEngine::SoftwareFile.create(
+      {
+        original_filename: Faker::File.file_name(dir: '', directory_separator: ''),
+        resource_id: resource_id,
+        upload_file_name: 'example_software_file.csv',
+        upload_content_type: 'text/plain',
+        upload_file_size: 31_726,
+        status_code: 200,
+        file_state: 'created'
+      }
+    )
+  end
+
+  def create_supplemental_file(resource_id)
+    StashEngine::SuppFile.create(
+      {
+        original_filename: Faker::File.file_name(dir: '', directory_separator: ''),
+        resource_id: resource_id,
+        upload_file_name: 'example_supp_file.csv',
+        upload_content_type: 'text/plain',
+        upload_file_size: 31_726,
+        status_code: 200,
+        file_state: 'created'
+      }
+    )
+  end
 end

--- a/spec/support/helpers/dataset_helper.rb
+++ b/spec/support/helpers/dataset_helper.rb
@@ -1,41 +1,5 @@
 module DatasetHelper
 
-  def create_data_file(resource_id)
-    StashEngine::DataFile.create(
-      {
-        resource_id: resource_id,
-        upload_file_name: 'example_data_file.csv',
-        upload_content_type: 'text/plain',
-        upload_file_size: 31_726,
-        file_state: 'created'
-      }
-    )
-  end
-
-  def create_software_file(resource_id)
-    StashEngine::SoftwareFile.create(
-      {
-        resource_id: resource_id,
-        upload_file_name: 'example_software_file.csv',
-        upload_content_type: 'text/plain',
-        upload_file_size: 31_726,
-        file_state: 'created'
-      }
-    )
-  end
-
-  def create_supplemental_file(resource_id)
-    StashEngine::SuppFile.create(
-      {
-        resource_id: resource_id,
-        upload_file_name: 'example_supp_file.csv',
-        upload_content_type: 'text/plain',
-        upload_file_size: 31_726,
-        file_state: 'created'
-      }
-    )
-  end
-
   def start_new_dataset
     click_button 'Start New Dataset'
     expect(page).to have_content('Describe Dataset', wait: 15)
@@ -142,7 +106,6 @@ module DatasetHelper
     find('#agree_to_payment').click
   end
 
-  # rubocop:disable Metrics/AbcSize
   def attach_files
     # Workaround to expose input file type elements
     page.execute_script('$("#data").removeClass()')
@@ -152,15 +115,7 @@ module DatasetHelper
     attach_file('data', "#{Rails.root}/spec/fixtures/file_example_ODS_10.ods")
     attach_file('software', "#{Rails.root}/spec/fixtures/file_example_ODS_100.ods")
     attach_file('supp', "#{Rails.root}/spec/fixtures/file_example_ODS_1000.ods")
-    expect(page).to have_content('file_example_ODS_10.ods')
-    expect(page).to have_content('data', count: 1)
-    expect(page).to have_content('file_example_ODS_100.ods')
-    expect(page).to have_content('software', count: 1)
-    expect(page).to have_content('file_example_ODS_1000.ods')
-    expect(page).to have_content('supplemental', count: 1)
-    expect(page).to have_content('Pending', count: 3)
   end
-  # rubocop:enable Metrics/AbcSize
 
   def build_stub_requests(valid, invalid)
     stub_request(:head, valid)

--- a/spec/support/helpers/generic_files_helper.rb
+++ b/spec/support/helpers/generic_files_helper.rb
@@ -42,18 +42,18 @@ module GenericFilesHelper
     expect(body['new_file'].to_json).to eql(new_file.to_json)
   end
 
-  def create_stub_requests
-    @resource.current_resource_state.update(resource_state: 'in_progress')
-
-    stub_request(:head, 'http://example.org/funbar.txt')
+  def create_valid_stub_request(url)
+    stub_request(:head, url)
       .with(
         headers: {
           'Accept' => '*/*'
         }
       )
-      .to_return(status: 200, headers: { 'Content-Length': 37_221, 'Content-Type': 'text/html' })
+      .to_return(status: 200, headers: { 'Content-Length': 37_221, 'Content-Type': 'text/plain' })
+  end
 
-    stub_request(:head, 'http://example.org/foobar.txt')
+  def create_invalid_stub_request(url)
+    stub_request(:head, url)
       .with(
         headers: {
           'Accept' => '*/*'

--- a/stash/stash-notifier/.gitignore
+++ b/stash/stash-notifier/.gitignore
@@ -1,3 +1,4 @@
 # stop the log, json and pid files from being committed for harvester
 log/*.log
 state/*.json
+state/local.pid

--- a/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
@@ -59,7 +59,7 @@
 
     <div class="c-review-files">
         <%= render partial: "stash_engine/data_files/show_merritt", locals: { resource: @resource } %>
-        <%= link_to 'Edit Files', stash_engine.upload_resource_path(@resource), id: 'upload_path',
+        <%= link_to 'Edit Files', stash_engine.upload_resource_path(@resource),
                   class: 'c-review-files-button o-button__icon-left', role: 'button' %>
     </div>
 
@@ -69,7 +69,7 @@
 
       <div class="c-review-files">
         <%= render partial: "stash_engine/data_files/show_zenodo", locals: { resource: @resource } %>
-        <%= link_to 'Edit Files', stash_engine.up_code_resource_path(@resource), id: 'software_file_path',
+        <%= link_to 'Edit Files', stash_engine.upload_resource_path(@resource),
                     class: 'c-review-files-button o-button__icon-left', role: 'button' %>
       </div>
     <% end %>

--- a/stash/stash_engine/app/controllers/stash_engine/generic_files_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/generic_files_controller.rb
@@ -75,7 +75,7 @@ module StashEngine
         format.html do
           render json: {
             # map(&:attributes): one way for translating ActiveRecord field type to json
-            valid_urls: @resource.generic_files.map(&:attributes),
+            valid_urls: @resource.generic_files.validated_table.map(&:attributes),
             invalid_urls: url_errors
           }
         end

--- a/stash/stash_engine/app/models/stash_engine/url_validator.rb
+++ b/stash/stash_engine/app/models/stash_engine/url_validator.rb
@@ -68,8 +68,7 @@ module StashEngine
     def upload_attributes_from(translator:, resource:, association:)
       valid = validate
       upload_attributes = {
-        resource_id: resource.id,
-        url: url,
+        resource_id: resource.id, url: url,
         status_code: status_code,
         file_state: 'created',
         original_url: (translator.direct_download.nil? ? nil : @url),

--- a/stash/stash_engine/app/models/stash_engine/url_validator.rb
+++ b/stash/stash_engine/app/models/stash_engine/url_validator.rb
@@ -79,7 +79,8 @@ module StashEngine
 
       # don't allow duplicate URLs that have already been put into this version this time
       # (duplicate indicated with 409 Conflict)
-      return upload_attributes.merge(status_code: 409) if resource.url_in_version?(association: 'generic_files', url: url)
+      return upload_attributes.merge(status_code: 409) \
+        if resource.url_in_version?(url: url, association: association)
 
       sanitized_filename = StashEngine::GenericFile
         .sanitize_file_name(UrlValidator

--- a/stash/stash_engine/app/views/stash_engine/resources/upload.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/resources/upload.html.erb
@@ -14,21 +14,20 @@
 <!-- map(&:attributes) one way for translating ActiveRecord field type to json at React side adequately -->
 <%= react_component("UploadFiles", {
   resource_id: @resource.id,
-  file_uploads: @resource.generic_files.map(&:attributes),
+  file_uploads: @resource.generic_files.validated_table.map(&:attributes),
   app_config_s3: APP_CONFIG[:s3],
   s3_dir_name: @resource.s3_dir_name(type: 'base')
 }) %>
 
 <div class="o-dataset-nav">
+  <%# TODO: Verify if this condition is necessary after React Upload Page %>
   <% if params[:controller].end_with?('resources') && params[:action].include?('upload') %>
     <!-- standard upload page -->
     <%= link_to 'Back to Describe Dataset', metadata_entry_pages_find_or_create_path(resource_id: params[:id]), class: 'o-button__icon-left', role: 'button', id: 'describe_back' %>
-
-    <%= link_to 'Proceed to Upload Software', up_code_resource_path(params[:id]), class: 'o-button__icon-right', role: 'button', id: 'proceed_review' %>
   <% else %>
     <!-- software/supplemental zenodo upload page, should only get here if you can upload to zenodo -->
     <%= link_to 'Back to Upload Data', stash_engine.upload_resource_path(params[:id]), class: 'o-button__icon-left', role: 'button', id: 'describe_back' %>
-    <%= link_to 'Proceed to Review', review_resource_path(params[:id]), class: 'o-button__icon-right', role: 'button', id: 'proceed_review' %>
   <% end %>
+  <%= link_to 'Proceed to Review', review_resource_path(params[:id]), class: 'o-button__icon-right', role: 'button', id: 'proceed_review' %>
 </div>
 


### PR DESCRIPTION
- Considers files from previous versions when removing them, displaying in Upload Files tab, and validating submitted urls;
- Does not add file to files table when the file is already there for the same upload type.