### PR TITLE
Ignores newer versions with all zenodo-type files removed for related ids

### DIFF
--- a/spec/factories/stash_engine/zenodo_copies.rb
+++ b/spec/factories/stash_engine/zenodo_copies.rb
@@ -8,5 +8,7 @@ FactoryBot.define do
     error_info { nil }
     identifier_id { nil }
     copy_type { 'data' }
+    software_doi { "#{rand.to_s[2..6]}/zenodo.#{rand.to_s[2..11]}" }
+    conceptrecid { rand.to_s[2..11] }
   end
 end

--- a/spec/models/stash_datacite/related_identifier_spec.rb
+++ b/spec/models/stash_datacite/related_identifier_spec.rb
@@ -139,14 +139,6 @@ module StashDatacite
         expect(re.verified).to be(true)
         expect(re.added_by).to eq('zenodo')
       end
-
-      it "doesn't care if user has deleted all files of that type, they still get a relation" do
-        create(:zenodo_copy, resource_id: @resource.id, identifier_id: @resource.identifier_id,
-                             copy_type: 'software', software_doi: @test_doi)
-        expect(@resource.related_identifiers.count).to eq(0)
-        StashDatacite::RelatedIdentifier.set_latest_zenodo_relations(resource: @resource)
-        expect(@resource.related_identifiers.count).to eq(1)
-      end
     end
 
     describe 'self.remove_zenodo_relation' do

--- a/spec/models/stash_engine/zenodo_copy_spec.rb
+++ b/spec/models/stash_engine/zenodo_copy_spec.rb
@@ -1,0 +1,83 @@
+module StashEngine
+  describe ZenodoCopy, type: :model do
+
+    before(:each) do
+      # Mock all the mailers fired by callbacks because these tests don't load everything we need
+      @identifier = create(:identifier)
+      @resource1 = create(:resource, identifier_id: @identifier.id)
+      @resource2 = create(:resource, identifier_id: @identifier.id)
+
+      @zc_soft1 = create(:zenodo_copy, identifier_id: @identifier.id, resource_id: @resource1.id, copy_type: 'software',
+                                       state: 'finished')
+      @soft_file1 = create(:software_file, resource_id: @resource1.id)
+
+      @zc_soft2 = create(:zenodo_copy, identifier_id: @identifier.id, resource_id: @resource2.id, copy_type: 'software',
+                                       state: 'finished')
+      @soft_file2 = create(:software_file, resource_id: @resource2.id)
+
+      @zc_supp1 = create(:zenodo_copy, identifier_id: @identifier.id, resource_id: @resource1.id, copy_type: 'supp',
+                                       state: 'finished')
+      @supp_file1 = create(:supp_file, resource_id: @resource1.id)
+
+      @zc_supp2 = create(:zenodo_copy, identifier_id: @identifier.id, resource_id: @resource2.id, copy_type: 'supp',
+                                       state: 'finished')
+      @supp_file2 = create(:supp_file, resource_id: @resource2.id)
+    end
+
+    describe 'self.last_copy_with_software(identifier_id:)' do
+      it 'returns the latest software copy when everything is finished and has files' do
+        expect(ZenodoCopy.last_copy_with_software(identifier_id: @identifier.id)).to eq(@zc_soft2)
+      end
+
+      it "returns the first software copy when the second isn't finished yet" do
+        @zc_soft2.update(software_doi: nil)
+        expect(ZenodoCopy.last_copy_with_software(identifier_id: @identifier.id)).to eq(@zc_soft1)
+      end
+
+      it "returns the first software copy when the second doesn't have files" do
+        @soft_file2.update(file_state: 'deleted')
+        expect(ZenodoCopy.last_copy_with_software(identifier_id: @identifier.id)).to eq(@zc_soft1)
+      end
+
+      it "doesn't return anything if no files" do
+        @resource1.software_files.each(&:destroy)
+        @resource2.software_files.each(&:destroy)
+        expect(ZenodoCopy.last_copy_with_software(identifier_id: @identifier.id)).to be_nil
+      end
+
+      it "doesn't return anything if all unfinished" do
+        @zc_soft1.update(software_doi: nil)
+        @zc_soft2.update(software_doi: nil)
+        expect(ZenodoCopy.last_copy_with_software(identifier_id: @identifier.id)).to be_nil
+      end
+    end
+
+    describe 'self.last_copy_with_supp(identifier_id:)' do
+      it 'returns the latest supplemental copy when everything is finished and has files' do
+        expect(ZenodoCopy.last_copy_with_supp(identifier_id: @identifier.id)).to eq(@zc_supp2)
+      end
+
+      it "returns the first supplemental copy when the second isn't finished yet" do
+        @zc_supp2.update(software_doi: nil)
+        expect(ZenodoCopy.last_copy_with_supp(identifier_id: @identifier.id)).to eq(@zc_supp1)
+      end
+
+      it "returns the first supplemental copy when the second doesn't have files" do
+        @supp_file2.update(file_state: 'deleted')
+        expect(ZenodoCopy.last_copy_with_supp(identifier_id: @identifier.id)).to eq(@zc_supp1)
+      end
+
+      it "doesn't return anything if no files" do
+        @resource1.supp_files.each(&:destroy)
+        @resource2.supp_files.each(&:destroy)
+        expect(ZenodoCopy.last_copy_with_supp(identifier_id: @identifier.id)).to be_nil
+      end
+
+      it "doesn't return anything if all unfinished" do
+        @zc_supp1.update(software_doi: nil)
+        @zc_supp2.update(software_doi: nil)
+        expect(ZenodoCopy.last_copy_with_supp(identifier_id: @identifier.id)).to be_nil
+      end
+    end
+  end
+end

