### PR TITLE
One off script for duplicating dataset version into a new dataset

### DIFF
--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -172,6 +172,63 @@ namespace :dev_ops do
     puts 'Done'
   end
 
+  desc 'Takes a DOI, user_id (number), tenant_id and copies the latest submitted version into a new dataset for manual submission'
+  task version_into_new_dataset: :environment do
+    # apparently I have to do this, at least in some cases because arguments to rake are ugly
+    # https://www.seancdavis.com/blog/4-ways-to-pass-arguments-to-a-rake-task/
+
+    # rubocop:disable Style/BlockDelimiters
+    ARGV.each { |a| task a.to_sym do; end }
+    # rubocop:enable Style/BlockDelimiters
+
+    unless ENV['RAILS_ENV']
+      puts 'RAILS_ENV must be explicitly set before running this script'
+      next
+    end
+
+    unless ARGV.length == 4
+      puts 'takes DOI, user_id (number from db), tenant_id -- please quote the DOI and do only bare DOI like 10.18737/D7CC8B'
+      next
+    end
+
+    identif_str = ARGV[1].strip
+    user_id = ARGV[2].strip.to_i
+    tenant_id = ARGV[3].strip
+
+    # get the identifier
+    dryad_id_obj = StashEngine::Identifier.where(identifier: identif_str).first
+
+    # get the the last resource
+    last_res = dryad_id_obj.resources.submitted_only.last
+
+    # duplicate the resource
+    new_res = last_res.amoeba_dup
+    new_res.tenant_id = tenant_id
+    new_res.identifier_id = nil
+
+    new_res.save
+
+    # Now create new identifier
+    my_id = Stash::Doi::IdGen.mint_id(resource: new_res)
+    id_type, id_text = my_id.split(':', 2)
+    db_id_obj = StashEngine::Identifier.create(identifier: id_text, identifier_type: id_type.upcase)
+
+    # cleanup some old garbage from merritt-sword and reset user
+    new_res.update(identifier_id: db_id_obj.id, user_id: user_id, current_editor_id: user_id, download_uri: nil, update_uri: nil)
+
+    # update the versions to be version 1, since otherwise it will be version number from old resource
+    new_res.stash_version.update(version: 1, merritt_version: 1)
+
+    # update all the files so they can be downloaded from presigned URLs from Merritt to put into this
+    new_res.data_files.present_files.each do |f|
+      last_f = StashEngine::DataFile.where(resource_id: last_res.id, upload_file_name: f.upload_file_name).present_files.first
+      f.update(url: last_f.merritt_s3_presigned_url, file_state: 'created', status_code: 200)
+    end
+
+    # delete any file records for deleted items
+    new_res.data_files.deleted_from_version.each {|f| f.destroy!}
+  end
+
   desc 'Updates database for Merritt ark changes'
   task embargo_zenodo: :environment do
     # apparently I have to do this, at least in some cases because arguments to rake are ugly

--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -226,7 +226,7 @@ namespace :dev_ops do
     end
 
     # delete any file records for deleted items
-    new_res.data_files.deleted_from_version.each {|f| f.destroy!}
+    new_res.data_files.deleted_from_version.each(&:destroy!)
   end
 
   desc 'Updates database for Merritt ark changes'


### PR DESCRIPTION
This is a little crazy and a one-off for some datasets that got deposited and the EZID DOIs were invalid because of some account thing.  So now they need to get new DOis and the DOIs need to to be for UC Santa Cruz.

Originally, we thought we could just do some local_id fun in Merritt to fix the DOIs if we made new ones, but apparently it's hard or impossible.

This script is kind of hack-ish.  What it does is 1) create a new resource for a dataset with Amoeba dup; 2) reset some info on it so it's no longer associated with the old identifier; 3) generates a new identifier under the preferred tenant; 4) re-associates the resource with the new identifier instead and resets versions back to version 1; 5) generates presigned URLs from Merritt for every Merritt file present in the old dataset; 6) removes any deleted files.

After all this is done the item is an "in progress" dataset that someone can go look over and submit from the user interface before the merritt presigned URLs expire since they're used to ingest it again into Merritt for the new dataset.

I didn't really add tests since this may not ever be used again and people will look over the new datasets it creates before manually submitting them.