### PR TITLE
Add provenance info for datasets created via API

### DIFF
--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -113,13 +113,13 @@ module StashApi
         expect(output[:locations].first[:place]).to eq(@meta.hash[:locations].first[:place])
       end
 
-      it 'creates a new curation activity and sets the publication date' do
+      it 'creates new curation activities and sets the publication date' do
         response_code = post '/api/v2/datasets', params: @meta.json, headers: default_authenticated_headers
         output = response_body_hash
         expect(response_code).to eq(201)
         @stash_id = StashEngine::Identifier.find(output[:id])
         @resource = @stash_id.resources.last
-        expect(@resource.curation_activities.size).to eq(1)
+        expect(@resource.curation_activities.size).to eq(2) # one for default creation, one for the API
 
         @curation_activity = Fixtures::StashApi::CurationMetadata.new
         dataset_id = CGI.escape(output[:identifier])
@@ -129,7 +129,7 @@ module StashApi
         expect(response_code).to eq(200)
 
         @resource.reload
-        expect(@resource.curation_activities.size).to eq(2)
+        expect(@resource.curation_activities.size).to eq(3)
         expect(@resource.publication_date).to be
       end
 
@@ -139,7 +139,7 @@ module StashApi
         expect(response_code).to eq(201)
         @stash_id = StashEngine::Identifier.find(output[:id])
         @resource = @stash_id.resources.last
-        expect(@resource.curation_activities.size).to eq(1)
+        expect(@resource.curation_activities.size).to eq(2)
 
         # Set a publication date in the past
         publish_date = Time.now - 10.days
@@ -153,7 +153,7 @@ module StashApi
         expect(response_code).to eq(200)
 
         @resource.reload
-        expect(@resource.curation_activities.size).to eq(2)
+        expect(@resource.curation_activities.size).to eq(3)
         expect(@resource.publication_date).to be_within(10.days).of(publish_date)
       end
     end

--- a/stash/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser.rb
@@ -23,8 +23,13 @@ module StashApi
     end
 
     # this is the basic required metadata
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def parse
       clear_previous_metadata
+      @resource.curation_activities << StashEngine::CurationActivity.create(status: @resource.current_curation_status || 'in_progress',
+                                                                            user_id: @user.id,
+                                                                            resource_id: @resource.id,
+                                                                            note: 'Created by API user')
       owning_user_id = establish_owning_user_id
       @resource.update(
         title: @hash['title'],
@@ -45,6 +50,7 @@ module StashApi
       @resource.identifier.save
       @resource.identifier
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     private
 

--- a/stash/stash_engine/app/controllers/stash_engine/metadata_entry_pages_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/metadata_entry_pages_controller.rb
@@ -23,7 +23,7 @@ module StashEngine
       redirect_to(metadata_entry_pages_new_version_path(resource_id: params[:resource_id]))
     end
 
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     # GET /stash/edit/{doi}/{edit_code}
     def edit_by_doi
       redirect_to root_path, alert: 'The target dataset is being processed. Please try again later.' and return if resource.processing?
@@ -36,6 +36,11 @@ module StashEngine
 
       if ownership_transfer_needed?
         if current_user
+          ca = CurationActivity.create(status: @resource.current_curation_status || 'in_progress',
+                                       user_id: 0,
+                                       resource_id: @resource.id,
+                                       note: "Transferring ownership to #{current_user.name} (#{current_user.id}) using an edit code")
+          @resource.curation_activities << ca
           @resource.user_id = current_user.id
           @resource.save
         else
@@ -58,7 +63,7 @@ module StashEngine
 
       redirect_to(metadata_entry_pages_find_or_create_path(resource_id: resource.id))
     end
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     # create a new version of this resource before editing with find or create
     def new_version


### PR DESCRIPTION
Adds some extra CurationActivities for datasets that are created through the API. This will help in tracking and debugging as journals start using the API more.