### PR TITLE
Loosen the rubocop restricitons

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,20 +49,34 @@ Layout/LineLength:
 
 # AbcSize is very low at 15 and often catches perfectly readable methods because of two small if statements
 Metrics/AbcSize:
-  Max: 30
+  Max: 45
 
-# The default MethodLength can flag methods which essentially do nothing, simply because they invoke another method with several parameters
+# The default Lengths can flag methods which essentially do nothing, simply because they invoke another method with several parameters
+Metrics/ClassLength:
+  Max: 200
+  Exclude:
+    - '**/spec/**/*.rb'
+    
 Metrics/MethodLength:
-  Max: 20
+  Max: 30
+  Exclude:
+    - '**/spec/**/*.rb'
+
+Metrics/BlockLength:
+  Max: 200
+  Exclude:
+    - '**/spec/**/*.rb'
+
+Metrics/ModuleLength:
   Exclude:
     - '**/spec/**/*.rb'
 
 # reasonable complexity
 Metrics/PerceivedComplexity:
-  Max: 15
+  Max: 20
 
 Metrics/CyclomaticComplexity:
-  Max: 15
+  Max: 20
 
 # We meant to do that
 Naming/MemoizedInstanceVariableName:
@@ -166,13 +180,3 @@ Style/RedundantRegexpEscape:
 Style/SlicingWithRange:
   Enabled: true
 
-# ############################################################
-# Special cases for specs
-
-Metrics/BlockLength:
-  Exclude:
-    - '**/spec/**/*.rb'
-
-Metrics/ModuleLength:
-  Exclude:
-    - '**/spec/**/*.rb'

--- a/lib/tasks/affiliation_import.rake
+++ b/lib/tasks/affiliation_import.rake
@@ -1,7 +1,6 @@
 require 'csv'
 
 # rubocop:disable Metrics/BlockLength
-# rubocop:disable Metrics/MethodLength
 # rubocop:disable Lint/UselessAssignment
 # rubocop:disable Metrics/AbcSize
 namespace :affiliation_import do
@@ -296,6 +295,5 @@ namespace :affiliation_import do
 end
 # rubocop:enable Metrics/BlockLength
 
-# rubocop:enable Metrics/MethodLength
 # rubocop:enable Lint/UselessAssignment
 # rubocop:enable Metrics/AbcSize

--- a/lib/tasks/datacite_target.rake
+++ b/lib/tasks/datacite_target.rake
@@ -1,6 +1,4 @@
 require_relative 'datacite_target/dash_updater'
-
-# rubocop:disable Metrics/BlockLength
 namespace :datacite_target do
 
   # This will update only items that are in non-Dryad tenants
@@ -43,4 +41,3 @@ namespace :datacite_target do
   end
 
 end
-# rubocop:enable Metrics/BlockLength

--- a/lib/tasks/download_check/merritt.rb
+++ b/lib/tasks/download_check/merritt.rb
@@ -33,7 +33,6 @@ module DownloadCheck
       end
     end
 
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def check_all_files
       # we always have to do this because the normalizer in 'http.rb' randomly mangles some things
       @http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
@@ -74,7 +73,7 @@ module DownloadCheck
         end
       end
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:enable
 
     def save_error(resource:, file:, error:)
       ark = %r{/d/(.+)$}.match(resource.download_uri)

--- a/lib/tasks/embargo_fix.rake
+++ b/lib/tasks/embargo_fix.rake
@@ -1,7 +1,5 @@
 # Emgargo fix tool -- correct overly-conservative embargoes that were put in place by migration
 # See ticket https://github.com/CDL-Dryad/dryad-product-roadmap/issues/400
-
-# rubocop:disable Metrics/BlockLength
 namespace :embargo_fix do
 
   desc 'Embargo manipulation to correct the problem of conservative embargoes from migration'
@@ -149,4 +147,3 @@ namespace :embargo_fix do
     p 'Finished embargo correction'
   end
 end
-# rubocop:enable Metrics/BlockLength

--- a/lib/tasks/local_to_s3.rake
+++ b/lib/tasks/local_to_s3.rake
@@ -3,8 +3,6 @@
 # See ticket https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1079
 
 require 'stash/aws/s3'
-
-# rubocop:disable Metrics/BlockLength
 namespace :local_to_s3 do
 
   desc 'Copy current files from the local directory to S3'
@@ -60,4 +58,3 @@ namespace :local_to_s3 do
   end
 
 end
-# rubocop:enable Metrics/BlockLength

--- a/lib/tasks/publication_updater.rake
+++ b/lib/tasks/publication_updater.rake
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/BlockLength
 namespace :publication_updater do
 
   # Query to retrieve the latest resource and its latest curation activity
@@ -62,4 +61,3 @@ namespace :publication_updater do
   end
 
 end
-# rubocop:enable Metrics/BlockLength

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,7 +1,5 @@
 require 'byebug'
 require 'pp'
-
-# rubocop:disable Metrics/BlockLength
 namespace :users do
   desc 'Merge old and new users (into old account like it works in the UI)'
   task merge_users: :environment do
@@ -38,4 +36,3 @@ namespace :users do
   end
 
 end
-# rubocop:enable Metrics/BlockLength

--- a/spec/fixtures/stash_api/metadata.rb
+++ b/spec/fixtures/stash_api/metadata.rb
@@ -1,7 +1,5 @@
 require 'faker'
 require 'json'
-
-# rubocop:disable Metrics/ClassLength
 module Fixtures
   module StashApi
     class Metadata
@@ -145,4 +143,3 @@ module Fixtures
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/spec/mocks/aws.rb
+++ b/spec/mocks/aws.rb
@@ -6,7 +6,6 @@ module Mocks
       mock_s3!
     end
 
-    # rubocop:disable Metrics/AbcSize
     def mock_s3!
       allow_any_instance_of(::Aws::S3::Object).to receive(:delete).and_return(nil)
       allow_any_instance_of(::Aws::S3::Object).to receive(:exists?).and_return(nil)
@@ -21,7 +20,6 @@ module Mocks
       # Add a default database configuration, which is needed by Resource.s3_dir_name
       allow(Rails).to receive(:configuration).and_return(OpenStruct.new(database_configuration: { 'test' => { 'host' => 'localhost' } }))
     end
-    # rubocop:enable Metrics/AbcSize
 
   end
 

