### PR TITLE
Journal email -- submission system

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -265,8 +265,8 @@ production:
     gmail_client_id: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_id] %>
     gmail_client_secret: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_secret] %>
     journal_account_name: journal-submit-app@datadryad.org
-    journal_processing_label: journal-submit
-    journal_error_label: journal-submit-error
+    journal_processing_label: journal-submit-v2
+    journal_error_label: journal-submit-error-v2
 
 # Terminate the if statement from the beginning of this file.
 <% end %>

--- a/cron/daily.sh
+++ b/cron/daily.sh
@@ -12,3 +12,4 @@ bundle exec rails identifiers:in_progess_reminder RAILS_ENV=$1 >> /apps/dryad/ap
 bundle exec rails identifiers:update_missing_search_words RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/update_search_words.log 2>&1
 bundle exec rails dev_ops:retry_zenodo_errors RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/retry_zenodo_errors.log 2>&1
 bundle exec rails curation_stats:update_recent RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/curation_stats.log 2>&1
+bundle exec rails journal_email:clean_old_manuscripts RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/manuscripts_clean.log 2>&1

--- a/cron/every_1.sh
+++ b/cron/every_1.sh
@@ -7,3 +7,4 @@ PATH=$PATH:/apps/dryad/local/bin
 cd /apps/dryad/apps/ui/current/
 
 STASH_ENV=$1 NOTIFIER_OUTPUT=stdout /dryad/apps/stash-notifier/main.rb >> /dryad/apps/ui/shared/cron/logs/stash-notifier.log 2>&1
+bundle exec rails journal_email:process RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/journal_email.log 2>&1

--- a/cron/every_1.sh
+++ b/cron/every_1.sh
@@ -7,4 +7,4 @@ PATH=$PATH:/apps/dryad/local/bin
 cd /apps/dryad/apps/ui/current/
 
 STASH_ENV=$1 NOTIFIER_OUTPUT=stdout /dryad/apps/stash-notifier/main.rb >> /dryad/apps/ui/shared/cron/logs/stash-notifier.log 2>&1
-bundle exec rails journal_email:process RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/journal_email.log 2>&1
+

--- a/cron/every_5.sh
+++ b/cron/every_5.sh
@@ -7,4 +7,4 @@ PATH=$PATH:/apps/dryad/local/bin
 cd /apps/dryad/apps/ui/current/
 
 bundle exec rails status_dashboard:check RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/status_dashboard_check.log 2>&1
-
+bundle exec rails journal_email:process RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/journal_email.log 2>&1

--- a/documentation/apis/journal_manuscript_metadata.md
+++ b/documentation/apis/journal_manuscript_metadata.md
@@ -121,15 +121,12 @@ Dryad metadata can be parsed from a plaintext email as long as it
 occurs in a single block in the email, starting with the Journal Code
 and ending with EndDryadContent (or the end of the email itself).
 
-Notices to the Dryad system can be generated as separate items from a
-manuscript submission system, or alternatively the metadata may be
-combined into existing routine notices to authors, as long
-as the content needed by the Dryad system is in a self-contained
-section of the email. Some journals add the Dryad notice to their
-standard emails to authors, prefacing the Dryad content with a
-statement like: "Below is the information about your manuscript that
-we are relaying to the Dryad repository to facilitate your data
-archiving."
+Notices to the Dryad system can be generated as Dryad-specific messages from a
+manuscript submission system. Alternatively, the metadata may be combined into
+existing routine notices to authors. Some journals add the Dryad notice to their
+standard emails to authors, prefacing the Dryad content with a statement like:
+"Below is the information about your manuscript that we are relaying to the
+Dryad repository to facilitate your data archiving."
 
 Example email:
 

--- a/documentation/apis/journals.md
+++ b/documentation/apis/journals.md
@@ -22,8 +22,7 @@ Metadata about the journals and their workflows is stored in Dryad's
 Meaning of fields
 -----------------
 
-Some of the fields in `StashEngine::Journal` are being updated as we
-transition journals from older workflows to newer ones.
+Options for processing in `StashEngine::Journal`
 
 - *allow_review_workflow* -- Was previously used to determine whether
   a journal allowed authors to submit data during the manuscript

--- a/documentation/apis/journals.md
+++ b/documentation/apis/journals.md
@@ -1,17 +1,12 @@
 
-Dryad Journal Module
-======================
+Journal information in Dryad
+=============================
 
