### PR TITLE
Add user_name to journal review notices

### DIFF
--- a/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
+++ b/stash/stash_engine/app/mailers/stash_engine/user_mailer.rb
@@ -9,12 +9,10 @@ module StashEngine
     def status_change(resource, status)
       return unless %w[submitted peer_review published embargoed].include?(status)
 
-      user = resource.authors.first || resource.user
-      return unless user.present? && user_email(user).present?
-
-      @user_name = user_name(user)
       assign_variables(resource)
-      mail(to: user_email(user),
+      return unless @user.present? && user_email(@user).present?
+
+      mail(to: user_email(@user),
            bcc: @resource&.tenant&.campus_contacts,
            template_name: status,
            subject: "#{rails_env} Dryad Submission \"#{@resource.title}\"")
@@ -70,12 +68,10 @@ module StashEngine
       logger.warn('Unable to send in_progress_reminder; nil resource') unless resource.present?
       return unless resource.present?
 
-      user = resource.authors.first || resource.user
-      return unless user.present? && user_email(user).present?
-
-      @user_name = user_name(user)
       assign_variables(resource)
-      mail(to: user_email(user),
+      return unless @user.present? && user_email(@user).present?
+
+      mail(to: user_email(@user),
            subject: "#{rails_env} REMINDER: Dryad Submission \"#{@resource.title}\"")
     end
 
@@ -83,12 +79,10 @@ module StashEngine
       logger.warn('Unable to send peer_review_reminder; nil resource') unless resource.present?
       return unless resource.present?
 
-      user = resource.authors.first || resource.user
-      return unless user.present? && user_email(user).present?
-
-      @user_name = user_name(user)
       assign_variables(resource)
-      mail(to: user_email(user),
+      return unless @user.present? && user_email(@user).present?
+
+      mail(to: user_email(@user),
            subject: "#{rails_env} REMINDER: Dryad Submission \"#{@resource.title}\"")
     end
 
@@ -139,6 +133,8 @@ module StashEngine
 
     def assign_variables(resource)
       @resource = resource
+      @user = resource.authors.first || resource.user
+      @user_name = user_name(@user)
       @helpdesk_email = APP_CONFIG['helpdesk_email'] || 'help@datadryad.org'
       @bcc_emails = APP_CONFIG['submission_bc_emails'] || [@helpdesk_email]
       @submission_error_emails = APP_CONFIG['submission_error_email'] || [@helpdesk_email]

--- a/stash/stash_engine/app/views/stash_engine/user_mailer/journal_review_notice.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/user_mailer/journal_review_notice.html.erb
@@ -5,6 +5,7 @@
 
 <p>
     Data DOI: <%= @resource.identifier_str %><br/>
+    Submitted by: <%= @user_name %><br/>
     Journal: <%= @resource.identifier.publication_name %><br/>
     Journal manuscript number: <%= @resource.identifier.manuscript_number %><br/>
     Article DOI: <%= @resource.identifier.publication_article_doi %><br/>


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1255

Adds the submitter's name to notices that journals receive for review purposes. Also, rearranges the mailer so @user is available in all emails.