--- a/spec/mocks/orcid.rb
+++ b/spec/mocks/orcid.rb
@@ -5,7 +5,6 @@ module Mocks
     class << self
 
       # Its a Hash Rubocop, get over yourself!
-      # rubocop:disable Metrics/AbcSize
       def omniauth_response(user)
         {
           uid: user.present? && user.orcid.present? ? user.orcid : Faker::Pid.orcid,
@@ -25,8 +24,6 @@ module Mocks
           }
         }
       end
-
-      # rubocop:enable Metrics/AbcSize
 
       def email_response(user)
         {

--- a/spec/support/resource_builder.rb
+++ b/spec/support/resource_builder.rb
@@ -6,7 +6,7 @@ require 'time'
 
 # Borrowed from stash_migrator
 module StashDatacite
-  class ResourceBuilder # rubocop:disable Metrics/ClassLength
+  class ResourceBuilder
     DESCRIPTION_TYPE = Datacite::Mapping::DescriptionType
 
     attr_reader :user_id, :tenant_id, :dcs_resource, :stash_files, :upload_time

--- a/stash/stash-merritt/lib/stash/merritt/builders/merritt_oaidc_builder.rb
+++ b/stash/stash-merritt/lib/stash/merritt/builders/merritt_oaidc_builder.rb
@@ -4,7 +4,7 @@ require 'action_controller'
 module Stash
   module Merritt
     module Builders
-      class MerrittOAIDCBuilder < Stash::Repo::FileBuilder # rubocop:disable Metrics/ClassLength
+      class MerrittOAIDCBuilder < Stash::Repo::FileBuilder
         ROOT_ATTRIBUTES = {
           'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
           'xsi:noNamespaceSchemaLocation' => 'http://dublincore.org/schemas/xmls/qdc/2008/02/11/qualifieddc.xsd',

--- a/stash/stash-merritt/stash-merritt.gemspec
+++ b/stash/stash-merritt/stash-merritt.gemspec
@@ -21,7 +21,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'stash/merritt/module_info'
 require 'uri'
 
-Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
+Gem::Specification.new do |s|
   s.name          = Stash::Merritt::NAME
   s.version       = Stash::Merritt::VERSION
   s.authors       = ['David Moles']

--- a/stash/stash-notifier/spec/unit/collection_set_spec.rb
+++ b/stash/stash-notifier/spec/unit/collection_set_spec.rb
@@ -1,8 +1,6 @@
 # require the items for the notifier
 Dir[File.join(__dir__, '..', '..', 'app', '*.rb')].sort.each { |file| require file }
 require 'ostruct'
-
-# rubocop:disable Metrics/ClassLength
 class CollectionSetSpec
   describe 'collection_set' do
 
@@ -162,4 +160,3 @@ class CollectionSetSpec
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash-sword/stash-sword.gemspec
+++ b/stash/stash-sword/stash-sword.gemspec
@@ -21,7 +21,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'uri'
 require 'stash/sword/module_info'
 
-Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
+Gem::Specification.new do |s|
   s.name          = Stash::Sword::NAME
   s.version       = Stash::Sword::VERSION
   s.authors       = ['David Moles']

--- a/stash/stash_api/app/controllers/stash_api/curation_activity_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/curation_activity_controller.rb
@@ -65,7 +65,6 @@ module StashApi
     private
 
     # Publish, embargo or simply change the status
-    # rubocop:disable Metrics/MethodLength
     def create_curation_activity(resource)
       return unless resource.present?
 
@@ -100,7 +99,6 @@ module StashApi
                                            note: ca_note,
                                            created_at: params[:curation_activity][:created_at] || Time.now.utc)
     end
-    # rubocop:enable Metrics/MethodLength
 
     def record_published_date(resource)
       return if resource.publication_date.present?

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -74,7 +74,6 @@ module StashApi
       end
     end
 
-    # rubocop:disable Metrics/MethodLength
     def em_update_status
       # If final_disposition is available, update the status of this dataset
       disposition = params['article']['final_disposition']
@@ -111,7 +110,6 @@ module StashApi
         status: 'Success'
       }
     end
-    # rubocop:enable Metrics/MethodLength
 
     # Reformat a request from Editorial Manager's Submission call, enabling it to conform to our normal API.
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -352,8 +350,6 @@ module StashApi
       @resource = @stash_identifier.resources.by_version_desc.first unless @stash_identifier.blank?
     end
 
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
     def do_patch
       content_type = request.headers['content-type']
       return unless request.method == 'PATCH' && content_type.present? && content_type.start_with?('application/json-patch+json')
@@ -381,8 +377,6 @@ module StashApi
       end
       yield
     end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/MethodLength
 
     def update_curation_status(new_status)
       note = 'status updated via API call'

--- a/stash/stash_api/app/controllers/stash_api/files_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/files_controller.rb
@@ -7,8 +7,6 @@ require 'stash/aws/s3'
 
 require_dependency 'stash_api/application_controller'
 require 'stash/download/file_presigned'
-
-# rubocop:disable Metrics/ClassLength
 module StashApi
   class FilesController < ApplicationController
 
@@ -214,4 +212,3 @@ module StashApi
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_api/app/controllers/stash_api/urls_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/urls_controller.rb
@@ -51,7 +51,6 @@ module StashApi
       validation_hash
     end
 
-    # rubocop:disable Metrics/AbcSize
     def skipped_validation_hash(_hsh)
       unless params[:size] && params[:mimeType] && params[:url]
         (render json: { error: 'You must supply a size, mimetype and url.' }.to_json, status: 403) && yield
@@ -64,7 +63,6 @@ module StashApi
       { resource_id: @resource.id, url: params[:url], status_code: 200, file_state: 'created',
         upload_file_name: my_path, upload_content_type: params[:mimeType], upload_file_size: params[:size] }
     end
-    # rubocop:enable Metrics/AbcSize
 
     def require_correctly_formatted_url
       (render json: { error: 'The URL you supplied is invalid.' }.to_json, status: 403) unless correctly_formatted_url?(params[:url])

--- a/stash/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 module StashApi
   # takes a dataset hash, parses it out and saves it to the appropriate places in the database
   class DatasetParser
