### PR TITLE
Allow forcible editing of datasets

### DIFF
--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -157,6 +157,9 @@ module StashEngine
       resource_ids = @identifier.resources.collect(&:id)
       @curation_activities = CurationActivity.where(resource_id: resource_ids).order(helpers.sortable_table_order, id: :asc)
       @internal_data = InternalDatum.where(identifier_id: @identifier.id)
+    rescue ActiveRecord::RecordNotFound
+      admin_path = stash_url_helpers.url_for(controller: 'stash_engine/admin_datasets', action: 'index', only_path: true)
+      redirect_to admin_path, notice: "Identifier ID #{params[:id]} no longer exists."
     end
 
     def stats_popup

--- a/stash/stash_engine/app/controllers/stash_engine/metadata_entry_pages_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/metadata_entry_pages_controller.rb
@@ -129,6 +129,7 @@ module StashEngine
       set_return_to_path_from_referrer # needed for dropping into edit (and back) from various places in the ui
 
       if @identifier.in_progress_only?
+        @identifier.in_progress_resource.update(current_editor_id: current_user&.id)
         redirect_to(metadata_entry_pages_find_or_create_path(resource_id: @identifier.in_progress_resource.id))
         false
       elsif @identifier.processing? || @identifier.error?

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/activity_log.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/activity_log.html.erb
@@ -59,3 +59,21 @@
 
 <div id="popup_dialog" style="display:none;">
 </div>
+
+<% if current_user.superuser? %>
+    <div id="dangerous_actions">
+	<div style="float: left"><h2>Dangerous Actions</h2>
+
+	    <div style="float: left">
+		<% res = @identifier&.latest_resource %>
+		<%= form_with(url: metadata_entry_pages_new_version_path, method: :post, local: true) do -%>
+			<button class="o-button__submit">Forcibly Edit Dataset</button>
+			<%= hidden_field_tag :resource_id, res&.id, id: "resource_id_#{res&.id}" %>
+			<%= hidden_field_tag :return_url, '/stash/dashboard' %>
+		<% end %>
+		<p>Forcibly editing a dataset will assign it to you, and begin an editing session.
+		Please only do this if you know the author is unable/unwilling to submit it.</p>
+	    </div>
+	</div>
+    </div>
+<% end %>


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1199

Gives superusers a button that allows them to edit a dataset, even if the dataset is still "in progress" by another user. Because this could lead to unfortunate race conditions, the button is located out of the way at the bottom of the Activity Log page, AND it is marked as "dangerous".