### PR TITLE
Default value for manuscript number in Editorial Manager bridge

### DIFF
--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -127,7 +127,7 @@ module StashApi
             identifier: art_params['article_doi']
           }.with_indifferent_access
         end
-        em_params['manuscriptNumber'] = art_params['manuscript_number'] if art_params['manuscript_number']
+        em_params['manuscriptNumber'] = art_params['manuscript_number'] || em_params['document_id'] || 'EM-DEPOSIT'
         em_params['title'] = art_params['article_title']
         em_params['abstract'] = art_params['abstract']
         keywords = [art_params['keywords'], art_params['classifications']].flatten.compact


### PR DESCRIPTION
If Editorial Manager does not provide a manuscript number, fall back to use deposit ID, or as a last resort fill it with a generic string. This allows users to progress through the submission system without worrying about the manuscript number. Editorial Manager will store and use the dataset DOI, so we do not need the manuscript number for later matching.