### PR TITLE
Both new and existing files show as "uploaded"

### DIFF
--- a/app/javascript/containers/UploadFiles.js
+++ b/app/javascript/containers/UploadFiles.js
@@ -164,7 +164,7 @@ class UploadFiles extends React.Component {
     setFileUploadComplete = (file, index) => {
         const chosenFiles = this.state.chosenFiles;
         chosenFiles[index].id = file.id;
-        chosenFiles[index].status = 'New';
+        chosenFiles[index].status = 'Uploaded';
         this.setState({chosenFiles: chosenFiles});
     }
 
@@ -342,7 +342,7 @@ class UploadFiles extends React.Component {
         return files.map(file => ({
             ...file,
             sanitized_name: file.upload_file_name,
-            status: 'New',  // TODO: correctly define the status based on status in database
+            status: 'Uploaded',
             uploadType: RailsActiveRecordToUploadType[file.type],
             sizeKb: formatSizeUnits(file.upload_file_size)
         }))

--- a/spec/features/stash_engine/upload_files_spec.rb
+++ b/spec/features/stash_engine/upload_files_spec.rb
@@ -74,7 +74,7 @@ Software and Supplemental Information can be uploaded for publication at'
       expect(page).to have_content(@file1.upload_file_name)
       expect(page).to have_content(@file2.url)
       expect(page).to have_content(@file3.upload_file_name)
-      expect(page).to have_content('New', count: 3)
+      expect(page).to have_content('Uploaded', count: 3)
     end
 
     it 'shows the right navigation buttons at the bottom' do
@@ -433,7 +433,7 @@ Software and Supplemental Information can be uploaded for publication at'
       click_button('data_manifest')
       fill_in('location_urls', with: 'http://example.org/funbar.txt')
       click_on('validate_files')
-      expect(page).to have_content('New')
+      expect(page).to have_content('Uploaded')
     end
 
     it 'only changes table status column to a progress bar if file status is Pending' do


### PR DESCRIPTION
The "new" terminology was confusing since some "new" files had been uploaded a while back in previous versions.

Instead, changing the term to "uploaded" which shows for both newly uploaded and previously (long ago) uploaded items.

This is what shows in the table of uploads on page 2 of the process.  Page 3 still shows new next to new items in this version, nothing (and an underlined link) for submitted versions and a strikethrough for removed items.