@@ -23,7 +22,6 @@ module StashApi
     end
 
     # this is the basic required metadata
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def parse
       clear_previous_metadata
       @resource.curation_activities << StashEngine::CurationActivity.create(status: @resource.current_curation_status || 'in_progress',
@@ -50,7 +48,7 @@ module StashApi
       @resource.identifier.save
       @resource.identifier
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:enable
 
     private
 
@@ -182,4 +180,3 @@ module StashApi
 
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_api/app/models/stash_api/version/metadata.rb
+++ b/stash/stash_api/app/models/stash_api/version/metadata.rb
@@ -8,7 +8,6 @@ module StashApi
         @resource = resource
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def value
         # setting some false values to nil because they get compacted.  Don't really want to advertise these options for
         # use by others besides ourselves because we don't want others to use them.
@@ -37,7 +36,7 @@ module StashApi
           loosenValidation: @resource.loosen_validation || nil
         }
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:enable
 
       def visibility
         if @resource.meta_view || @resource.file_view

--- a/stash/stash_api/config/routes.rb
+++ b/stash/stash_api/config/routes.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/BlockLength
 StashApi::Engine.routes.draw do
 
   # use_doorkeeper
@@ -40,4 +39,3 @@ StashApi::Engine.routes.draw do
   get '/queue_length', to: 'submission_queue#length'
 
 end
-# rubocop:enable Metrics/BlockLength

--- a/stash/stash_api/db/migrate/20180316234058_create_doorkeeper_tables.rb
+++ b/stash/stash_api/db/migrate/20180316234058_create_doorkeeper_tables.rb
@@ -1,5 +1,5 @@
 class CreateDoorkeeperTables < ActiveRecord::Migration[4.2]
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength
   def change
     create_table :oauth_applications do |t|
       t.string  :name,         null: false
@@ -66,5 +66,5 @@ class CreateDoorkeeperTables < ActiveRecord::Migration[4.2]
       column: :application_id
     )
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:enable Metrics/MethodLength
 end

--- a/stash/stash_datacite/app/controllers/stash_datacite/contributors_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/contributors_controller.rb
@@ -1,6 +1,4 @@
 require_dependency 'stash_datacite/application_controller'
-
-# rubocop:disable Metrics/ClassLength
 module StashDatacite
   class ContributorsController < ApplicationController
     before_action :set_contributor, only: %i[update delete]
@@ -146,4 +144,3 @@ module StashDatacite
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -5,10 +5,8 @@ require 'stash/import/dryad_manuscript'
 require 'stash/link_out/pubmed_sequence_service'
 require 'stash/link_out/pubmed_service'
 require 'cgi'
-# rubocop:disable Metrics/ClassLength, Metrics/MethodLength
 module StashDatacite
   class PublicationsController < ApplicationController
-    # rubocop:disable Metrics/AbcSize
     def update
       @se_id = StashEngine::Identifier.find(params[:internal_datum][:identifier_id])
       @resource = StashEngine::Resource.find(params[:internal_datum][:resource_id])
@@ -138,7 +136,6 @@ module StashDatacite
       logger.error("Dryad manuscript API returned a HTTParty/Socket error for ISSN: #{@pub_issn.value}, MSID: #{@msid.value}\r\n #{e}")
       @error = 'We could not find metadata to import for this manuscript. Please enter your metadata below.'
     end
-    # rubocop:enable Metrics/AbcSize
 
     def update_doi_metadata
       unless params[:internal_datum][:doi].present?
@@ -231,4 +228,3 @@ module StashDatacite
 
   end
 end
-# rubocop:enable Metrics/ClassLength, Metrics/MethodLength

--- a/stash/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
@@ -1,6 +1,5 @@
 require_dependency 'stash_datacite/application_controller'
 
-# rubocop:disable Metrics/ClassLength
 module StashDatacite
   # this is a class for composite (AJAX/UJS?) views starting at the resource or resources
   class ResourcesController < ApplicationController
@@ -57,7 +56,6 @@ module StashDatacite
       end
     end
 
-    # rubocop:disable Metrics/AbcSize
     def submission
       resource_id = params[:resource_id]
       resource = StashEngine::Resource.find(resource_id)
@@ -115,7 +113,6 @@ module StashDatacite
       StashEngine::CurationActivity.create(status: last.status, user_id: current_user.id, note: params[:user_comment],
                                            resource_id: last.resource_id)
     end
-    # rubocop:enable Metrics/AbcSize
 
     def max_submission_size
       current_tenant.max_submission_size.to_i
@@ -173,4 +170,3 @@ module StashDatacite
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_datacite/app/models/stash_datacite/geolocation.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/geolocation.rb
@@ -3,7 +3,7 @@
 require 'datacite/mapping'
 
 module StashDatacite
-  class Geolocation < ApplicationRecord # rubocop:disable Metrics/ClassLength
+  class Geolocation < ApplicationRecord
     self.table_name = 'dcs_geo_locations'
     belongs_to :resource, class_name: StashEngine::Resource.to_s
     belongs_to :geolocation_place, class_name: 'StashDatacite::GeolocationPlace', foreign_key: 'place_id', optional: true

--- a/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
@@ -5,8 +5,6 @@ require 'http'
 module StashDatacite
 
   class ExternalServerError < RuntimeError; end
-
-  # rubocop:disable Metrics/ClassLength
   class RelatedIdentifier < ApplicationRecord
     self.table_name = 'dcs_related_identifiers'
     belongs_to :resource, class_name: StashEngine::Resource.to_s
@@ -130,7 +128,7 @@ module StashDatacite
       "This dataset #{relation_name_english} #{related_identifier_type_friendly}: #{related_identifier}"
     end
 
-    # rubocop:disable Metrics/MethodLength, Naming/AccessorMethodName
+    # rubocop:disable Naming/AccessorMethodName
     def self.set_latest_zenodo_relations(resource:)
       resource.related_identifiers.where(added_by: 'zenodo').destroy_all
 
@@ -158,7 +156,7 @@ module StashDatacite
              resource_id: resource.id,
              added_by: 'zenodo')
     end
-    # rubocop:enable Metrics/MethodLength, Naming/AccessorMethodName
+    # rubocop:enable Naming/AccessorMethodName
 
     def self.remove_zenodo_relation(resource_id:, doi:)
       doi = standardize_doi(doi)
@@ -257,5 +255,5 @@ module StashDatacite
       self.related_identifier = related_identifier.strip unless related_identifier.nil?
     end
   end
-  # rubocop:enable Metrics/ClassLength
+
 end

--- a/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
@@ -18,7 +18,6 @@ class TrueClass
 end
 
 require 'stash_datacite/author_patch'
-# rubocop:disable Metrics/ClassLength
 module StashDatacite
   module Resource
     class Completions
