### PR TITLE
Warn about submission unless they give us data files

### DIFF
--- a/spec/features/stash_engine/review_and_submit_spec.rb
+++ b/spec/features/stash_engine/review_and_submit_spec.rb
@@ -51,4 +51,23 @@ RSpec.feature 'ReviewAndSubmit', type: :feature, js: true do
     end
   end
 
+  describe 'Warn for no data files' do
+    before(:each) do
+      ActionMailer::Base.deliveries = []
+      # Sign in and create a new dataset
+      sign_in(@author)
+      visit root_path
+      click_link 'My Datasets'
+      start_new_dataset
+      fill_required_fields
+      # navigate_to_review
+    end
+
+    it 'warns that there are no data files' do
+      click_link 'Review and Submit'
+
+      expect(page).to have_text('We notice you do not have any data files in this submission.')
+    end
+  end
+
 end

--- a/spec/models/stash_datacite/completions_spec.rb
+++ b/spec/models/stash_datacite/completions_spec.rb
@@ -202,6 +202,17 @@ module StashDatacite
             expect(completions.urls_validated?).to eq(true)
           end
         end
+
+        describe 'has_data?' do
+          it 'returns false if no data files present' do
+            @resource.data_files.destroy_all
+            expect(@completions.has_data?).to eq(false)
+          end
+
+          it 'returns true if data files are present' do
+            expect(@completions.has_data?).to eq(true)
+          end
+        end
       end
 
       describe :s3_error_uploads do

--- a/spec/models/stash_datacite/completions_spec.rb
+++ b/spec/models/stash_datacite/completions_spec.rb
@@ -203,14 +203,14 @@ module StashDatacite
           end
         end
 
-        describe 'has_data?' do
+        describe 'contains_data?' do
           it 'returns false if no data files present' do
             @resource.data_files.destroy_all
-            expect(@completions.has_data?).to eq(false)
+            expect(@completions.contains_data?).to eq(false)
           end
 
           it 'returns true if data files are present' do
-            expect(@completions.has_data?).to eq(true)
+            expect(@completions.contains_data?).to eq(true)
           end
         end
       end

--- a/spec/support/helpers/dataset_helper.rb
+++ b/spec/support/helpers/dataset_helper.rb
@@ -33,9 +33,7 @@ module DatasetHelper
 
   def navigate_to_review
     click_link 'Review and Submit'
-    if page.has_content?('We notice you do not have any data files in this submission.')
-      page.send_keys :escape
-    end
+    page.send_keys :escape if page.has_content?('We notice you do not have any data files in this submission.')
     expect(page).to have_content('Review Description')
   end
 

--- a/spec/support/helpers/dataset_helper.rb
+++ b/spec/support/helpers/dataset_helper.rb
@@ -33,6 +33,9 @@ module DatasetHelper
 
   def navigate_to_review
     click_link 'Review and Submit'
+    if page.has_content?('We notice you do not have any data files in this submission.')
+      page.send_keys :escape
+    end
     expect(page).to have_content('Review Description')
   end
 

--- a/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
@@ -196,11 +196,7 @@ module StashDatacite
         messages << 'The first author must have an email supplied' unless author_email
         messages << 'Authors must have affiliations' unless author_affiliation
         messages << 'Fix or remove upload URLs that were unable to validate' unless urls_validated?
-        unless contains_data?
-          messages << 'Data files are required for submission.  If you only have software or supplemental ' \
-                      'information, please submit directly to ' \
-                      '<a href="https://zenodo.org" target="_blank" style="color: white">https://zenodo.org</a>'
-        end
+
         if error_uploads.present?
           messages << 'Some files can not be submitted because they may have had errors uploading. ' \
             'Please re-upload the following files if you still see this error in a few minutes.'

--- a/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
@@ -99,6 +99,11 @@ module StashDatacite
         errored_uploads
       end
 
+      # checks for existing data files, Dryad is a data repository and shouldn't be used only as a way to deposit in Zenodo
+      def has_data?
+        @resource.data_files.present_files.count.positive?
+      end
+
       def over_manifest_file_size?(size_limit)
         @resource.data_files.present_files.sum(:upload_file_size) > size_limit
       end
@@ -191,6 +196,9 @@ module StashDatacite
         messages << 'The first author must have an email supplied' unless author_email
         messages << 'Authors must have affiliations' unless author_affiliation
         messages << 'Fix or remove upload URLs that were unable to validate' unless urls_validated?
+        messages << 'Data files are required for submission.  If you only have software or supplemental ' \
+                    'information, please submit directly to ' \
+                    '<a href="https://zenodo.org" target="_blank" style="color: white">https://zenodo.org</a>' unless has_data?
         if error_uploads.present?
           messages << 'Some files can not be submitted because they may have had errors uploading. ' \
             'Please re-upload the following files if you still see this error in a few minutes.'

--- a/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/resource/completions.rb
@@ -100,7 +100,7 @@ module StashDatacite
       end
 
       # checks for existing data files, Dryad is a data repository and shouldn't be used only as a way to deposit in Zenodo
-      def has_data?
+      def contains_data?
         @resource.data_files.present_files.count.positive?
       end
 
@@ -196,9 +196,11 @@ module StashDatacite
         messages << 'The first author must have an email supplied' unless author_email
         messages << 'Authors must have affiliations' unless author_affiliation
         messages << 'Fix or remove upload URLs that were unable to validate' unless urls_validated?
-        messages << 'Data files are required for submission.  If you only have software or supplemental ' \
-                    'information, please submit directly to ' \
-                    '<a href="https://zenodo.org" target="_blank" style="color: white">https://zenodo.org</a>' unless has_data?
+        unless contains_data?
+          messages << 'Data files are required for submission.  If you only have software or supplemental ' \
+                      'information, please submit directly to ' \
+                      '<a href="https://zenodo.org" target="_blank" style="color: white">https://zenodo.org</a>'
+        end
         if error_uploads.present?
           messages << 'Some files can not be submitted because they may have had errors uploading. ' \
             'Please re-upload the following files if you still see this error in a few minutes.'

--- a/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
@@ -119,6 +119,17 @@
   <% end %>
 </div>
 
+  <!-- hidden dialog with info about data belongs in Dryad -->
+  <div id="popup_dialog" style="display:none;">
+    <p>
+      Dryad is a repository that focuses on research data.  We notice you do not have any data files in this submission.
+    </p>
+    <p>
+      If you are only interested in uploading software or supplemental
+      information, we suggest submitting directly to <a href="https://zenodo.org" target="_blank">https://zenodo.org</a>.
+    </p>
+  </div>
+
 <script type="text/javascript">
   // display some flash messages, (why do we need this?, ajax?)
   <% flash.each do |type, message| %>
@@ -140,6 +151,24 @@
       $('#submit_dataset').prop('disabled', true);
     }
   }
+
+  // make a popup if no data files
+  <% unless @completions.contains_data? %>
+    $("#popup_dialog").dialog({
+      autoOpen: true,
+      height: 'auto',
+      width: '500px',
+      modal: true,
+      title: 'Submitting Data Files to Dryad'
+    });
+
+    // allow to close dialog with escape key
+    $(document).keyup(function(e) {
+      if (e.key === "Escape") {
+        $("#popup_dialog").dialog("close");
+      }
+    });
+  <% end %>
 </script>
 
 


### PR DESCRIPTION
Data files are why Dryad exists and we shouldn't be a conduit for people to use Zenodo with no data.