--- a/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
@@ -134,8 +134,7 @@ module StashDatacite
     def self.set_latest_zenodo_relations(resource:)
       resource.related_identifiers.where(added_by: 'zenodo').destroy_all
 
-      sfw_copy = resource.identifier.zenodo_copies.where(copy_type: %w[software software_publish])
-        .where('software_doi IS NOT NULL').order(:resource_id, :id).last
+      sfw_copy = StashEngine::ZenodoCopy.last_copy_with_software(identifier_id: resource.identifier.id)
       if sfw_copy.present?
         doi = standardize_doi(sfw_copy.software_doi)
         create(related_identifier: doi,
@@ -147,8 +146,7 @@ module StashDatacite
                added_by: 'zenodo')
       end
 
-      supp_copy = resource.identifier.zenodo_copies.where(copy_type: %w[supp supp_publish])
-        .where('software_doi IS NOT NULL').order(:resource_id, :id).last
+      supp_copy = StashEngine::ZenodoCopy.last_copy_with_supp(identifier_id: resource.identifier.id)
       return unless supp_copy.present?
 
       doi = standardize_doi(supp_copy.software_doi)

--- a/stash/stash_engine/app/models/stash_engine/zenodo_copy.rb
+++ b/stash/stash_engine/app/models/stash_engine/zenodo_copy.rb
@@ -17,5 +17,25 @@ module StashEngine
     scope :supp, -> { where(copy_type: %w[supp supp_publish]) }
 
     scope :done, -> { where('deposition_id IS NOT NULL').where(state: 'finished') }
+
+    def self.last_copy_with_software(identifier_id:)
+      joins('INNER JOIN stash_engine_generic_files gf ON stash_engine_zenodo_copies.resource_id = gf.resource_id')
+        .where('stash_engine_zenodo_copies.identifier_id = ?', identifier_id)
+        .where('stash_engine_zenodo_copies.software_doi IS NOT NULL')
+        .where('stash_engine_zenodo_copies.copy_type LIKE "software%"')
+        .where('gf.type = "StashEngine::SoftwareFile"')
+        .where("gf.file_state IN ('created', 'copied')")
+        .order('stash_engine_zenodo_copies.id DESC').first
+    end
+
+    def self.last_copy_with_supp(identifier_id:)
+      joins('INNER JOIN stash_engine_generic_files gf ON stash_engine_zenodo_copies.resource_id = gf.resource_id')
+        .where('stash_engine_zenodo_copies.identifier_id = ?', identifier_id)
+        .where('stash_engine_zenodo_copies.software_doi IS NOT NULL')
+        .where('stash_engine_zenodo_copies.copy_type LIKE "supp%"')
+        .where('gf.type = "StashEngine::SuppFile"')
+        .where("gf.file_state IN ('created', 'copied')")
+        .order('stash_engine_zenodo_copies.id DESC').first
+    end
   end
 end


### PR DESCRIPTION
To test (currently deployed to dev right now):

1. Add and submit a dataset with software.
2. Publish the dataset.  Make a note of the Zenodo doi.
3. Now go edit the dataset again and remove all the software.  Submit it.
4. Publish the dataset again.

After all the updates at zenodo, it should reflect the first doi.