### PR TITLE
Scripting to delete datasets

### DIFF
--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -172,6 +172,63 @@ namespace :dev_ops do
     puts 'Done'
   end
 
+  desc 'Takes a DOI, user_id (number), tenant_id and copies the latest submitted version into a new dataset for manual submission'
+  task version_into_new_dataset: :environment do
+    # apparently I have to do this, at least in some cases because arguments to rake are ugly
+    # https://www.seancdavis.com/blog/4-ways-to-pass-arguments-to-a-rake-task/
+
+    # rubocop:disable Style/BlockDelimiters
+    ARGV.each { |a| task a.to_sym do; end }
+    # rubocop:enable Style/BlockDelimiters
+
+    unless ENV['RAILS_ENV']
+      puts 'RAILS_ENV must be explicitly set before running this script'
+      next
+    end
+
+    unless ARGV.length == 4
+      puts 'takes DOI, user_id (number from db), tenant_id -- please quote the DOI and do only bare DOI like 10.18737/D7CC8B'
+      next
+    end
+
+    identif_str = ARGV[1].strip
+    user_id = ARGV[2].strip.to_i
+    tenant_id = ARGV[3].strip
+
+    # get the identifier
+    dryad_id_obj = StashEngine::Identifier.where(identifier: identif_str).first
+
+    # get the the last resource
+    last_res = dryad_id_obj.resources.submitted_only.last
+
+    # duplicate the resource
+    new_res = last_res.amoeba_dup
+    new_res.tenant_id = tenant_id
+    new_res.identifier_id = nil
+
+    new_res.save
+
+    # Now create new identifier
+    my_id = Stash::Doi::IdGen.mint_id(resource: new_res)
+    id_type, id_text = my_id.split(':', 2)
+    db_id_obj = StashEngine::Identifier.create(identifier: id_text, identifier_type: id_type.upcase)
+
+    # cleanup some old garbage from merritt-sword and reset user
+    new_res.update(identifier_id: db_id_obj.id, user_id: user_id, current_editor_id: user_id, download_uri: nil, update_uri: nil)
+
+    # update the versions to be version 1, since otherwise it will be version number from old resource
+    new_res.stash_version.update(version: 1, merritt_version: 1)
+
+    # update all the files so they can be downloaded from presigned URLs from Merritt to put into this
+    new_res.data_files.present_files.each do |f|
+      last_f = StashEngine::DataFile.where(resource_id: last_res.id, upload_file_name: f.upload_file_name).present_files.first
+      f.update(url: last_f.merritt_s3_presigned_url, file_state: 'created', status_code: 200)
+    end
+
+    # delete any file records for deleted items
+    new_res.data_files.deleted_from_version.each {|f| f.destroy!}
+  end
+
   desc 'Updates database for Merritt ark changes'
   task embargo_zenodo: :environment do
     # apparently I have to do this, at least in some cases because arguments to rake are ugly

--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -226,7 +226,7 @@ namespace :dev_ops do
     end
 
     # delete any file records for deleted items
-    new_res.data_files.deleted_from_version.each {|f| f.destroy!}
+    new_res.data_files.deleted_from_version.each(&:destroy!)
   end
 
   desc 'Updates database for Merritt ark changes'

--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -288,6 +288,8 @@ namespace :dev_ops do
       puts "deposition_id: #{zc.deposition_id}, copy_type: #{zc.copy_type}, doi: #{zc.software_doi || identifier.identifier}"
     end
 
+    puts "\nAsk Merritt to remove the item with url #{identifier.resources.first.download_uri}\n"
+
     puts "\nRemoving from the database\n"
 
     identifier.destroy!

--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -1,6 +1,8 @@
 require 'yaml'
 require_relative 'dev_ops/passenger'
 require_relative 'dev_ops/download_uri'
+require 'rsolr'
+require 'ezid/client'
 
 # rubocop:disable Metrics/BlockLength
 namespace :dev_ops do
@@ -227,6 +229,68 @@ namespace :dev_ops do
 
     # delete any file records for deleted items
     new_res.data_files.deleted_from_version.each(&:destroy!)
+  end
+
+  desc 'Takes a DOI (bare, without doi on front) and destroys it'
+  task destroy_dataset: :environment do
+    # apparently I have to do this, at least in some cases because arguments to rake are ugly
+    # https://www.seancdavis.com/blog/4-ways-to-pass-arguments-to-a-rake-task/
+
+    # rubocop:disable Style/BlockDelimiters
+    ARGV.each { |a| task a.to_sym do; end }
+    # rubocop:enable Style/BlockDelimiters
+
+    unless ENV['RAILS_ENV']
+      puts 'RAILS_ENV must be explicitly set before running this script'
+      next
+    end
+
+    unless ARGV.length == 2
+      puts 'Takes a DOI (bare, without doi on front) and destroys it like 10.18737/D7CC8B'
+      next
+    end
+
+    identif_str = ARGV[1].strip
+
+    puts "Are you sure you want to delete #{identif_str}?  (Type 'yes' to proceed)"
+    response = $stdin.gets
+    exit unless response.strip.casecmp('YES').zero?
+
+    # get identifier
+    identifier = StashEngine::Identifier.where(identifier: identif_str).first
+
+    if identifier.nil?
+      puts 'The DOI was not found to remove'
+      exit
+    end
+
+    puts 'Deleting from SOLR'
+    solr = RSolr.connect url: Blacklight.connection_config[:url]
+    solr.delete_by_query("uuid:\"doi:#{identif_str}\"")
+    solr.commit
+
+    tenant = identifier.resources.last.tenant
+    if tenant.identifier_service.provider == 'ezid'
+      puts 'tombstoning EZID'
+      ezid_client = ::Ezid::Client.new(user: tenant.identifier_service.account, password: tenant.identifier_service.password)
+      params = { status: 'unavailable | withdrawn' }
+      begin
+        ezid_client.modify_identifier("doi:#{identif_str}", params)
+      rescue Ezid::IdentifierNotFoundError
+        puts "EZID couldn't find identifier to create a tombstone"
+      end
+    else
+      puts 'Please remove access in the DataCite UI -- this functionality may be added later'
+    end
+
+    puts "\nYou may need to ask Zenodo to remove the following deposition_ids or DOIs manually"
+    identifier.zenodo_copies.order(:deposition_id, :copy_type).each do |zc|
+      puts "deposition_id: #{zc.deposition_id}, copy_type: #{zc.copy_type}, doi: #{zc.software_doi || identifier.identifier}"
+    end
+
+    puts "\nRemoving from the database\n"
+
+    identifier.destroy!
   end
 
   desc 'Updates database for Merritt ark changes'


### PR DESCRIPTION
I had to delete 19 at once so didn't want to have to do all the steps by hand for all 19.

Example to run:

```
RAILS_ENV=development rails dev_ops:destroy_dataset "10.5072/FK25T3QP13"
```

It will 1) Remove from SOLR, 2) Tombstone in EZID or remind you to do something in DataCite UI--we can build this out later if we want to automate, 3) List all the Zenodo dependencies you should ask them to remove, 4) destroy from our database.

I'll add a note in confluence.