### PR TITLE
Fix API/completions issue

### DIFF
--- a/spec/models/stash_datacite/completions_spec.rb
+++ b/spec/models/stash_datacite/completions_spec.rb
@@ -220,6 +220,14 @@ module StashDatacite
           expect(completions.s3_error_uploads).to eq(@resource.generic_files.map(&:upload_file_name))
         end
 
+        it 'does not check missing files once Merritt processing is complete' do
+          @resource.generic_files.map(&:calc_s3_path).each do |s3_path|
+            allow(Stash::Aws::S3).to receive('exists?').with(s3_key: s3_path).and_return(false)
+          end
+          allow(@resource).to receive('submitted?').and_return(true)
+          expect(completions.s3_error_uploads).to be(nil)
+        end
+
         it 'only checks files that are new uploads and are not urls' do
           @resource.generic_files.first.update(file_state: 'copied')
           @resource.generic_files.second.update(url: 'http://example.com')

--- a/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
@@ -90,6 +90,8 @@ module StashDatacite
       end
 
       def s3_error_uploads
+        return if @resource.submitted?
+
         files = @resource.generic_files.newly_created.file_submission
         errored_uploads = []
         files.each do |f|


### PR DESCRIPTION
This issue was uncovered when testing the API integration with EJP. 

When a resource has state `submitted`, the files are fully in Merritt and no longer in S3. The completions were still checking for files in S3. In the UI, this isn't a problem, because the completions will never be checked after the resource has been submitted. However, some API operations check the completions to ensure a resource is in a state that allows it to be modified.

This PR skips the S3 check after the state is `submitted`.