-The journal module provides information about the journals associated
-with Dryad. It runs from the old (v1) Dryad server, so its API is
-separate from the newer [data-access API](https://datadryad.org/api/v2/docs/).
-
-The journal module performs two functions:
-
-1. Managing metadata about the journals and their workflows. (**This
-   feature is deprecated.**)
-2. Processing metadata emails from journals and updating the status of
-   associated datasets.
+Dryad manages two types of information about journals:
+1. Metadata about the journals and their workflows, which is used to manage
+   processing of datasets associated with each journal.
+2. Metadata about journal manuscripts, which can be imported into a dataset, and
+   which can automatically change the status of a `peer_review` dataset.
 
 Metadata about journals
 =======================
@@ -38,36 +33,14 @@ Options for processing in `StashEngine::Journal`
   controls whether an automatic 1-year blackout/embargo is added to
   the dataset.
 
+Metadata about Manuscripts
+=============================
 
-Legacy data in v1 server
-------------------------
-
-Until we have a proper editing UI in Dryad, journal metadata is still
-edited with the UI in the v1 system, and then updates are imported
-to the production server using a command like:
-`RAILS_ENV=production bundle exec rails dryad_migration:migrate_journal_metadata`
-
-Journal metadata is still available through the v1 journal module's API,
-but **this feature is deprecated**.
-
-List all journals:
-`https://datadryad.org/api/v1/journals`
-
-Get details about a single journal:
-`https://datadryad.org/api/v1/journals/{issn}`
-
-Get a list of datasets associated with a journal (up to 2019-09-17):
-`https://datadryad.org/api/v1/journals/{issn}/packages`
-
-Additional query parameters that can be used to modify the
-results returned for the above calls:
-- `count` specifies the number of results per page.
-- `date_from` and `date_to` can filter results to packages released in a date range.
-- `cursor` can be used to specify the key used to start the results page.
-
+Metadata about manuscripts is stored in Dryad's
+`StashEngine::Manuscript` model.
 
 Submitting a dataset using the manuscript metadata
-==================================================
+---------------------------------------------------
 
 1. On a Dryad server, using the normal UI, make a submission with the
    journal name and manuscript number.
@@ -78,7 +51,7 @@ Submitting a dataset using the manuscript metadata
 
 
 Processing journal emails
-==========================
+-------------------------
 
 Journals send metadata emails to Dryad, which are parsed and stored in
 preparation for the user to create an associated dataset. For details
@@ -92,34 +65,20 @@ Overview of the email workflow
    `journal-submit@datadryad.org` email address, which forwards to `journal-submit-app@datadryad.org`
 2. Messages in `journal-submit-app@datadryad.org` are automatically labeled
    by GMail with a special label.
-3. At a regular interval, the journal-submit webapp retrieves the newest
-   emails with the special label, saving those messages to process
-   further and removing the label. The specific label is set by the maven
-   settings on the server, so each Dryad server can react to a different
-   label.
-4. The webapp processes the new emails: it gets the byte stream with the
-   email content and detects the journal's name.
-5. The webapp then looks up the journal name in the journal concepts, to
-   learn the `parsingScheme` to use. The value of this attribute is used
-   to match on the parsing classes in the journal-submit's codebase.
-6. When a particular parser is determined to be the correct one to use,
-   the webapp uses that to parse the remainder of the email, putting
-   metadata values into a ParsingResult object.
-7. The ParsingResult class is then used to export the metadata into the
-   database.
-8. Later, a submitter will use the Submission System to retrieve the
+3. At a regular interval, Dryad retrieves emails with the label, and processes
+   them into `StashEngine::Manuscript` objects.
+4. Later, a submitter may use the Submission System to retrieve the
    parsed metadata and initiate a new data submission.
-9. If an email fails to parse properly because it's malformed, it will
-   be tagged with the server's GMail error label.
+5. If an email fails to parse properly because it's malformed, it will
+   be tagged with a GMail error label.
 
 Users with access to the `journal-submit-app` gmail account can also
 manually add and remove the gmail labels to re-process specific
-emails. To trigger the journal-submit webapp manually, use the a url like
-https://whatever.server/journal-submit/retrieve.
+emails.
 
 
-Send email for an existing journal
------------------------------------
+Testing the metadata emails
+----------------------------
 
 The workflow starts when a journal send an email to the
 `journal-submit@datadryad.org` address. You can manually construct an
@@ -153,18 +112,7 @@ Development servers are normally configured to look for the tag
 development server, login to the email account and manually apply this tag.
 
 To force a Dryad server to process the email, make a call like this:
-`curl https://servername.datadryad.org/journal-submit/retrieve`
-
-The results of email processing can be seen on the applicable server,
-in the file `journal-submit.log`
-
-
-Manscripts in the database
-----------------------------
-
-In the (v1) database, the processed manuscript metadata can be seen
-with a command like:
-`select msid, status, date_added from manuscript order by manuscript_id desc;`
+`rails journal_email:process`
 
 
 Automatic updates of `peer_review` datasets
@@ -174,14 +122,17 @@ When journals send updates of manuscript status, these updates trigger
 changes in the status of associated datasets.
 
 To see these changes:
-1. Create a dataset in `peer_review` status as described above
+1. Create a dataset associated with a journal as described above, and put it in `peer_review` status
 2. Send an updated email, with the same manuscript number, but with `Article Status: accepted`
 3. Process the email as described above
-4. Verify that the associated manuscript has moved to `submitted` status
+4. Verify that the associated dataset has moved to `submitted` status
+
+When the email contains `Article Status: rejected`, the associated dataset will
+be moved to `withdrawn` status.
 
 
-Technical details for the journal module
-========================================
+Technical details
+=================
 
 Configuring/updating the Rails connection with GMail
 -----------------------------------------------------
@@ -203,35 +154,23 @@ affected by updates to the codebase. You can test whether the
 token is valid and/or reset the token by running:
 `rails journal_email:validate_gmail_connection`
 
-
-OLD -- Troubleshooting
----------------
-
-If running http://localhost:9999/journal-submit/test returns errors,
-it is possible that the stored credential has gotten out of
-sync. Delete the credential file on the server (stored at
-/opt/dryad/submission/credential/StoredCredential) and reauthorize the
-webapp.
-
-If running http://localhost:9999/journal-submit/retrieve returns an
-error saying that messages are still being processed, you can clear
-that by running http://localhost:9999/journal-submit/clear.
+If something is wrong with the authorization, you can delete the `token.yaml`
+file and generate it again.
 
 
 Configuring the Gmail labels
 ----------------------------
 
-The labels that are being looked for by the webapp need to be
-configured in the Gmail settings. Log into the Gmail web site as the
-`journal-submit-app@datadryad.org` account. Create matching labels for
-the server you're configuring, matching the
-`<default.submit.journal.label>` and
-`<default.submit.journal.error.label>` settings in the Maven settings
-file (as above). If you want to listen for all incoming emails, set a
-filter to label all incoming messages with the label. The webapp will
-remove that label as it processes the labeled emails. Do not use an
-existing label for a new server instance, or else the new server's
-webapp will remove some other server's labels!
+The labels that are being looked for by the webapp need to be configured in the
+Gmail settings. Log into the Gmail web site as the
+`journal-submit-app@datadryad.org` account. Create matching labels for the
+server you're configuring, matching the
+`APP_CONFIG[:google][:journal_processing_label]` and
+`APP_CONFIG[:google][:journal_error_label]` settings. If you want to process
+all incoming emails, set a filter that will label all incoming messages. Dryad
+will remove that label as it processes the labeled emails. Note that if two
+servers use the same label, they will both be proccesing the same set of
+messages, and each message will only be processed by one server.
 
 
 Full testing workflow
@@ -240,58 +179,45 @@ Full testing workflow
 Some of this information appears above, but the complete details are
 provided here...
 
-Set up the servers:
-- On the target Dryad/Dash server,
-  - Ensure it has the correct authentication for the Dryad/DSpace
-    server. This is in app_config.yml, old_dryad_url and
-    old_dryad_access_token
-- On the Dryad/DSpace server (dryad-dspace-server) that will process
-  emails,
-  - Ensure it has a journal concept set up with the journal name and
-    settings that you want to test.
-  - Ensure it has authentication information for the correct email
-    account. This account is usually journal-submit-app@datadryad.org for
-    all servers, so shouldn't require a change. In dspace.cfg,
-    submit.journal.clientsecrets
-  - Check which email label it will look for. This is in dspace.cfg,
-    submit.journal.email.label
-  - Ensure it has the correct authentication for the Dryad/Dash
-    server. This is in dspace.cfg, dash.server and associated auth key.
+Set up the server:
+- ensure all of the settings are correct in the `google` section of the
+`app_config.yml`
+- ensure the associated labels exist in the GMail account
+- run `rails journal_email:validate_gmail_connection` to ensure the server can
+  communicate with the GMail account
 
-To run the test:
+To run a test:
 - Send an email to the Gmail account with the required metadata. The
   account can be journal-submit-app OR the more general
   journal-submit@datadryad.org. Note that you must use a "real" journal
-  name to match the settings in the concept above. Something like:
+  ISSNname to match the settings in the concept above. Something like:
 
 ```
 Journal Name: Molecular Ecology
+Journal Code: molecol
 MS Reference Number: abc123
 Article Status: submitted
 MS Title: Some great and unique title
 MS Authors: Author Authorious
-Contact Author: Author Authorious
-Contact Author Email: fake-author@datadryad.org
 Keywords: great research, stellar data
 ```
 
-- In the GMail account (journal-submit-app@datadryad.org), apply the
+- In the GMail account (`journal-submit-app@datadryad.org`), apply the
   proper label to the email
-- Either wait, or force the email to be processed by accessing
-  http://dryad-dspace-server.datadryad.org/journal-submit/retrieve
-- View the logs on the Dryad/V1 server to ensure the email was processed
+- Force the email to be processed with `rails journal_email:process`
+- Inspect the `StashEngine::Manuscript` table to ensure the email was processed
   correctly.
-- On the Dryad/Dash server, create a submission with the associated
-  journal name and manuscript number. It should correctly import the
-  metadata and use the journal settings to determine whether peer review
-  is allowed and whether to charge the user. Normally, you will want to
-  put the submission into peer_review status to test the subsequent steps.
-- Either wait for Merritt processing of the Dryad/Dash submission, or
-  force the notifier to run (notifier_force.sh on most servers)
-- Send another email to journal-submit@datadryad.org to update the
+- Create a submission with the associated journal name and manuscript number. It
+  should correctly import the metadata and use the journal settings to determine
+  whether peer review is allowed and whether to charge the user. Normally, you
+  will want to put the submission into `peer_review` status to test the
+  subsequent steps.
+- Wait for Merritt processing of the Dryad submission, or
+  force the notifier to run (`notifier_force.sh` on most servers)
+- Send another email to `journal-submit@datadryad.org` to update the
   status of the submission. This can be exactly the same message as
   above, just with the Article Status changed to either "accepted" or
   "rejected".
 - Again, apply the correct label to the email.
-- Again, wait or force the email to be processed.
-- View the results in server logs and the status of the Dryad/Dash submission.
+- Again, force the email to be processed.
+- View the results in server logs and the status of the submitted dataset.

--- a/documentation/apis/journals.md
+++ b/documentation/apis/journals.md
@@ -221,3 +221,32 @@ Keywords: great research, stellar data
 - Again, apply the correct label to the email.
 - Again, force the email to be processed.
 - View the results in server logs and the status of the submitted dataset.
+
+
+Sample Rails commands
+-----------------------
+
+To initialize the GMail connection:
+`rails journal_email:validate_gmail_connection`
+
+To process emails:
+`rails journal_email:process`
+
+To use individual emails:
+```
+require 'stash/google/journal_gmail'
+m=Stash::Google::JournalGMail.messages_to_process.first
+mc=Stash::Google::JournalGMail.message_content(message: m)
+ms=Stash::Google::JournalGMail.message_subject(message: m)
+l=Stash::Google::JournalGMail.message_labels(message: m)
+```
+
+To access parsed metadata:
+```
+m=StashEngine::Manuscript.last
+m.status
+m.journal
+m.manuscript_number
+m.metadata['ms title']
+m.metadata['ms authors']
+```

--- a/documentation/server_maintenance/v1_server.md
+++ b/documentation/server_maintenance/v1_server.md
@@ -1,8 +1,5 @@
-Journal Module & v1 Server
-==========================
-
-The journal module runs as part of the v1 server. For details about
-its inner workings, see the [Journal Module Documentation](../apis/journals.md).
+V1 Server
+===========
 
 Restarting the v1 Server
 ------------------------
@@ -27,3 +24,4 @@ The v1 server can be restarted by:
 4. `bin/tomcat_start.sh`
 5. After a few minutes, visit one of the URLs above to verify that the
    server has started.
+

--- a/spec/factories/stash_engine/journals.rb
+++ b/spec/factories/stash_engine/journals.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
 
     title { Faker::Company.industry }
     issn { "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}" }
-
+    journal_code { Faker::Name.initials(number: 4) }
   end
 
 end

--- a/spec/features/stash_datacite/manuscript_populate_metadata_spec.rb
+++ b/spec/features/stash_datacite/manuscript_populate_metadata_spec.rb
@@ -19,18 +19,6 @@ RSpec.feature 'Populate manuscript metadata from outside source', type: :feature
       start_new_dataset
     end
 
-    xit 'warns when dataset info could not be found' do
-      # this stubs the old dryad api tha Daisie was calling, soon to be changed more
-      stub_request(:get, 'https://api.datadryad.example.org/api/v1/organizations/1573-8469/manuscripts/APPS-D-grog-plant0001221?access_token=bad_token')
-        .with(headers: { 'Content-Type' => 'application/json' })
-        .to_return(status: 404, body: '', headers: {})
-      find('input[value="manuscript"]').click
-      fill_manuscript_info(name: 'European Journal of Plant Pathology', issn: '1573-8469', msid: 'APPS-D-grog-plant0001221')
-      click_button 'Import Manuscript Metadata'
-      expect(page.find('div#population-warnings')).to have_content('We could not find metadata to import for this manuscript. ' \
-          'Please enter your metadata below.')
-    end
-
     xit "gives message when journal isn't selected" do
       find('input[value="manuscript"]').click
       fill_manuscript_info(name: 'European Journal of Plant Pathology', issn: nil, msid: nil)
@@ -42,30 +30,6 @@ RSpec.feature 'Populate manuscript metadata from outside source', type: :feature
       find('input[value="manuscript"]').click
       click_button 'Import Manuscript Metadata'
       expect(page.find('div#population-warnings')).to have_content('Please fill in the form completely')
-    end
-
-    # Commenting this one out for now. seems to fail randomly
-    xit 'works for successful request to Dryad manuscript API' do
-      stub_request(:get, 'https://api.datadryad.example.org/api/v1/organizations/1759-6831/manuscripts/JSE-2017-12-137?access_token=bad_token')
-        .with(
-          headers: {
-            'Content-Type' => 'application/json'
-          }
-        ).to_return(status: 200,
-                    body: File.new(File.join(Rails.root, 'spec', 'fixtures', 'http_responses', 'dryad_manuscript.json')),
-                    headers: { 'Content-Type' => 'application/json' })
-      journal = 'Journal of Systematics and Evolution'
-      issn = '1759-6831'
-      msid = 'JSE-2017-12-137'
-      fill_manuscript_info(name: journal, issn: issn, msid: msid)
-      click_button 'Import Manuscript Metadata'
-      expect(page).to have_field('title',
-                                 with: 'Leaf and infructescence fossils of Alnus (Betulaceae) from the late Eocene ' \
-        'of the southeastern Qinghai-Tibetan Plateau',
-                                 wait: 40)
-      # The autofill just populates info into the database and then displays the info from the database on the page.
-      # We already have unit tests for population into the database and also tests for field display on the entry page,
-      # so this is just a basic test to be sure population is happening.
     end
 
   end

--- a/spec/models/stash_engine/manuscript_spec.rb
+++ b/spec/models/stash_engine/manuscript_spec.rb
@@ -8,21 +8,25 @@ module StashEngine
     end
 
     describe '#from_message_content' do
+      before(:each) do
+        @ms_number = "ms-#{Faker::Number.number(digits: 4)}"
+        @title = Faker::Lorem.sentence
+      end
+
       it 'turns a basic message into a manuscript' do
-        ms_number = "ms-#{Faker::Number.number(digits: 4)}"
-        title = Faker::Lorem.sentence
         content = "Journal Name: #{@journal.title}\n" \
                   "Online ISSN: #{@journal.issn}\n" \
-                  "MS Reference Number: #{ms_number}\n" \
-                  "MS Title: #{title}\n" \
+                  "Article Status: accepted\n" \
+                  "MS Reference Number: #{@ms_number}\n" \
+                  "MS Title: #{@title}\n" \
                   'MS Authors: Lastname, Firstname; McOtherLastname, Somename'
         result = Manuscript.from_message_content(content: content)
         expect(result).not_to be_nil
         expect(result.success?).to be_truthy
         expect(result.payload).not_to be_nil
-        expect(result.payload.manuscript_number).to eq(ms_number)
-        puts("PAYLmmet #{result.payload.metadata} -- #{title}")
-        expect(result.payload.metadata['ms title']).to eq(title)
+        expect(result.payload.manuscript_number).to eq(@ms_number)
+        puts("PAYLmmet #{result.payload.metadata} -- #{@title}")
+        expect(result.payload.metadata['ms title']).to eq(@title)
       end
 
       it 'provides an error when parsing fails' do
@@ -33,6 +37,67 @@ module StashEngine
         expect(result.payload).to be_nil
         expect(result.error).not_to be_nil
       end
+
+      it 'provides an error when journal info missing' do
+        content = "Article Status: accepted\n" \
+                  "MS Reference Number: #{@ms_number}\n" \
+                  "MS Title: #{@title}\n" \
+                  'MS Authors: Lastname, Firstname; McOtherLastname, Somename'
+        result = Manuscript.from_message_content(content: content)
+        expect(result).not_to be_nil
+        expect(result.success?).to be_falsey
+        expect(result.payload).to be_nil
+        expect(result.error).to include('Journal')
+      end
+
+      it 'provides an error when MS Number missing' do
+        content = "Online ISSN: #{@journal.issn}\n" \
+                  "Article Status: accepted\n" \
+                  "MS Title: #{@title}\n" \
+                  'MS Authors: Lastname, Firstname; McOtherLastname, Somename'
+        result = Manuscript.from_message_content(content: content)
+        expect(result).not_to be_nil
+        expect(result.success?).to be_falsey
+        expect(result.payload).to be_nil
+        expect(result.error).to include('MS Reference Number')
+      end
+
+      it 'provides an error when Title missing' do
+        content = "Online ISSN: #{@journal.issn}\n" \
+                  "Article Status: accepted\n" \
+                  "MS Reference Number: #{@ms_number}\n" \
+                  'MS Authors: Lastname, Firstname; McOtherLastname, Somename'
+        result = Manuscript.from_message_content(content: content)
+        expect(result).not_to be_nil
+        expect(result.success?).to be_falsey
+        expect(result.payload).to be_nil
+        expect(result.error).to include('Title')
+      end
+
+      it 'provides an error when Author info missing' do
+        content = "Online ISSN: #{@journal.issn}\n" \
+                  "Article Status: accepted\n" \
+                  "MS Reference Number: #{@ms_number}\n" \
+                  "MS Title: #{@title}\n"
+        result = Manuscript.from_message_content(content: content)
+        expect(result).not_to be_nil
+        expect(result.success?).to be_falsey
+        expect(result.payload).to be_nil
+        expect(result.error).to include('Authors')
+      end
+
+      it 'provides an error when Article Status info missing' do
+        content = "Online ISSN: #{@journal.issn}\n" \
+                  "MS Reference Number: #{@ms_number}\n" \
+                  "MS Title: #{@title}\n" \
+                  'MS Authors: Lastname, Firstname; McOtherLastname, Somename'
+        result = Manuscript.from_message_content(content: content)
+        expect(result).not_to be_nil
+        expect(result.success?).to be_falsey
+        expect(result.payload).to be_nil
+        expect(result.error).to include('Article Status')
+      end
+
     end
   end
 end

--- a/spec/models/stash_engine/manuscript_spec.rb
+++ b/spec/models/stash_engine/manuscript_spec.rb
@@ -25,7 +25,6 @@ module StashEngine
         expect(result.success?).to be_truthy
         expect(result.payload).not_to be_nil
         expect(result.payload.manuscript_number).to eq(@ms_number)
-        puts("PAYLmmet #{result.payload.metadata} -- #{@title}")
         expect(result.payload.metadata['ms title']).to eq(@title)
       end
 

--- a/spec/models/stash_engine/manuscript_spec.rb
+++ b/spec/models/stash_engine/manuscript_spec.rb
@@ -12,7 +12,6 @@ module StashEngine
         ms_number = "ms-#{Faker::Number.number(digits: 4)}"
         title = Faker::Lorem.sentence
         content = "Journal Name: #{@journal.title}\n" \
-                  "Journal Code: RSOS\n" \
                   "Online ISSN: #{@journal.issn}\n" \
                   "MS Reference Number: #{ms_number}\n" \
                   "MS Title: #{title}\n" \

--- a/spec/models/stash_engine/manuscript_spec.rb
+++ b/spec/models/stash_engine/manuscript_spec.rb
@@ -1,0 +1,25 @@
+require 'webmock/rspec'
+require 'byebug'
+
+module StashEngine
+  describe Manuscript, type: :model do
+    before(:each) do
+    
+    end
+
+    describe '#from_message_content' do
+      it 'turns a basic message into a manuscript' do
+        content = "Journal Name: Royal Society Open Science\n" \
+                  "Journal Code: RSOS\n" \
+                  "Online ISSN: 2054-5703" \
+                  "MS Reference Number: abc123" \
+                  "MS Title: Some great title" \
+                  "MS Authors: "
+      end
+
+      it 'provides an error when parsing fails' do
+        assert(false)
+      end
+    end
+  end
+end

--- a/spec/models/stash_engine/manuscript_spec.rb
+++ b/spec/models/stash_engine/manuscript_spec.rb
@@ -4,21 +4,35 @@ require 'byebug'
 module StashEngine
   describe Manuscript, type: :model do
     before(:each) do
-    
+      @journal = create(:journal)
     end
 
     describe '#from_message_content' do
       it 'turns a basic message into a manuscript' do
-        content = "Journal Name: Royal Society Open Science\n" \
+        ms_number = "ms-#{Faker::Number.number(digits: 4)}"
+        title = Faker::Lorem.sentence
+        content = "Journal Name: #{@journal.title}\n" \
                   "Journal Code: RSOS\n" \
-                  "Online ISSN: 2054-5703" \
-                  "MS Reference Number: abc123" \
-                  "MS Title: Some great title" \
-                  "MS Authors: "
+                  "Online ISSN: #{@journal.issn}\n" \
+                  "MS Reference Number: #{ms_number}\n" \
+                  "MS Title: #{title}\n" \
+                  'MS Authors: Lastname, Firstname; McOtherLastname, Somename'
+        result = Manuscript.from_message_content(content: content)
+        expect(result).not_to be_nil
+        expect(result.success?).to be_truthy
+        expect(result.payload).not_to be_nil
+        expect(result.payload.manuscript_number).to eq(ms_number)
+        puts("PAYLmmet #{result.payload.metadata} -- #{title}")
+        expect(result.payload.metadata['ms title']).to eq(title)
       end
 
       it 'provides an error when parsing fails' do
-        assert(false)
+        content = 'abc'
+        result = Manuscript.from_message_content(content: content)
+        expect(result).not_to be_nil
+        expect(result.success?).to be_falsey
+        expect(result.payload).to be_nil
+        expect(result.error).not_to be_nil
       end
     end
   end

--- a/spec/services/stash_engine/email_parser_spec.rb
+++ b/spec/services/stash_engine/email_parser_spec.rb
@@ -79,6 +79,17 @@ module StashEngine
         parser = EmailParser.new(content: content)
         expect(parser.journal).to eq(@journal)
       end
+
+      it 'applies the manuscript_number_regex to clean manuscript numbers' do
+        regex = '.*?(\d+-\d+).*?'
+        @journal.manuscript_number_regex = regex
+        @journal.save
+        ms_number = "ABC#{Faker::Number.number(digits: 2)}-#{Faker::Number.number(digits: 4)}.R2"
+        target_ms_number = ms_number.match(regex)[1]
+        content = "Journal Code: #{@journal.journal_code}\nMS Reference Number: #{ms_number}"
+        parser = EmailParser.new(content: content)
+        expect(parser.manuscript_number).to eq(target_ms_number)
+      end
     end
 
     describe '#authors' do

--- a/spec/services/stash_engine/email_parser_spec.rb
+++ b/spec/services/stash_engine/email_parser_spec.rb
@@ -17,7 +17,7 @@ module StashEngine
         parser = EmailParser.new(content: content)
         hash = parser.metadata_hash
 
-        expect(hash['journal code']).to eq('RSOS')
+        expect(hash['journal code']).to eq('rsos')
       end
 
       it 'turns an HTML message into a hash' do
@@ -25,7 +25,7 @@ module StashEngine
         parser = EmailParser.new(content: content)
         hash = parser.metadata_hash
 
-        expect(hash['journal code']).to eq('RSOS')
+        expect(hash['journal code']).to eq('rsos')
       end
 
       it 'ignores content after the EndDryadContent tag' do

--- a/spec/services/stash_engine/email_parser_spec.rb
+++ b/spec/services/stash_engine/email_parser_spec.rb
@@ -3,7 +3,7 @@ module StashEngine
     before(:each) do
     end
 
-    describe '#metadata_hash' do
+    describe '#metadata_basics' do
       it 'does not return content when there are no parseable values' do
         content = "Journal: Royal Society Open Science\nSome other garbage"
         parser = EmailParser.new(content: content)
@@ -35,69 +35,111 @@ module StashEngine
 
         expect(hash['journal code']).to be_nil
       end
+    end
 
-      describe 'author parsing' do
-        it 'parses authors with "last, first", separated by semicolons' do
-          content = 'MS Authors: last, first; last2, first2'
-          parser = EmailParser.new(content: content)
-          hash = parser.metadata_hash
-
-          expect(hash['ms authors']).not_to be_nil
-          expect(hash['ms authors'].size).to eq(2)
-          expect(hash['ms authors'][0]['family_name']).to eq('last')
-        end
-
-        it 'parses authors with "first last, first last", separated by commas' do
-          content = 'MS Authors: first last, first2 last2, first3 last3'
-          parser = EmailParser.new(content: content)
-          hash = parser.metadata_hash
-
-          expect(hash['ms authors']).not_to be_nil
-          expect(hash['ms authors'].size).to eq(3)
-          expect(hash['ms authors'][0]['family_name']).to eq('last')
-          expect(hash['ms authors'][1]['family_name']).to eq('last2')
-          expect(hash['ms authors'][2]['family_name']).to eq('last3')
-        end
-
-        it 'parses authors with "first last, first last", with "and" at the end' do
-          content = 'MS Authors: first last, first2 last2 and first3 last3'
-          parser = EmailParser.new(content: content)
-          hash = parser.metadata_hash
-
-          expect(hash['ms authors']).not_to be_nil
-          expect(hash['ms authors'].size).to eq(3)
-          expect(hash['ms authors'][0]['family_name']).to eq('last')
-          expect(hash['ms authors'][1]['family_name']).to eq('last2')
-          expect(hash['ms authors'][2]['family_name']).to eq('last3')
-        end
-
-        it 'parses authors with "first last", keeping suffixes and dropping titles' do
-          content = 'MS Authors: first last, Jr.; first2 last2, PhD; Ms. first3 last3'
-          parser = EmailParser.new(content: content)
-          hash = parser.metadata_hash
-
-          expect(hash['ms authors']).not_to be_nil
-          expect(hash['ms authors'].size).to eq(3)
-          expect(hash['ms authors'][0]['family_name']).to eq('last, Jr.')
-          expect(hash['ms authors'][1]['family_name']).to eq('last2')
-          expect(hash['ms authors'][2]['given_name']).to eq('first3')
-          expect(hash['ms authors'][2]['family_name']).to eq('last3')
-        end
-
-        it 'parses authors with a single name' do
-          content = 'MS Authors: Elvis Presley and Cher'
-          parser = EmailParser.new(content: content)
-          hash = parser.metadata_hash
-
-          expect(hash['ms authors']).not_to be_nil
-          expect(hash['ms authors'].size).to eq(2)
-          expect(hash['ms authors'][0]['family_name']).to eq('Presley')
-          expect(hash['ms authors'][1]['given_name']).to eq('')
-          expect(hash['ms authors'][1]['family_name']).to eq('Cher')
-        end
-
+    describe '#identifier' do
+      it 'finds identifier from data DOI' do
+        ident = create(:identifier)
+        content = "Dryad Data DOI: doi:#{ident.identifier}"
+        parser = EmailParser.new(content: content)
+        expect(parser.identifier).to eq(ident)
       end
 
+      it 'finds identifier from manuscript number' do
+        ident = create(:identifier)
+        journal = create(:journal)
+        ms_number = "ms-#{Faker::Number.number(digits: 4)}"
+        create(:internal_data, identifier_id: ident.id, data_type: 'manuscriptNumber', value: ms_number)
+        create(:internal_data, identifier_id: ident.id, data_type: 'publicationISSN', value: journal.issn)
+        content = "Online ISSN: #{journal.issn}\nMS Reference Number: #{ms_number}"
+        parser = EmailParser.new(content: content)
+        expect(parser.identifier).to eq(ident)
+      end
+    end
+
+    describe '#journal' do
+      before(:each) do
+        @journal = create(:journal)
+      end
+
+      it 'finds journal from print ISSN' do
+        content = "Print ISSN: #{@journal.issn}"
+        parser = EmailParser.new(content: content)
+        expect(parser.journal).to eq(@journal)
+      end
+
+      it 'finds journal from online ISSN' do
+        content = "Print ISSN: 1234-1234\nOnline ISSN: #{@journal.issn}"
+        parser = EmailParser.new(content: content)
+        expect(parser.journal).to eq(@journal)
+      end
+
+      it 'finds journal from journal code' do
+        content = "Journal Code: #{@journal.code}"
+        parser = EmailParser.new(content: content)
+        expect(parser.journal).to eq(@journal)
+      end
+    end
+
+    describe '#authors' do
+      it 'parses authors with "last, first", separated by semicolons' do
+        content = 'MS Authors: last, first; last2, first2'
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+
+        expect(hash['ms authors']).not_to be_nil
+        expect(hash['ms authors'].size).to eq(2)
+        expect(hash['ms authors'][0]['family_name']).to eq('last')
+      end
+
+      it 'parses authors with "first last, first last", separated by commas' do
+        content = 'MS Authors: first last, first2 last2, first3 last3'
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+
+        expect(hash['ms authors']).not_to be_nil
+        expect(hash['ms authors'].size).to eq(3)
+        expect(hash['ms authors'][0]['family_name']).to eq('last')
+        expect(hash['ms authors'][1]['family_name']).to eq('last2')
+        expect(hash['ms authors'][2]['family_name']).to eq('last3')
+      end
+
+      it 'parses authors with "first last, first last", with "and" at the end' do
+        content = 'MS Authors: first last, first2 last2 and first3 last3'
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+
+        expect(hash['ms authors']).not_to be_nil
+        expect(hash['ms authors'].size).to eq(3)
+        expect(hash['ms authors'][0]['family_name']).to eq('last')
+        expect(hash['ms authors'][1]['family_name']).to eq('last2')
+        expect(hash['ms authors'][2]['family_name']).to eq('last3')
+      end
+
+      it 'parses authors with "first last", keeping suffixes and dropping titles' do
+        content = 'MS Authors: first last, Jr.; first2 last2, PhD; Ms. first3 last3'
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+
+        expect(hash['ms authors']).not_to be_nil
+        expect(hash['ms authors'].size).to eq(3)
+        expect(hash['ms authors'][0]['family_name']).to eq('last, Jr.')
+        expect(hash['ms authors'][1]['family_name']).to eq('last2')
+        expect(hash['ms authors'][2]['given_name']).to eq('first3')
+        expect(hash['ms authors'][2]['family_name']).to eq('last3')
+      end
+
+      it 'parses authors with a single name' do
+        content = 'MS Authors: Elvis Presley and Cher'
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+
+        expect(hash['ms authors']).not_to be_nil
+        expect(hash['ms authors'].size).to eq(2)
+        expect(hash['ms authors'][0]['family_name']).to eq('Presley')
+        expect(hash['ms authors'][1]['given_name']).to eq('')
+        expect(hash['ms authors'][1]['family_name']).to eq('Cher')
+      end
     end
   end
 end

--- a/spec/services/stash_engine/email_parser_spec.rb
+++ b/spec/services/stash_engine/email_parser_spec.rb
@@ -1,0 +1,42 @@
+module StashEngine
+  describe EmailParser do
+    before(:each) do
+    end
+
+    describe '#metadata_hash' do
+      it 'does not return content when there are no parseable values' do
+        content = "Journal: Royal Society Open Science\nSome other garbage"
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+        
+        expect(hash.size).to eq(0)
+      end
+     
+      it 'turns a basic message into a hash' do
+        content = "Journal Name: Royal Society Open Science\nJournal Code: RSOS\nOnline ISSN: 2054-5703"
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+
+        expect(hash['journal code']).to eq('RSOS')
+      end
+
+      it 'turns an HTML message into a hash' do
+        content = "Journal Name: Royal Society Open Science<br/>Journal Code: RSOS<br />Online ISSN: 2054-5703"
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+        
+        expect(hash['journal code']).to eq('RSOS')
+      end
+
+      it 'ignores content after the EndDryadContent tag' do
+        content = "Journal Name: Royal Society Open Science<br/>EndDryadContent<br/>Journal Code: RSOS<br />Online ISSN: 2054-5703"
+        parser = EmailParser.new(content: content)
+        hash = parser.metadata_hash
+        
+        expect(hash['journal code']).to eq(nil)
+      end
+      
+    end
+  end
+end
+

--- a/spec/services/stash_engine/email_parser_spec.rb
+++ b/spec/services/stash_engine/email_parser_spec.rb
@@ -75,7 +75,7 @@ module StashEngine
       end
 
       it 'finds journal from journal code' do
-        content = "Journal Code: #{@journal.code}"
+        content = "Journal Code: #{@journal.journal_code}"
         parser = EmailParser.new(content: content)
         expect(parser.journal).to eq(@journal)
       end

--- a/stash/stash_datacite/lib/stash/import/dryad_manuscript.rb
+++ b/stash/stash_datacite/lib/stash/import/dryad_manuscript.rb
@@ -1,10 +1,12 @@
+# This class does the work of moving metadata from a StashEngine::Manuscript into a StashEngine::Resource
 module Stash
   module Import
     class DryadManuscript
 
-      def initialize(resource:, httparty_response:)
+      def initialize(resource:, manuscript:)
         @resource = resource
-        @response = httparty_response.with_indifferent_access # so you can use symbols instead of strings for access
+        @manuscript = manuscript
+        @metadata = manuscript.metadata
       end
 
       def populate
@@ -15,56 +17,37 @@ module Stash
       end
 
       def populate_title
-        return if @response[:title].blank?
+        return if @metadata['ms title'].blank?
 
-        @resource.update(title: @response[:title])
+        @resource.update(title: @metadata['ms title'])
       end
 
       def populate_authors
-        return if @response[:authors].blank? || @response[:authors][:author].blank?
+        return if @metadata['ms authors'].blank? || @metadata['ms authors'].first.blank?
 
-        authors = @response[:authors][:author]
-        authors.each do |api_author|
-          author = @resource.authors.create(
-            author_first_name: api_author['givenNames'],
-            author_last_name: api_author['familyName'],
-            author_orcid: (api_author['identifierType'] == 'orcid' ? api_author[:identifier] : nil)
+        authors = @metadata['ms authors']
+        authors.each do |ms_author|
+          @resource.authors.create(
+            author_first_name: ms_author['given_name'],
+            author_last_name: ms_author['family_name'],
+            author_orcid: (ms_author['identifierType'] == 'orcid' ? ms_author['identifier'] : nil)
           )
-          update_email(db_author: author)
         end
       end
 
       def populate_abstract
-        return if @response[:abstract].blank?
+        return if @metadata['abstract'].blank?
 
         abstract = @resource.descriptions.where(description_type: 'abstract').first_or_create
-        abstract.update(description: @response[:abstract])
+        abstract.update(description: @metadata['abstract'])
       end
 
       def populate_keywords
-        return if @response[:keywords].blank?
+        return if @metadata['keywords'].blank?
 
-        @resource.subjects << @response[:keywords].map do |kw|
+        @resource.subjects << @metadata['keywords'].map do |kw|
           StashDatacite::Subject.find_or_create_by(subject: kw)
         end
-      end
-
-      # the 'correspondingAuthor' may be able to give us one of the authors email addresses, but not for most items
-      def update_email(db_author:)
-        return if @response['correspondingAuthor'].blank? || @response['correspondingAuthor']['author'].blank? ||
-            @response['correspondingAuthor']['email'].blank?
-
-        return unless db_author.author_first_name == @response['correspondingAuthor']['author']['givenNames'] &&
-            db_author.author_last_name == @response['correspondingAuthor']['author']['familyName']
-
-        email = @response['correspondingAuthor']['email']
-
-        # Some emails have a bunch of crap crammed in like "schirmel@uni-landau.de Contact Institution: University of Koblenz-Landau",
-        # but it's not really always, so trying to extract an email with a regular expression if one is lying around in the junk somewhere.
-        email = email.match(/\S+@\S+\.{1}\S+/).to_s
-        return if email.blank?
-
-        db_author.update(author_email: email)
       end
 
     end

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -4,6 +4,16 @@ module StashEngine
     belongs_to :identifier, optional: true
     serialize :metadata
 
+    def accepted?
+      accepted_statuses = %w[accepted published]
+      accepted_statuses.include?(status)
+    end
+
+    def rejected?
+      rejected_statuses = ['rejected', 'transferred', 'rejected w/o review']
+      rejected_statuses.include?(status)
+    end
+
     # Create a new Manuscript from the content of an email message
     def self.from_message_content(content:)
       result = OpenStruct.new(success?: false, error: 'No content')
@@ -20,6 +30,7 @@ module StashEngine
                                  metadata: parser.metadata_hash)
 
         if manu.present? && manu.id.present?
+          update_existing_dataset_status(manu)
           result.delete_field('error')
           result[:success?] = true
           result[:payload] = manu
@@ -29,6 +40,35 @@ module StashEngine
       end
 
       result
+    end
+
+    def self.update_existing_dataset_status(manuscript)
+      return unless manuscript.identifier
+
+      target_status = nil
+      target_note = 'setting manuscript status based on notification from journal'
+      if manuscript.accepted?
+        target_status = 'submitted'
+      elsif manuscript.rejected?
+        target_status = 'withdrawn'
+      end
+
+      resource = manuscript.identifier.latest_resource
+
+      # if the status is being updated based on notification from a journal, DON'T go backwards in workflow,
+      # that is, don't change a status other than submitted or peer_review
+      unless %w[submitted peer_review].include?(resource.current_curation_status)
+        target_note = "received notification from journal module that the associated manuscript is #{manuscript.status}, " \
+                      "but the dataset is #{resource.current_curation_status}, so it will retain that status"
+        target_status = resource.current_curation_status
+      end
+
+      return unless target_status
+
+      StashEngine::CurationActivity.create(resource: resource,
+                                           status: target_status,
+                                           user_id: 0,  # system user
+                                           note: target_note)
     end
 
     def self.check_parsing_errors(parser)

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -11,21 +11,40 @@ module StashEngine
       return result unless content
 
       parser = EmailParser.new(content: content)
+      parsing_error = check_parsing_errors(parser)
 
-      manu = Manuscript.create(journal: parser.journal,
-                               identifier: parser.identifier,
-                               manuscript_number: parser.manuscript_number,
-                               status: parser.article_status,
-                               metadata: parser.metadata_hash)
+      if !parsing_error
+        manu = Manuscript.create(journal: parser.journal,
+                                 identifier: parser.identifier,
+                                 manuscript_number: parser.manuscript_number,
+                                 status: parser.article_status,
+                                 metadata: parser.metadata_hash)
 
-      if manu.present? && manu.id.present?
-        result.delete_field('error')
-        result[:success?] = true
-        result[:payload] = manu
+        if manu.present? && manu.id.present?
+          result.delete_field('error')
+          result[:success?] = true
+          result[:payload] = manu
+        end
+      else
+        result[:error] = parsing_error
       end
 
       result
     end
 
+    def self.check_parsing_errors(parser)
+      return 'Unable to locate Journal -- either through Journal Code or an ISSN' unless parser.journal
+      return 'Article Status not found' unless parser.article_status
+      unless parser.manuscript_number || parser.identifier
+        return 'Unable to identify manuscript -- either through MS Reference Number or Dryad Data DOI'
+      end
+
+      hash = parser.metadata_hash
+      return 'Unable to create metadata hash' unless hash.present?
+      return 'Unable to parse MS Authors' unless hash['ms authors'].present?
+      return 'Unable to locate MS Title' unless hash['ms title'].present?
+
+      nil
+    end
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -9,7 +9,41 @@ module StashEngine
       result = OpenStruct.new(success?: false, error: 'No content')
       return result unless content
 
-      # convert into lines
+      lines = content_to_lines(content)
+
+      # convert the lines to a hash
+      hash = lines_to_hash(lines)
+      puts "HASH #{hash}"
+      
+      # clean authors (and any other parts of the hash that need cleaning)
+      # TODO clean_authors(hash)      
+
+      # TODO j = find_journal(hash)
+
+      # TODO ident = find_associated_identifier(hash)
+      
+#      mn = Manuscript.new(journal: j,
+#                          identififier: ident,
+#                          manuscript_number: hash['ms reference number'],
+#                          status: hash['article status'],
+#                          metadata: hash)
+
+      if lines.present?
+        result.delete_field('error')
+        result[:success?] = true
+#        result[:payload] = lines
+      end
+
+#      puts "RESULT #{result}"
+      result
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    private
+
+    # Breaks a large string of content into an array of lines,
+    # stripping any material after the ending tag
+    def self.content_to_lines(content)
       lines = content.split(%r{\n+|\r+|<br/>|<br />})
       puts "LIN #{lines}"
       # remove any lines after EndDryadContent
@@ -21,20 +55,39 @@ module StashEngine
           break
         end
       end
-      lines = lines[0..last_dryad_line] if last_dryad_line > 0
-
-      # determine the journal
-      # make a manuscript object for that journal
-
-      if lines.present?
-        result.delete_field('error')
-        result[:success?] = true
-        result[:payload] = lines
-      end
-
-      puts "RESULT #{result}"
-      result
+      lines = lines[0..last_dryad_line - 1] if last_dryad_line > 0
+      lines
     end
-    # rubocop:enable Metrics/MethodLength
+
+    def self.lines_to_hash(lines)
+      # Although journal emails may contain many fields, we only use the fields that are listed here
+      allowed_tags = ["journal code", "journal name", "ms reference number", "ms title", "ms authors", "article status",
+                      "publication doi", "keywords", "dryad data doi"]
+      hash = {}
+      lines.each_with_index do |line, index|
+        puts "-- ln #{index} -- #{line}"
+        next unless line.include?(':')
+        colon_index = line.index(':')
+        tag = line[0..colon_index-1].downcase
+        # if the line starts with a valid tag, add it to the hash
+        if allowed_tags.include?(tag)
+          value = line[colon_index+1..].strip
+          puts "  -- tag |#{tag}|#{value}|"
+          hash[tag] = value
+        end
+        # if the line starts the abstract, add all of the remaining lines, and break from the loop
+        if tag == "abstract"
+          value = line[colon_index+1..]
+          remaining_lines = lines[index+1..]
+          value += ' ' + remaining_lines.join(' ') if remaining_lines.present?
+          puts "  -- tag |#{tag}|#{value}|"
+          hash[tag] = value.strip
+          break
+        end
+        
+      end
+      hash
+    end
+    
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -3,5 +3,38 @@ module StashEngine
     belongs_to :journal
     belongs_to :identifier, optional: true
 
+    # rubocop:disable Metrics/MethodLength
+    def self.from_message_content(content:)
+      puts("CON #{content}")
+      result = OpenStruct.new(success?: false, error: 'No content')
+      return result unless content
+
+      # convert into lines
+      lines = content.split(%r{\n+|\r+|<br/>|<br />})
+      puts "LIN #{lines}"
+      # remove any lines after EndDryadContent
+      last_dryad_line = 0
+      lines.each_with_index do |val, index|
+        puts "#{val} => #{index}"
+        if val.include?('EndDryadContent')
+          last_dryad_line = index
+          break
+        end
+      end
+      lines = lines[0..last_dryad_line] if last_dryad_line > 0
+
+      # determine the journal
+      # make a manuscript object for that journal
+
+      if lines.present?
+        result.delete_field('error')
+        result[:success?] = true
+        result[:payload] = lines
+      end
+
+      puts "RESULT #{result}"
+      result
+    end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -3,90 +3,27 @@ module StashEngine
     belongs_to :journal
     belongs_to :identifier, optional: true
 
-    # rubocop:disable Metrics/MethodLength
+    # Create a new Manuscript from the content of an email message
     def self.from_message_content(content:)
       puts("CON #{content}")
       result = OpenStruct.new(success?: false, error: 'No content')
       return result unless content
-
-      lines = content_to_lines(content)
-
-      # convert the lines to a hash
-      hash = lines_to_hash(lines)
-      puts "HASH #{hash}"
       
-      # clean authors (and any other parts of the hash that need cleaning)
-      # TODO clean_authors(hash)      
-
-      # TODO j = find_journal(hash)
-
-      # TODO ident = find_associated_identifier(hash)
+      parser = EmailParser.new(content: content)
       
-#      mn = Manuscript.new(journal: j,
-#                          identififier: ident,
-#                          manuscript_number: hash['ms reference number'],
-#                          status: hash['article status'],
-#                          metadata: hash)
-
-      if lines.present?
+      manu = Manuscript.create(journal: parser.journal,
+                               identifier: parser.identifier,
+                               manuscript_number: parser.manuscript_number,
+                               status: parser.article_status,
+                               metadata: parser.metadata_hash)
+      
+      if manu.present?
         result.delete_field('error')
         result[:success?] = true
-#        result[:payload] = lines
+        result[:payload] = manu
       end
-
-#      puts "RESULT #{result}"
+      
       result
-    end
-    # rubocop:enable Metrics/MethodLength
-
-    private
-
-    # Breaks a large string of content into an array of lines,
-    # stripping any material after the ending tag
-    def self.content_to_lines(content)
-      lines = content.split(%r{\n+|\r+|<br/>|<br />})
-      puts "LIN #{lines}"
-      # remove any lines after EndDryadContent
-      last_dryad_line = 0
-      lines.each_with_index do |val, index|
-        puts "#{val} => #{index}"
-        if val.include?('EndDryadContent')
-          last_dryad_line = index
-          break
-        end
-      end
-      lines = lines[0..last_dryad_line - 1] if last_dryad_line > 0
-      lines
-    end
-
-    def self.lines_to_hash(lines)
-      # Although journal emails may contain many fields, we only use the fields that are listed here
-      allowed_tags = ["journal code", "journal name", "ms reference number", "ms title", "ms authors", "article status",
-                      "publication doi", "keywords", "dryad data doi"]
-      hash = {}
-      lines.each_with_index do |line, index|
-        puts "-- ln #{index} -- #{line}"
-        next unless line.include?(':')
-        colon_index = line.index(':')
-        tag = line[0..colon_index-1].downcase
-        # if the line starts with a valid tag, add it to the hash
-        if allowed_tags.include?(tag)
-          value = line[colon_index+1..].strip
-          puts "  -- tag |#{tag}|#{value}|"
-          hash[tag] = value
-        end
-        # if the line starts the abstract, add all of the remaining lines, and break from the loop
-        if tag == "abstract"
-          value = line[colon_index+1..]
-          remaining_lines = lines[index+1..]
-          value += ' ' + remaining_lines.join(' ') if remaining_lines.present?
-          puts "  -- tag |#{tag}|#{value}|"
-          hash[tag] = value.strip
-          break
-        end
-        
-      end
-      hash
     end
     
   end

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -1,0 +1,7 @@
+module StashEngine
+  class Manuscript < ApplicationRecord
+    belongs_to :journal
+    belongs_to :identifier, optional: true
+
+  end
+end

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -2,29 +2,30 @@ module StashEngine
   class Manuscript < ApplicationRecord
     belongs_to :journal
     belongs_to :identifier, optional: true
+    serialize :metadata
 
     # Create a new Manuscript from the content of an email message
     def self.from_message_content(content:)
       puts("CON #{content}")
       result = OpenStruct.new(success?: false, error: 'No content')
       return result unless content
-      
+
       parser = EmailParser.new(content: content)
-      
+
       manu = Manuscript.create(journal: parser.journal,
                                identifier: parser.identifier,
                                manuscript_number: parser.manuscript_number,
                                status: parser.article_status,
                                metadata: parser.metadata_hash)
-      
-      if manu.present?
+
+      if manu.present? && manu.id.present?
         result.delete_field('error')
         result[:success?] = true
         result[:payload] = manu
       end
-      
+
       result
     end
-    
+
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -6,7 +6,6 @@ module StashEngine
 
     # Create a new Manuscript from the content of an email message
     def self.from_message_content(content:)
-      puts("CON #{content}")
       result = OpenStruct.new(success?: false, error: 'No content')
       return result unless content
 

--- a/stash/stash_engine/app/services/stash_engine/email_parser.rb
+++ b/stash/stash_engine/app/services/stash_engine/email_parser.rb
@@ -1,30 +1,20 @@
 module StashEngine
 
+  # rubocop:disable Metrics/ClassLength, Metrics/MethodLength
   class EmailParser
+    attr_reader :journal, :identifier
 
     def initialize(content:)
       @content = content
       parse
-    end      
-
-    def journal
-      #TODO
-      nil
-    end
-
-    def identifier
-      #TODO
-      nil
     end
 
     def manuscript_number
-      #TODO
-      nil
+      @hash['ms reference number']
     end
 
     def article_status
-      #TODO
-      nil
+      @hash['article status']
     end
 
     def metadata_hash
@@ -32,71 +22,71 @@ module StashEngine
     end
 
     private
-    
+
     def parse
-      @lines = content_to_lines
-      
-      # convert the lines to a hash
-      @hash = lines_to_hash
-      puts "HASH #{hash}"
-      
+      parse_content_to_lines
+      lines_to_hash
+      puts "HASH #{@hash}"
+
+      find_journal
+      puts "JOURNAL #{@journal}"
+
       # clean authors (and any other parts of the hash that need cleaning)
-      # TODO clean_authors(hash)      
-      
-      j = find_journal
-      puts "JOURNAL #{j}"
-      
-      # TODO ident = find_associated_identifier(hash)
+      clean_authors
+      puts "AUTH #{@hash['ms authors']}"
+
+      # TODO: ident = find_associated_identifier(hash)
     end
 
     # Breaks a large string of content into an array of lines,
     # stripping any material after the ending tag
-    def content_to_lines
-      lines = @content.split(%r{\n+|\r+|<br/>|<br />|<BR/>|<BR />})
-      puts "LIN #{lines}"
+    def parse_content_to_lines
+      @lines = @content.split(%r{\n+|\r+|<br/>|<br />|<BR/>|<BR />})
+      puts "LIN #{@lines}"
       # remove any lines after EndDryadContent
       last_dryad_line = 0
-      lines.each_with_index do |val, index|
+      @lines.each_with_index do |val, index|
         puts "#{val} => #{index}"
         if val.include?('EndDryadContent')
           last_dryad_line = index
           break
         end
       end
-      lines = lines[0..last_dryad_line - 1] if last_dryad_line > 0
-      @lines = lines
+      @lines = @lines[0..last_dryad_line - 1] if last_dryad_line > 0
+      @lines
     end
-    
+
     def lines_to_hash
       # Although journal emails may contain many fields, we only use the fields that are listed here
-      allowed_tags = ["journal code", "journal name", "ms reference number", "ms title", "ms authors", "article status",
-                      "publication doi", "keywords", "dryad data doi", "print issn", "online issn"]
-      @hash = {}
+      allowed_tags = ['journal code', 'journal name', 'ms reference number', 'ms title', 'ms authors', 'article status',
+                      'publication doi', 'keywords', 'dryad data doi', 'print issn', 'online issn']
+      @hash = {}.with_indifferent_access
       @lines.each_with_index do |line, index|
         puts "-- ln #{index} -- #{line}"
         next unless line.include?(':')
+
         colon_index = line.index(':')
-        tag = line[0..colon_index-1].downcase
+        tag = line[0..colon_index - 1].downcase
         # if the line starts with a valid tag, add it to the hash
         if allowed_tags.include?(tag)
-          value = line[colon_index+1..].strip
+          value = line[colon_index + 1..].strip
           puts "  -- tag |#{tag}|#{value}|"
           @hash[tag] = value
         end
         # if the line starts the abstract, add all of the remaining lines, and break from the loop
-        if tag == "abstract"
-          value = line[colon_index+1..]
-          remaining_lines = @lines[index+1..]
-          value += ' ' + remaining_lines.join(' ') if remaining_lines.present?
-          puts "  -- tag |#{tag}|#{value}|"
-          @hash[tag] = value.strip
-          break
-        end
-        
+        next unless tag == 'abstract'
+
+        value = line[colon_index + 1..]
+        remaining_lines = @lines[index + 1..]
+        value += " #{remaining_lines.join(' ')}" if remaining_lines.present?
+        puts "  -- tag |#{tag}|#{value}|"
+        @hash[tag] = value.strip
+        break
+
       end
       @hash
     end
-    
+
     def find_journal
       puts "HASH #{@hash}"
       @journal = nil
@@ -104,11 +94,11 @@ module StashEngine
       @journal = StashEngine::Journal.where(journal_code: @hash['journal code'].downcase).first if @hash['journal code']
       puts "    -- j1 #{@journal}"
       return if @journal
-            
+
       @journal = StashEngine::Journal.where(issn: @hash['print issn']).first if @hash['print issn']
       puts "    -- j2 #{@journal}"
       return if @journal
-      
+
       @journal = StashEngine::Journal.where(issn: @hash['online issn']).first if @hash['online issn']
       puts "    -- j3 #{@journal}"
       return if @journal
@@ -119,5 +109,81 @@ module StashEngine
       @journal
     end
 
+    # Convert the author string into an array of names
+    # Author lists generally come as either "last, first; last, first"
+    # or as "first last, first last and first last" (sometimes with the Oxford comma before the 'and' token)
+    def clean_authors
+      author_string = @hash['ms authors']
+      return unless author_string
+
+      authors = []
+
+      # first check to see if the authors are semicolon-separated
+      split_string = author_string.split(';')
+      puts "SPLIT #{split_string}"
+
+      # if it didn't have semicolons, it must have commas
+      if split_string.size == 1
+        split_string = author_string.split(',')
+
+        # although, if there was only one author and it was listed as lastname, firstname, it would have a comma too...
+        if split_string.length == 2 && !split_string[1].include?(' and ')
+          authors << [split_string[0], split_string[1]]
+          split_string = []
+        end
+      end
+
+      split_string.each do |auth|
+        if auth.include?(' and ')
+          # It's the end of the list, so we parse both names
+          two_auths = auth.split(' and ')
+          authors << parse_author_name(two_auths[0])
+          authors << parse_author_name(two_auths[1])
+        else
+          authors << parse_author_name(auth)
+        end
+      end
+
+      @hash['ms authors'] = authors
+    end
+
+    # Parse the name of a single author
+    # @return {family_name:, given_name:}]
+    def parse_author_name(auth)
+      # Remove any leading title, like Dr., Mrs.
+      auth.strip!
+      auth.gsub!(/^[DM]+r*s*\.*\s+/, '')
+      suffix = ''
+
+      # is there a comma in the name?
+      # it could either be lastname, firstname, or firstname lastname, title
+      # rubocop:disable Style/CaseLikeIf
+      comma_match = auth.match(/^(.+),\s*(.+)$/)
+      if comma_match
+        if comma_match[2].match(/(Jr\.*|Sr\.*|III)/)
+          # if it's a suffix situation, then part 1 is "firstname lastname"
+          # the last name will be the last word in group 1 + ", " + suffix
+          suffix = ", #{comma_match[2].strip}"
+          auth = comma_match[1]
+        elsif comma_match[2].match(/(Ph|J)\.*D\.*|M\.*[DAS]c*\.*/)
+          # if it's a title situation, throw the title away and assume the part before is "firstname lastname"
+          auth = comma_match[1]
+        else
+          # it's simply "lastname, firstname", so return it in that order
+          return { family_name: comma_match[1], given_name: comma_match[2] }.with_indifferent_access
+        end
+      end
+      # rubocop:enable Style/CaseLikeIf
+
+      space_match = auth.match(/^(.+) +(.*)$/)
+      if space_match
+        { family_name: "#{space_match[2]}#{suffix}", given_name: space_match[1] }.with_indifferent_access
+      else
+        # there is only one word in the name: assign it to the familyName
+        { family_name: auth, given_name: '' }.with_indifferent_access
+      end
+    end
+
   end
 end
+# rubocop:enable Metrics/ClassLength, Metrics/MethodLength

--- a/stash/stash_engine/app/services/stash_engine/email_parser.rb
+++ b/stash/stash_engine/app/services/stash_engine/email_parser.rb
@@ -27,7 +27,9 @@ module StashEngine
       parse_content_to_lines
       lines_to_hash
       find_journal
+      parse_keywords
       parse_author_list
+      parse_manuscript_number
       find_associated_identifier
     end
 
@@ -197,6 +199,24 @@ module StashEngine
         # there is only one word in the name: assign it to the familyName
         { family_name: auth, given_name: '' }.with_indifferent_access
       end
+    end
+
+    def parse_keywords
+      return [] if @hash['keywords'].blank?
+
+      @hash['keywords'] = @hash['keywords'].split(/[,;]/).map(&:strip)
+    end
+
+    # Apply the journal's regex to the manuscript number, removing any irrelevant parts
+    def parse_manuscript_number
+      regex = @journal&.manuscript_number_regex
+      return if regex.blank?
+
+      msid = @hash['ms reference number']
+      return if msid.match(regex).blank?
+
+      result = msid.match(regex)[1]
+      @hash['ms reference number'] = result if result.present?
     end
 
   end

--- a/stash/stash_engine/app/services/stash_engine/email_parser.rb
+++ b/stash/stash_engine/app/services/stash_engine/email_parser.rb
@@ -1,0 +1,123 @@
+module StashEngine
+
+  class EmailParser
+
+    def initialize(content:)
+      @content = content
+      parse
+    end      
+
+    def journal
+      #TODO
+      nil
+    end
+
+    def identifier
+      #TODO
+      nil
+    end
+
+    def manuscript_number
+      #TODO
+      nil
+    end
+
+    def article_status
+      #TODO
+      nil
+    end
+
+    def metadata_hash
+      @hash
+    end
+
+    private
+    
+    def parse
+      @lines = content_to_lines
+      
+      # convert the lines to a hash
+      @hash = lines_to_hash
+      puts "HASH #{hash}"
+      
+      # clean authors (and any other parts of the hash that need cleaning)
+      # TODO clean_authors(hash)      
+      
+      j = find_journal
+      puts "JOURNAL #{j}"
+      
+      # TODO ident = find_associated_identifier(hash)
+    end
+
+    # Breaks a large string of content into an array of lines,
+    # stripping any material after the ending tag
+    def content_to_lines
+      lines = @content.split(%r{\n+|\r+|<br/>|<br />})
+      puts "LIN #{lines}"
+      # remove any lines after EndDryadContent
+      last_dryad_line = 0
+      lines.each_with_index do |val, index|
+        puts "#{val} => #{index}"
+        if val.include?('EndDryadContent')
+          last_dryad_line = index
+          break
+        end
+      end
+      lines = lines[0..last_dryad_line - 1] if last_dryad_line > 0
+      @lines = lines
+    end
+    
+    def lines_to_hash
+      # Although journal emails may contain many fields, we only use the fields that are listed here
+      allowed_tags = ["journal code", "journal name", "ms reference number", "ms title", "ms authors", "article status",
+                      "publication doi", "keywords", "dryad data doi", "print issn", "online issn"]
+      @hash = {}
+      @lines.each_with_index do |line, index|
+        puts "-- ln #{index} -- #{line}"
+        next unless line.include?(':')
+        colon_index = line.index(':')
+        tag = line[0..colon_index-1].downcase
+        # if the line starts with a valid tag, add it to the hash
+        if allowed_tags.include?(tag)
+          value = line[colon_index+1..].strip
+          puts "  -- tag |#{tag}|#{value}|"
+          @hash[tag] = value
+        end
+        # if the line starts the abstract, add all of the remaining lines, and break from the loop
+        if tag == "abstract"
+          value = line[colon_index+1..]
+          remaining_lines = @lines[index+1..]
+          value += ' ' + remaining_lines.join(' ') if remaining_lines.present?
+          puts "  -- tag |#{tag}|#{value}|"
+          @hash[tag] = value.strip
+          break
+        end
+        
+      end
+      @hash
+    end
+    
+    def find_journal
+      puts "HASH #{@hash}"
+      @journal = nil
+      # prefer finding by journal code, fallback to ISSN or title
+      @journal = StashEngine::Journal.where(journal_code: @hash['journal code'].downcase).first if @hash['journal code']
+      puts "    -- j1 #{@journal}"
+      return if @journal
+            
+      @journal = StashEngine::Journal.where(issn: @hash['print issn']).first if @hash['print issn']
+      puts "    -- j2 #{@journal}"
+      return if @journal
+      
+      @journal = StashEngine::Journal.where(issn: @hash['online issn']).first if @hash['online issn']
+      puts "    -- j3 #{@journal}"
+      return if @journal
+
+      @journal = StashEngine::Journal.where(title: @hash['journal name']).first if @hash['journal name']
+
+      puts "    -- j4 #{@journal}"
+      @journal
+    end
+
+  end
+end

--- a/stash/stash_engine/app/services/stash_engine/email_parser.rb
+++ b/stash/stash_engine/app/services/stash_engine/email_parser.rb
@@ -60,6 +60,7 @@ module StashEngine
       # Although journal emails may contain many fields, we only use the fields that are listed here
       allowed_tags = ['journal code', 'journal name', 'ms reference number', 'ms title', 'ms authors', 'article status',
                       'publication doi', 'keywords', 'dryad data doi', 'print issn', 'online issn']
+      downcase_tags = ['journal code', 'article status', 'publication doi', 'dryad data doi']
       @hash = {}.with_indifferent_access
       @lines.each_with_index do |line, index|
         puts "-- ln #{index} -- #{line}"
@@ -70,6 +71,7 @@ module StashEngine
         # if the line starts with a valid tag, add it to the hash
         if allowed_tags.include?(tag)
           value = line[colon_index + 1..].strip
+          value.downcase! if downcase_tags.include?(tag)
           puts "  -- tag |#{tag}|#{value}|"
           @hash[tag] = value
         end
@@ -152,7 +154,7 @@ module StashEngine
 
         # although, if there was only one author and it was listed as lastname, firstname, it would have a comma too...
         if split_string.length == 2 && !split_string[1].include?(' and ')
-          authors << [split_string[0], split_string[1]]
+          authors << [split_string[0].strip, split_string[1].strip]
           split_string = []
         end
       end
@@ -194,14 +196,14 @@ module StashEngine
           auth = comma_match[1]
         else
           # it's simply "lastname, firstname", so return it in that order
-          return { family_name: comma_match[1], given_name: comma_match[2] }.with_indifferent_access
+          return { family_name: comma_match[1].strip, given_name: comma_match[2].strip }.with_indifferent_access
         end
       end
       # rubocop:enable Style/CaseLikeIf
 
       space_match = auth.match(/^(.+) +(.*)$/)
       if space_match
-        { family_name: "#{space_match[2]}#{suffix}", given_name: space_match[1] }.with_indifferent_access
+        { family_name: "#{space_match[2].strip}#{suffix}", given_name: space_match[1].strip }.with_indifferent_access
       else
         # there is only one word in the name: assign it to the familyName
         { family_name: auth, given_name: '' }.with_indifferent_access

--- a/stash/stash_engine/app/services/stash_engine/email_parser.rb
+++ b/stash/stash_engine/app/services/stash_engine/email_parser.rb
@@ -42,11 +42,9 @@ module StashEngine
     # stripping any material after the ending tag
     def parse_content_to_lines
       @lines = @content.split(%r{\n+|\r+|<br/>|<br />|<BR/>|<BR />})
-      puts "LIN #{@lines}"
       # remove any lines after EndDryadContent
       last_dryad_line = 0
       @lines.each_with_index do |val, index|
-        puts "#{val} => #{index}"
         if val.include?('EndDryadContent')
           last_dryad_line = index
           break
@@ -63,7 +61,6 @@ module StashEngine
       downcase_tags = ['journal code', 'article status', 'publication doi', 'dryad data doi']
       @hash = {}.with_indifferent_access
       @lines.each_with_index do |line, index|
-        puts "-- ln #{index} -- #{line}"
         next unless line.include?(':')
 
         colon_index = line.index(':')
@@ -72,7 +69,6 @@ module StashEngine
         if allowed_tags.include?(tag)
           value = line[colon_index + 1..].strip
           value.downcase! if downcase_tags.include?(tag)
-          puts "  -- tag |#{tag}|#{value}|"
           @hash[tag] = value
         end
         # if the line starts the abstract, add all of the remaining lines, and break from the loop
@@ -81,7 +77,6 @@ module StashEngine
         value = line[colon_index + 1..]
         remaining_lines = @lines[index + 1..]
         value += " #{remaining_lines.join(' ')}" if remaining_lines.present?
-        puts "  -- tag |#{tag}|#{value}|"
         @hash[tag] = value.strip
         break
 
@@ -90,24 +85,19 @@ module StashEngine
     end
 
     def find_journal
-      puts "HASH #{@hash}"
       @journal = nil
       # prefer finding by journal code, fallback to ISSN or title
       @journal = StashEngine::Journal.where(journal_code: @hash['journal code'].downcase).first if @hash['journal code']
-      puts "    -- j1 #{@journal}"
       return if @journal
 
       @journal = StashEngine::Journal.where(issn: @hash['print issn']).first if @hash['print issn']
-      puts "    -- j2 #{@journal}"
       return if @journal
 
       @journal = StashEngine::Journal.where(issn: @hash['online issn']).first if @hash['online issn']
-      puts "    -- j3 #{@journal}"
       return if @journal
 
       @journal = StashEngine::Journal.where(title: @hash['journal name']).first if @hash['journal name']
 
-      puts "    -- j4 #{@journal}"
       @journal
     end
 
@@ -115,7 +105,6 @@ module StashEngine
       @identifier = nil
       # prefer finding by data doi
       data_doi = @hash['dryad data doi']
-      puts "DATA DOI #{data_doi}"
       if data_doi
         data_doi.downcase!
         data_doi.sub!(/^doi:/, '')
@@ -146,7 +135,6 @@ module StashEngine
 
       # first check to see if the authors are semicolon-separated
       split_string = author_string.split(';')
-      puts "SPLIT #{split_string}"
 
       # if it didn't have semicolons, it must have commas
       if split_string.size == 1

--- a/stash/stash_engine/app/services/stash_engine/email_parser.rb
+++ b/stash/stash_engine/app/services/stash_engine/email_parser.rb
@@ -52,7 +52,7 @@ module StashEngine
     # Breaks a large string of content into an array of lines,
     # stripping any material after the ending tag
     def content_to_lines
-      lines = @content.split(%r{\n+|\r+|<br/>|<br />})
+      lines = @content.split(%r{\n+|\r+|<br/>|<br />|<BR/>|<BR />})
       puts "LIN #{lines}"
       # remove any lines after EndDryadContent
       last_dryad_line = 0

--- a/stash/stash_engine/db/migrate/20210412142929_create_stash_engine_manuscripts.rb
+++ b/stash/stash_engine/db/migrate/20210412142929_create_stash_engine_manuscripts.rb
@@ -1,0 +1,12 @@
+class CreateStashEngineManuscripts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :stash_engine_manuscripts do |t|
+      t.belongs_to :journal
+      t.belongs_to :identifier, optional: true
+      t.string :manuscript_number
+      t.string :status
+      t.text :metadata, limit: 16.megabytes - 1
+      t.timestamps
+    end
+  end
+end

--- a/stash/stash_engine/db/migrate/20210415204844_add_code_to_journals.rb
+++ b/stash/stash_engine/db/migrate/20210415204844_add_code_to_journals.rb
@@ -1,0 +1,5 @@
+class AddCodeToJournals < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stash_engine_journals, :journal_code, :string
+  end
+end

--- a/stash/stash_engine/lib/stash/google/journal_gmail.rb
+++ b/stash/stash_engine/lib/stash/google/journal_gmail.rb
@@ -110,10 +110,10 @@ module Stash
           result = StashEngine::Manuscript.from_message_content(content: content)
           if result.success?
             puts "-- created #{result.payload}"
-          # TODO-reinstate-when-tested  remove_processing_label(message: m)
+            remove_processing_label(message: m)
           else
             puts "-- ERROR #{result.error} -- Adding error label to #{m.id}"
-            # TODO-reinstate add_error_label(message: m)
+            add_error_label(message: m)
           end
         end
       end

--- a/stash/stash_engine/lib/tasks/migration.rake
+++ b/stash/stash_engine/lib/tasks/migration.rake
@@ -23,8 +23,13 @@ namespace :dryad_migration do
     end
   end
 
-  desc 'Migrate content from the v1 journal module'
+  desc 'DEPRECATED -- Migrate content from the v1 journal module'
   task migrate_journal_metadata: :environment do
+    puts 'WARNING! This task is deprecated --- data in the v1 server is no longer up to date, ' \
+         'so please do not import it into a current Dryad production system! ' \
+         'You will have 1 minute to cancel before this script proceeds.'
+    sleep(1.minute)
+
     File.foreach('journalISSNs.txt') do |issn|
       issn = issn.strip
       url = "#{APP_CONFIG.old_dryad_url}/api/v1/journals/#{issn}"

--- a/stash/stash_engine/lib/tasks/migration.rake
+++ b/stash/stash_engine/lib/tasks/migration.rake
@@ -7,6 +7,22 @@ require 'database_cleaner'
 
 # rubocop:disable Metrics/BlockLength
 namespace :dryad_migration do
+  desc 'Import journal codes from a local file'
+  task import_journal_codes: :environment do
+    File.foreach('journal_codes.csv') do |line|
+      code, issn = line.split(',')
+      code.downcase!
+      issn.chomp!
+      puts "code=#{code} issn=#{issn}"
+      journal = StashEngine::Journal.where(issn: issn).first
+      if journal
+        journal.journal_code = code
+        journal.save
+        puts "  -- #{code} saved to #{journal.title}"
+      end
+    end
+  end
+
   desc 'Migrate content from the v1 journal module'
   task migrate_journal_metadata: :environment do
     File.foreach('journalISSNs.txt') do |issn|

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -355,6 +355,11 @@ namespace :journal_email do
   task validate_gmail_connection: :environment do
     Stash::Google::JournalGMail.validate_gmail_connection
   end
+
+  desc 'Process all messages in the GMail account that have the target label'
+  task process: :environment do
+    Stash::Google::JournalGMail.process
+  end
 end
 
 # rubocop:enable Metrics/BlockLength

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -360,6 +360,11 @@ namespace :journal_email do
   task process: :environment do
     Stash::Google::JournalGMail.process
   end
+
+  desc 'Clean outdated manuscript entries'
+  task clean_old_manuscripts: :environment do
+    StashEngine::Manuscript.where('created_at < ?', 2.years.ago).delete_all
+  end
 end
 
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1188

This builds on https://github.com/CDL-Dryad/dryad-app/pull/443, so you can either review that first, or just this one for everything together.

This PR connects the Manuscript model to the Dryad submission system, and removes reliance on the v1 journal module. 

To test:
1. Ensure the GMail connection is authorized and journal codes are imported, as described in https://github.com/CDL-Dryad/dryad-app/pull/443
2. Parse at least one email message, as described in https://github.com/CDL-Dryad/dryad-app/pull/443
3. Create a new Dryad dataset in the submission system.
4. Enter the journal name and manuscript number associated with the email you parsed, and click "Import Manuscript Metadata"
5. All of the details from the email should get imported into the dataset.