@@ -214,4 +213,3 @@ module StashDatacite
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_datacite/app/models/stash_datacite/resource/schema_dataset.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/schema_dataset.rb
@@ -8,7 +8,7 @@ module StashDatacite
     # this class creates a schema.org dataset structure that can be output as json+ld or others
     # https://developers.google.com/search/docs/data-types/datasets
     # https://schema.org/Dataset
-    class SchemaDataset # rubocop:disable Metrics/ClassLength
+    class SchemaDataset
       ITEMS_TO_ADD = {
         '@id' => :doi_url,
         'name' => :names,

--- a/stash/stash_datacite/config/routes.rb
+++ b/stash/stash_datacite/config/routes.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/BlockLength
 StashDatacite::Engine.routes.draw do
 
   get 'titles/new', to: 'titles#new'
@@ -93,4 +92,3 @@ StashDatacite::Engine.routes.draw do
 
   patch 'peer_review/toggle', to: 'peer_review#toggle', as: :peer_review
 end
-# rubocop:enable Metrics/BlockLength

--- a/stash/stash_datacite/db/migrate/20160720180420_drop_orcid_id_from_dcs_creators.rb
+++ b/stash/stash_datacite/db/migrate/20160720180420_drop_orcid_id_from_dcs_creators.rb
@@ -1,5 +1,4 @@
 class DropOrcidIdFromDcsCreators < ActiveRecord::Migration[4.2]
-  # rubocop:disable Metrics/MethodLength
   def change
     # Create missing name identifier records
     execute <<-SQL
@@ -34,5 +33,5 @@ class DropOrcidIdFromDcsCreators < ActiveRecord::Migration[4.2]
     # Remove old orcid_id column
     remove_column :dcs_creators, :orcid_id
   end
-  # rubocop:enable Metrics/MethodLength
+
 end

--- a/stash/stash_datacite/db/migrate/20160805223035_add_indexes_where_needed.rb
+++ b/stash/stash_datacite/db/migrate/20160805223035_add_indexes_where_needed.rb
@@ -1,5 +1,5 @@
 class AddIndexesWhereNeeded < ActiveRecord::Migration[4.2]
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength
   def change
     add_index(:dcs_affiliations, :short_name, length: { short_name: 50 })
     add_index(:dcs_affiliations, :long_name, length: { long_name: 50 })
@@ -34,5 +34,5 @@ class AddIndexesWhereNeeded < ActiveRecord::Migration[4.2]
     add_index(:dcs_titles, :resource_id)
     add_index(:dcs_versions, :resource_id)
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:enable Metrics/MethodLength
 end

--- a/stash/stash_datacite/lib/stash/import/crossref.rb
+++ b/stash/stash_datacite/lib/stash/import/crossref.rb
@@ -242,7 +242,6 @@ module Stash
         affiliation.save if affiliation.present?
       end
 
-      # rubocop:disable Metrics/AbcSize
       def populate_author(hash)
         new_auth = StashEngine::Author.new(resource_id: @resource.id, author_orcid: hash['ORCID'],
                                            author_first_name: hash['given'], author_last_name: hash['family'])
@@ -257,7 +256,6 @@ module Stash
         populate_affiliation(author, hash)
         author.save
       end
-      # rubocop:enable Metrics/AbcSize
 
       def populate_authors
         return unless @sm['author'].present? && @sm['author'].any?

--- a/stash/stash_datacite/lib/stash/indexer/indexing_resource.rb
+++ b/stash/stash_datacite/lib/stash/indexer/indexing_resource.rb
@@ -51,8 +51,6 @@ module Datacite
     end
   end
 end
-
-# rubocop:disable Metrics/ClassLength
 module Stash
   module Indexer
     class IndexingResource
@@ -67,7 +65,6 @@ module Stash
       end
 
       # this is really what we want to get out of this for solr indexing, the rest is for compatibility with old indexing
-      # rubocop:disable Metrics/MethodLength
       def to_index_document
         georss = calc_bounding_box
         {
@@ -92,7 +89,6 @@ module Stash
           dryad_author_affiliation_id_sm: author_affiliation_ids
         }
       end
-      # rubocop:enable Metrics/MethodLength
 
       def default_title
         @resource&.title&.strip
@@ -177,7 +173,7 @@ module Stash
         # elem.name == 'resource' && Datacite::Mapping.datacite_namespace?(elem)
       end
 
-      def calc_bounding_box # rubocop:disable Metrics/AbcSize
+      def calc_bounding_box
         lat_min, lat_max, long_min, long_max = nil
         geo_location_points.each do |pt|
           lat_min = [lat_min, pt.latitude].compact.min
@@ -271,4 +267,3 @@ module Stash
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_datacite/stash_datacite.gemspec
+++ b/stash/stash_datacite/stash_datacite.gemspec
@@ -21,7 +21,7 @@ require 'stash_datacite/version'
 # for our uses.
 
 # Describe your gem and declare its dependencies:
-Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
+Gem::Specification.new do |s|
   s.name        = 'stash_datacite'
   s.version     = StashDatacite::VERSION
   s.authors     = ['sfisher']

--- a/stash/stash_discovery/stash_discovery.gemspec
+++ b/stash/stash_discovery/stash_discovery.gemspec
@@ -21,7 +21,7 @@ require 'stash_discovery/version'
 # for our uses.
 
 # Describe your gem and declare its dependencies:
-Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
+Gem::Specification.new do |s|
   s.name        = 'stash_discovery'
   s.version     = StashDiscovery::VERSION
   s.authors     = ['David Moles']

--- a/stash/stash_engine/app/controllers/stash_engine/admin_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_controller.rb
@@ -94,7 +94,6 @@ module StashEngine
     end
 
     # TODO: move into models or elsewhere for queries, but can't get tests to run right now so holding off
-    # rubocop:disable Metrics/AbcSize
     def limit_to_tenant!
       @stats[:user_count] = @stats[:user_count].where(tenant_id: current_user.tenant_id)
       @stats[:dataset_count] = @stats[:dataset_count].joins(resources: :user)
@@ -105,7 +104,6 @@ module StashEngine
       @stats[:dataset_submitted_7days] = @stats[:dataset_submitted_7days].joins(resources: :user)
         .where(['stash_engine_users.tenant_id = ?', current_user.tenant_id]).distinct
     end
-    # rubocop:enable Metrics/AbcSize
 
     def setup_superuser_facets
       @tenant_facets = StashEngine::Tenant.all.sort_by(&:short_name)

--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -1,7 +1,6 @@
 require_dependency 'stash_engine/application_controller'
 
 module StashEngine
-  # rubocop:disable Metrics/ClassLength
   class AdminDatasetsController < ApplicationController
 
     include SharedSecurityController
@@ -13,7 +12,6 @@ module StashEngine
     TENANT_IDS = Tenant.all.map(&:tenant_id)
 
     # the admin datasets main page showing users and stats, but slightly different in scope for superusers vs tenant admins
-    # rubocop:disable Metrics/AbcSize
     def index
       my_tenant_id = (%w[admin tenant_curator].include?(current_user.role) ? current_user.tenant_id : nil)
       tenant_limit = (%w[admin tenant_curator].include?(current_user.role) ? current_user.tenant : nil)
@@ -34,7 +32,6 @@ module StashEngine
         end
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     # Unobtrusive Javascript (UJS) to do AJAX by running javascript
     def data_popup
@@ -79,7 +76,7 @@ module StashEngine
       end
     end
 
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def curation_activity_change
       respond_to do |format|
         format.js do
@@ -111,7 +108,7 @@ module StashEngine
         end
       end
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
     # show curation activities for this item
     def activity_log
@@ -227,5 +224,5 @@ module StashEngine
     end
 
   end
-  # rubocop:enable Metrics/ClassLength
+
 end

--- a/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
@@ -2,8 +2,6 @@ require_dependency 'stash_engine/application_controller'
 require 'stash/download/file_presigned'
 require 'stash/download/version_presigned'
 require 'http'
-
-# rubocop:disable Metrics/ClassLength
 module StashEngine
   class DownloadsController < ApplicationController
     include ActionView::Helpers::DateHelper
@@ -40,7 +38,6 @@ module StashEngine
     end
 
     # for downloading the full version
-    # rubocop:disable Metrics/MethodLength
     def download_resource
       @resource = nil
       @resource = Resource.where(id: params[:resource_id]).first if params[:share].nil?
@@ -68,7 +65,6 @@ module StashEngine
       end
     end
 
-    # rubocop:enable Metrics/MethodLength
     # checks assembly status for a resource and returns json from Merritt and http-ish status code, from progressbar polling
     def assembly_status
       @resource = nil
@@ -204,4 +200,3 @@ module StashEngine
 
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_engine/app/controllers/stash_engine/generic_files_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/generic_files_controller.rb
@@ -1,6 +1,4 @@
 require 'stash/aws/s3'
-
-# rubocop:disable Metrics/ClassLength
 module StashEngine
   class GenericFilesController < ApplicationController
 
@@ -188,4 +186,3 @@ module StashEngine
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_engine/app/controllers/stash_engine/landing_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/landing_controller.rb
@@ -70,7 +70,6 @@ module StashEngine
       end
     end
 
-    # rubocop:disable Metrics/AbcSize
     # PATCH /dataset/doi:10.xyz/abc
     def update
       return render(body: nil, status: 404) unless id
@@ -106,7 +105,6 @@ module StashEngine
       logger.debug(e)
       render(body: nil, status: 422) # 422 Unprocessable Entity, see RFC 5789 sec. 2.2
     end
-    # rubocop:enable Metrics/AbcSize
 
     # ############################################################
     # Private

--- a/stash/stash_engine/app/controllers/stash_engine/metadata_entry_pages_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/metadata_entry_pages_controller.rb
@@ -23,7 +23,7 @@ module StashEngine
       redirect_to(metadata_entry_pages_new_version_path(resource_id: params[:resource_id]))
     end
 
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     # GET /stash/edit/{doi}/{edit_code}
     def edit_by_doi
       redirect_to root_path, alert: 'The target dataset is being processed. Please try again later.' and return if resource.processing?
@@ -63,7 +63,7 @@ module StashEngine
 
       redirect_to(metadata_entry_pages_find_or_create_path(resource_id: resource.id))
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
     # create a new version of this resource before editing with find or create
     def new_version

--- a/stash/stash_engine/app/controllers/stash_engine/resources_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/resources_controller.rb
@@ -1,6 +1,4 @@
 require_dependency 'stash_engine/application_controller'
-
-# rubocop:disable Metrics/ClassLength
 module StashEngine
   class ResourcesController < ApplicationController
     before_action :require_login
@@ -190,4 +188,3 @@ module StashEngine
 
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_engine/app/controllers/stash_engine/sessions_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/sessions_controller.rb
@@ -1,7 +1,7 @@
 require_dependency 'stash_engine/application_controller'
 
 module StashEngine
-  class SessionsController < ApplicationController # rubocop:disable Metrics/ClassLength
+  class SessionsController < ApplicationController
 
     before_action :require_login, only: %i[callback]
     skip_before_action :verify_authenticity_token, only: %i[callback orcid_callback] # omniauth takes care of this differently
@@ -39,7 +39,6 @@ module StashEngine
     def choose_login; end
 
     # this only available in non-production environments and only if special environment variable set when starting server
-    # rubocop:disable Metrics/AbcSize
     def test_login
       return render(body: 'unauthorized', status: 401) if Rails.env.include?('prod') || ENV['TEST_LOGIN'].blank?
 
@@ -59,7 +58,6 @@ module StashEngine
       session[:user_id] = existing.id
       redirect_to dashboard_path, status: :found
     end
-    # rubocop:enable Metrics/AbcSize
 
     def choose_sso
       tenants = [OpenStruct.new(id: '', name: '')]

--- a/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
+++ b/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 module StashEngine
 
   # Mails users about submissions
@@ -166,4 +165,3 @@ module StashEngine
   end
 
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
+++ b/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
@@ -9,8 +9,6 @@
 #
 # If you want to get just one identifier for redrawing a single row, something like this should work
 # @dataset = StashEngine::AdminDatasets::CurationTableRow.where(params: {}, tenant: nil, identifier_id: 37575).first
-
-# rubocop:disable Metrics/ClassLength
 module StashEngine
   module AdminDatasets
     class CurationTableRow
@@ -64,7 +62,6 @@ module StashEngine
 
       # this method is long, but quite uncomplicated as it mostly just sets variables from the query
       #
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def initialize(result)
         return unless result.is_a?(Array) && result.length >= 22
 
@@ -92,7 +89,7 @@ module StashEngine
         @citations = result[21] || 0
         @relevance = result.length > 22 ? result[22] : nil
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:enable
       #
 
       # lets you get a resource when you need it and caches it
@@ -206,4 +203,3 @@ module StashEngine
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_engine/app/models/stash_engine/concerns/model_uploadable.rb
+++ b/stash/stash_engine/app/models/stash_engine/concerns/model_uploadable.rb
@@ -22,7 +22,6 @@ module StashEngine
       end
 
       # display the correct error message based on the url status code
-      # rubocop:disable Metrics/MethodLength
       def error_message
         return '' if url.nil? || status_code == 200
 
@@ -49,7 +48,6 @@ module StashEngine
           'The given URL is invalid. Please check the URL and resubmit.'
         end
       end
-      # rubocop:enable Metrics/MethodLength
 
       def digest?
         !digest.blank? && !digest_type.nil?

--- a/stash/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -197,7 +197,6 @@ module StashEngine
     end
 
     # Triggered on a status change
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def email_status_change_notices
       return if previously_published?
 
@@ -284,7 +283,7 @@ module StashEngine
       resource.update_column(:file_view, false) unless changed # if nothing changed between previous published and this, don't view same files again
       resource.update_column(:file_view, false) unless resource.current_file_uploads.present?
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:enable
 
     # Helper methods
     # ------------------------------------------

--- a/stash/stash_engine/app/models/stash_engine/curation_stats.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_stats.rb
@@ -1,5 +1,3 @@
-# rubocop:disable Metrics/ClassLength
-
 # CurationStats stores some statistics about the submission/curation process
 # that rarely change and take a little time to calculate. This class may only be
 # instantiated once for each date. Rather than instantiating with `new` or `create`,
@@ -55,7 +53,7 @@ module StashEngine
     # The number of datasets available for curation on that day
     # (either entered 'curation' or 'submitted', and the author made the last change)
     # - author made the ca to 'curation' or 'submitted', or if it was system, author made the last non-system one
-    # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/AbcSize
     def populate_datasets_to_be_curated
       datasets_found = Set.new
       # for each dataset that received the target status on the given day
@@ -89,7 +87,7 @@ module StashEngine
       end
       update(datasets_to_be_curated: datasets_found.size)
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/AbcSize
 
     # The number of new submissions that day (so the first time we see them as 'submitted' in the system)
     def populate_new_datasets_to_submitted
@@ -200,4 +198,3 @@ module StashEngine
 
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_engine/app/models/stash_engine/data_file.rb
+++ b/stash/stash_engine/app/models/stash_engine/data_file.rb
@@ -32,7 +32,6 @@ module StashEngine
     # reused in a few places.  If we move to a different repo this will need to change.
     #
     # If you use this method, you need to rescue the HTTP::Error and Stash::Download::Merritt errors if you don't want them raised
-    # rubocop:disable Metrics/AbcSize
     def merritt_s3_presigned_url
       raise Stash::Download::MerrittError, "Tenant not defined for resource_id: #{resource&.id}" if resource&.tenant.blank?
 
@@ -47,7 +46,6 @@ module StashEngine
       raise Stash::Download::MerrittError,
             "Merritt couldn't create presigned URL for #{merritt_presign_info_url}\nHttp status code: #{r.status.code}"
     end
-    # rubocop:enable Metrics/AbcSize
 
     # example
     # http://mrtexpress-stage.cdlib.org/dv/<version>/<ark>/<file pathname>

--- a/stash/stash_engine/app/models/stash_engine/generic_file.rb
+++ b/stash/stash_engine/app/models/stash_engine/generic_file.rb
@@ -20,7 +20,6 @@ module StashEngine
     enum digest_type: %w[md5 sha-1 sha-256 sha-384 sha-512].map { |i| [i.to_sym, i] }.to_h
 
     # display the correct error message based on the url status code
-    # rubocop:disable Metrics/MethodLength
     def error_message
       return '' if url.nil? || status_code == 200
 
@@ -47,7 +46,6 @@ module StashEngine
         'The given URL is invalid. Please check the URL and resubmit.'
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     def digest?
       !digest.blank? && !digest_type.nil?

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -237,7 +237,6 @@ module StashEngine
       Journal.where(issn: publication_issn).first
     end
 
-    # rubocop:disable Metrics/AbcSize
     def record_payment
       return if payment_type.present? && payment_type != 'unknown'
 
@@ -259,7 +258,6 @@ module StashEngine
       end
       save
     end
-    # rubocop:enable Metrics/AbcSize
 
     def allow_review?
       return true if journal.blank?
@@ -370,7 +368,6 @@ module StashEngine
     end
 
     # this is a method that will likely only be used to fill & migrate data to deal with more fine-grained version display
-    # rubocop:disable Metrics/MethodLength
     def fill_resource_view_flags
       my_pub = false
       resources.each do |res|
@@ -403,7 +400,6 @@ module StashEngine
         res.update_column(:file_view, false) unless res.current_file_uploads.present?
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     # This tells us if the curators made us orphan all old versions in the resource history in order to make display look pretty.
     # In this case we still may call this and want to show some version of the files because there was never a version remaining

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -620,7 +620,6 @@ module StashEngine
 
     # TODO: Move this to the Author model as `Author.from_user` perhaps so that we do not need to comingle
     # StashDatacite objects directly here.
-    # rubocop:disable Metrics/AbcSize
     def fill_author_from_user!
       f_name = user.first_name
       l_name = user.last_name
@@ -638,7 +637,6 @@ module StashEngine
       # disabling because we no longer wnat this with UC Press
       # author.affiliation_by_name(user.tenant.short_name) if user.try(:tenant)
     end
-    # rubocop:enable Metrics/AbcSize
 
     # -----------------------------------------------------------
     # Publication

--- a/stash/stash_engine/app/models/stash_engine/url_validator.rb
+++ b/stash/stash_engine/app/models/stash_engine/url_validator.rb
@@ -7,7 +7,7 @@ require 'byebug'
 # getting cert errors, maybe https://www.engineyard.com/blog/ruby-ssl-error-certificate-verify-failed fixes it ?
 
 module StashEngine
-  class UrlValidator # rubocop:disable Metrics/ClassLength
+  class UrlValidator
 
     attr_reader :mime_type, :size, :url, :status_code, :redirected_to, :filename
 
@@ -35,7 +35,7 @@ module StashEngine
     end
 
     # this method does the magic and checks the URL
-    def validate # rubocop:disable Metrics/MethodLength
+    def validate
       unless correctly_formatted_url?
         @status_code = 400 # bad request because the URL is malformed
         return false

--- a/stash/stash_engine/app/models/stash_engine/user.rb
+++ b/stash/stash_engine/app/models/stash_engine/user.rb
@@ -1,5 +1,4 @@
 module StashEngine
-  # rubocop:disable Metrics/ClassLength
   class User < ApplicationRecord
 
     has_many :resources
@@ -148,5 +147,5 @@ module StashEngine
     end
 
   end
-  # rubocop:enable Metrics/ClassLength
+
 end

--- a/stash/stash_engine/app/services/stash_engine/email_parser.rb
+++ b/stash/stash_engine/app/services/stash_engine/email_parser.rb
@@ -1,6 +1,4 @@
 module StashEngine
-
-  # rubocop:disable Metrics/ClassLength, Metrics/MethodLength, Metrics/AbcSize
   class EmailParser
     attr_reader :journal, :identifier
 
@@ -221,4 +219,3 @@ module StashEngine
 
   end
 end
-# rubocop:enable Metrics/ClassLength, Metrics/MethodLength, Metrics/AbcSize

--- a/stash/stash_engine/config/initializers/omniauth.rb
+++ b/stash/stash_engine/config/initializers/omniauth.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/BlockLength
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :shibboleth,
            callback_path: '/stash/auth/shibboleth/callback',
@@ -41,4 +40,4 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     Rack::Response.new(['302 Moved'], 302, 'Location' => env['omniauth.origin'] || '/').finish
   end
 end
-# rubocop:enable Metrics/BlockLength
+

--- a/stash/stash_engine/lib/stash/download/base.rb
+++ b/stash/stash_engine/lib/stash/download/base.rb
@@ -25,7 +25,6 @@ module Stash
       end
 
       # this is a method that should be overridden
-      # rubocop:disable Metrics/AbcSize
       def stream_response(url:, tenant:, filename:, read_timeout: 30)
         cc.request.env['rack.hijack'].call
         user_stream = cc.request.env['rack.hijack_io']
@@ -51,7 +50,6 @@ module Stash
         end
         cc.response.close
       end
-      # rubocop:enable Metrics/AbcSize
 
       # these send methods are the streaming methods for a 'rack.hijack',
       def send_headers(stream:, header_obj:, filename:)
@@ -77,7 +75,6 @@ module Stash
         raise e
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def send_stream(user_stream:, merritt_stream:)
         # use this file to write contents of the stream
         FileUtils.mkdir_p(Rails.root.join('uploads')) # ensures this file is created if it doesn't exist, needed mostly for tests
@@ -120,7 +117,7 @@ module Stash
         # class no longer exists to track history, and we're really not using this class anymore -- remants before presigned download urls
         # StashEngine::DownloadHistory.mark_end(download_history: @download_history) unless @download_history.nil?
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:enable
 
       def save_to_file(merritt_stream:, write_file:)
         chunk_size = 1024 * 512 # 512k

--- a/stash/stash_engine/lib/stash/google/journal_gmail.rb
+++ b/stash/stash_engine/lib/stash/google/journal_gmail.rb
@@ -11,8 +11,6 @@ require 'fileutils'
 #
 # This class is focused on the processing needed for metadata emails from
 # journals, but it could be expanded for more generic GMail functionality.
-
-# rubocop:disable Metrics/ClassLength
 module Stash
   module Google
     class JournalGMail
@@ -145,7 +143,6 @@ module Stash
 
         # Ensure valid credentials, either by restoring from a saved token
         # or intitiating a (command-line) OAuth2 authorization.
-        # rubocop:disable Metrics/MethodLength
         def initialize_gmail_service
           @gmail = ::Google::Apis::GmailV1::GmailService.new
           @gmail.client_options.application_name = APPLICATION_NAME
@@ -174,7 +171,6 @@ module Stash
           @gmail.authorization = credentials
           @gmail
         end
-        # rubocop:enable Metrics/MethodLength
 
         def processing_label_name
           APP_CONFIG[:google][:journal_processing_label]
@@ -202,4 +198,3 @@ module Stash
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_engine/lib/stash/link_out/pubmed_sequence_service.rb
+++ b/stash/stash_engine/lib/stash/link_out/pubmed_sequence_service.rb
@@ -12,7 +12,6 @@ module LinkOut
   # to the nucleotide databases (and here to the NUCCORE database), which should, however,
   # be the most common use-case, and may also need to be restricted to sequences for those
   # articles that also have a DOI.
-  # rubocop:disable Metrics/ClassLength
   class PubmedSequenceService
 
     include ::LinkOut::Helper
@@ -165,5 +164,5 @@ module LinkOut
     end
 
   end
-  # rubocop:enable Metrics/ClassLength
+
 end

--- a/stash/stash_engine/lib/stash/payments/invoicer.rb
+++ b/stash/stash_engine/lib/stash/payments/invoicer.rb
@@ -1,8 +1,6 @@
 # this require needed in tests, but not really in app, though it doesn't hurt anything
 require_relative '../../../app/helpers/stash_engine/application_helper'
 require 'stripe'
-
-# rubocop:disable Metrics/ClassLength
 module Stash
   module Payments
     class Invoicer
@@ -165,4 +163,3 @@ module Stash
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_engine/lib/stash/repo/repository.rb
+++ b/stash/stash_engine/lib/stash/repo/repository.rb
@@ -4,7 +4,7 @@ require 'concurrent'
 module Stash
   module Repo
     # Abstraction for a repository
-    class Repository # rubocop:disable Metrics/ClassLength
+    class Repository
       attr_reader :url_helpers, :executor
 
       # Initializes this repository

--- a/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
@@ -5,7 +5,6 @@ module Stash
 
     # to generate the metadata for the Zenodo API, see https://developers.zenodo.org/#depositions
     # and the "Deposit metadata" they request, which is kind of similar to ours, but slightly different
-    # rubocop:disable Metrics/ClassLength
     class MetadataGenerator
       # currently dataset_type may be :data, :software or :supp (for supplemental)
       def initialize(resource:, dataset_type: :data)
@@ -186,6 +185,6 @@ module Stash
       end
 
     end
-    # rubocop:enable Metrics/ClassLength
+
   end
 end

--- a/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -22,7 +22,7 @@ module Stash
         false
       end
 
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize
       def self.standard_request(method, url, **args)
         retries = 0
 
@@ -67,7 +67,7 @@ module Stash
           # rubocop:enable Style/GuardClause
         end
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize
 
       # NOTE: Alex suggested we use a URL like https://sandbox.zenodo.org/api/deposit/depositions?q=doi:%2210.7959/dryad.bzkh1894f%22
       # to do lookups by DOIs to see they exist before proceeding with a retry on a POST request.

--- a/stash/stash_engine/lib/stash/zenodo_software/copier.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/copier.rb
@@ -22,8 +22,6 @@ require 'stash/aws/s3'
 #
 # We may lose some history of metadata changes for zenodo software but we only care about published versions at Zenodo and
 # at least the latest metadata changes on publication are present.  File changes get versioned internally at Zenodo.
-
-# rubocop:disable Metrics/ClassLength
 module Stash
   module ZenodoSoftware
 
@@ -212,4 +210,3 @@ module Stash
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_engine/lib/stash/zenodo_software/file_collection.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/file_collection.rb
@@ -58,7 +58,6 @@ module Stash
       end
 
       # contains response: and digest: keys
-      # rubocop:disable Metrics/AbcSize
       def check_digests(streamer_response:, file_model:)
         out = streamer_response
         upload = file_model
@@ -75,7 +74,7 @@ module Stash
         raise FileError, "Error #{upload.digest_type} digest doesn't match database value:\nCalculated:#{out[:digests][upload.digest_type]}\n" \
               "Database: #{upload.digest}"
       end
-      # rubocop:enable Metrics/AbcSize
+
     end
   end
 end

--- a/stash/stash_engine/lib/stash/zenodo_software/streamer.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/streamer.rb
@@ -31,7 +31,7 @@ module Stash
       # This takes an argument of the digests types you want returned as an array, see DIGEST_INITIALIZERS for types.  It returns
       # the zenodo response and the hexdigests for the types you specify
 
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:disable Metrics/MethodLength
       def stream(digest_types: [])
         digests_obj = Digests.new(digest_types: digest_types)
 
@@ -79,7 +79,7 @@ module Stash
         raise Stash::ZenodoReplicate::ZenodoError, "Error retrieving HTTP URL for duplication #{@file_model.zenodo_replication_url}\n" \
             "Original error: #{e}\n#{e.backtrace.join("\n")}"
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/stash/stash_engine/lib/tasks/counter.rake
+++ b/stash/stash_engine/lib/tasks/counter.rake
@@ -2,8 +2,6 @@ require 'net/scp'
 require_relative 'counter/validate_file'
 require_relative 'counter/log_combiner'
 require_relative 'counter/json_stats'
-
-# rubocop:disable Metrics/BlockLength
 namespace :counter do
 
   desc 'get and combine files from the other servers'
@@ -85,4 +83,3 @@ namespace :counter do
     puts "note: in order to scp, you must add this server's public key to the authorized keys for the server you want to copy from"
   end
 end
-# rubocop:enable Metrics/BlockLength

--- a/stash/stash_engine/lib/tasks/counter/json_stats.rb
+++ b/stash/stash_engine/lib/tasks/counter/json_stats.rb
@@ -1,7 +1,7 @@
 require 'json'
 require 'byebug'
 
-# rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+# rubocop:disable Metrics/AbcSize
 class JsonStats
 
   def initialize(filename)
@@ -58,4 +58,4 @@ class JsonStats
   end
 end
 
-# rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+# rubocop:enable Metrics/AbcSize

--- a/stash/stash_engine/lib/tasks/counter/validate_file.rb
+++ b/stash/stash_engine/lib/tasks/counter/validate_file.rb
@@ -3,7 +3,6 @@ require 'ipaddr'
 require 'uri'
 
 # this is a long, but very consistent and simple class, so suck it rubocop
-# rubocop:disable Metrics/ClassLength
 module Counter
   class ValidateFile
 
@@ -179,4 +178,3 @@ module Counter
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/stash/stash_engine/lib/tasks/link_out.rake
+++ b/stash/stash_engine/lib/tasks/link_out.rake
@@ -3,7 +3,6 @@ require_relative '../stash/link_out/labslink_service'
 require_relative '../stash/link_out/pubmed_sequence_service'
 require_relative '../stash/link_out/pubmed_service'
 
-# rubocop:disable Metrics/BlockLength
 namespace :link_out do
 
   desc 'Generate and then push the LinkOut file(s) to the LinkOut FTP servers'
@@ -133,4 +132,3 @@ namespace :link_out do
   end
 
 end
-# rubocop:enable Metrics/BlockLength

--- a/stash/stash_engine/lib/tasks/migration.rake
+++ b/stash/stash_engine/lib/tasks/migration.rake
@@ -4,8 +4,6 @@ require 'database_cleaner'
 
 # Tasks for migration of various content into the Dryad environment. Tasks in this file are not intended for
 # long-term use; they are either for a single migration or for use over a limited time period.
-
-# rubocop:disable Metrics/BlockLength
 namespace :dryad_migration do
   desc 'Import journal codes from a local file'
   task import_journal_codes: :environment do
@@ -124,4 +122,3 @@ namespace :dryad_migration do
   end
 
 end
-# rubocop:enable Metrics/BlockLength

--- a/stash/stash_engine/lib/tasks/status_dashboard.rake
+++ b/stash/stash_engine/lib/tasks/status_dashboard.rake
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/BlockLength
 namespace :status_dashboard do
 
   desc 'Check Solr'
@@ -132,4 +131,3 @@ namespace :status_dashboard do
   ].freeze
   # rubocop:enable Layout/LineLength
 end
-# rubocop:enable Metrics/BlockLength

--- a/stash/stash_engine/stash_engine.gemspec
+++ b/stash/stash_engine/stash_engine.gemspec
@@ -19,7 +19,7 @@ require 'stash_engine/version'
 # travis or on new software installs intended for development or testing because add_development_dependency is weak sauce
 # for our uses.
 
-Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
+Gem::Specification.new do |s|
   s.name        = 'stash_engine'
   s.version     = StashEngine::VERSION
   s.authors     = ['sfisher']


### PR DESCRIPTION
Loosening the restrictions that were most frequently disabled. This has the side effect of removing a large number of `disable` statements.

I tried to maintain a reasonable level of strictness, trying to keep the code well-structured while reducing the level of annoyance. I raised the limits that we constantly have to disable, but for every limit I raised, there are still some instances where our code is over the limit and we have some corresponding `disable` statements for it.