### PR TITLE
Fix callback logic and associated tests

### DIFF
--- a/spec/models/stash_api/dataset_parser_spec.rb
+++ b/spec/models/stash_api/dataset_parser_spec.rb
@@ -317,7 +317,6 @@ module StashApi
         new_resource.current_editor_id = @user.id
         new_resource.save!
         @resource = new_resource
-
         dp = DatasetParser.new(hash: @update_metadata, id: @stash_identifier, user: @user)
         @stash_identifier = dp.parse
         expect(@stash_identifier.resources.count).to eq(2)

--- a/spec/models/stash_engine/curation_activity_spec.rb
+++ b/spec/models/stash_engine/curation_activity_spec.rb
@@ -45,7 +45,7 @@ module StashEngine
         @user = create(:user)
         @identifier = create(:identifier)
         @resource = create(:resource, identifier_id: @identifier.id)
-        @resource_state = create(:resource_state, resource_id: @resource.id)
+        @resource_state = create(:resource_state, :submitted, resource_id: @resource.id)
         @resource.update(current_resource_state_id: @resource_state.id)
         @version = create(:version, resource_id: @resource.id)
 
@@ -53,45 +53,44 @@ module StashEngine
         allow(@mock_idgen).to receive('update_identifier_metadata!'.intern) # .and_return('called make metadata')
         allow(Stash::Doi::IdGen).to receive(:make_instance).and_return(@mock_idgen)
 
-        # get rid of callbacks for adding one and testing
         @curation_activity1 = create(:curation_activity, resource: @resource)
-        # CurationActivity.set_callback(:create, :after, :submit_to_datacite)
+      end
+
+      it 'does submit when Published is set' do
+        create(:curation_activity, resource_id: @resource.id, status: 'published')
+        expect(@mock_idgen).to have_received(:update_identifier_metadata!)
       end
 
       it "doesn't submit when a status besides Embargoed or Published is set" do
         CurationActivity.create(resource_id: @resource.id, status: 'curation')
-        expect(@mock_idgen).to_not have_received(:update_identifier_metadata)
+        expect(@mock_idgen).to_not have_received(:update_identifier_metadata!)
       end
 
       it "doesn't submit when status isn't changed" do
-        CurationActivity.skip_callback(:create, :after, :submit_to_datacite, :process_payment)
         @curation_activity2 = create(:curation_activity, resource: @resource, status: 'published')
-        CurationActivity.set_callback(:create, :after, :submit_to_datacite)
-
         CurationActivity.create(resource_id: @resource.id, status: 'published')
-        expect(@mock_idgen).to_not have_received(:update_identifier_metadata)
+        expect(@mock_idgen).to have_received(:update_identifier_metadata!).once
+
       end
 
       it "doesn't submit if never sent to Merritt" do
         @resource_state.update(resource_state: 'in_progress')
         CurationActivity.create(resource_id: @resource.id, status: 'published')
-        expect(@mock_idgen).to_not have_received(:update_identifier_metadata)
+        expect(@mock_idgen).to_not have_received(:update_identifier_metadata!)
       end
 
       it "doesn't submit if no version number" do
         @version.update!(version: nil, merritt_version: nil)
         CurationActivity.create(resource_id: @resource.id, status: 'published')
-        expect(@mock_idgen).to_not have_received(:update_identifier_metadata)
+        expect(@mock_idgen).to_not have_received(:update_identifier_metadata!)
       end
 
       it "doesn't submit non-production (test) identifiers after first version" do
         @resource2 = create(:resource, identifier_id: @identifier.id)
         @resource_state2 = create(:resource_state, resource_id: @resource2.id)
         @version2 = create(:version, resource_id: @resource2.id, version: 2, merritt_version: 2)
-        CurationActivity.skip_callback(:create, :after, :submit_to_datacite)
         CurationActivity.create(resource: @resource2, status: 'published')
-        CurationActivity.set_callback(:create, :after, :submit_to_datacite)
-        expect(@mock_idgen).to_not have_received(:update_identifier_metadata)
+        expect(@mock_idgen).to_not have_received(:update_identifier_metadata!)
       end
     end
 
@@ -101,7 +100,6 @@ module StashEngine
         @identifier = create(:identifier)
         @resource = create(:resource, identifier_id: @identifier.id, user: @user)
 
-        CurationActivity.skip_callback(:create, :after, :update_solr)
         allow_any_instance_of(CurationActivity).to receive(:should_update_doi?).and_return(true)
 
         logger = double(ActiveSupport::Logger)

--- a/spec/models/stash_engine/curation_activity_spec.rb
+++ b/spec/models/stash_engine/curation_activity_spec.rb
@@ -68,8 +68,9 @@ module StashEngine
 
       it "doesn't submit when status isn't changed" do
         @curation_activity2 = create(:curation_activity, resource: @resource, status: 'published')
-        CurationActivity.create(resource_id: @resource.id, status: 'published')
         expect(@mock_idgen).to have_received(:update_identifier_metadata!).once
+        CurationActivity.create(resource_id: @resource.id, status: 'published')
+        expect(@mock_idgen).to have_received(:update_identifier_metadata!).once # should not be called for the second 'published'
 
       end
 

--- a/stash/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -67,11 +67,16 @@ module StashEngine
     # ------------------------------------------
 
     # When the status is published/embargoed send to Stripe and DataCite
-    after_create :submit_to_datacite, :update_solr, :process_payment, :remove_peer_review,
-                 if: proc { |ca|
-                       !ca.resource.skip_datacite_update && (ca.published? || ca.embargoed?) &&
-                                 latest_curation_status_changed?
-                     }
+    after_create do
+      if !resource.skip_datacite_update &&
+          (published? || embargoed?) &&
+          latest_curation_status_changed?
+        submit_to_datacite
+        update_solr
+        process_payment
+        remove_peer_review
+      end
+    end
 
     after_create :copy_to_zenodo, if: proc { |ca|
       !ca.resource.skip_datacite_update && ca.published? && latest_curation_status_changed?


### PR DESCRIPTION
Fixes the issue noted in https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1259, which was appearing intermittently, depending on the order for running some of the tests.

The root problem was that some CurationActivity callbacks were being called at times they should not, because there were several methods listed in one callback line, and the `if` statement was only applying to the last one. I moved these methods into a single block so the `if` applies to all of them. Then, I discovered that the tests for the callbacks were all useless, because they were testing for the absence of a method call that didn't exist. They are actually testing the real functionality now.