### PR TITLE
Cache list of curators for faster query processing

### DIFF
--- a/spec/features/stash_datacite/dataset_versioning_spec.rb
+++ b/spec/features/stash_datacite/dataset_versioning_spec.rb
@@ -21,6 +21,7 @@ RSpec.feature 'DatasetVersioning', type: :feature do
     ignore_zenodo!
     neuter_curation_callbacks!
     @curator = create(:user, role: 'superuser')
+    stub_const('StashEngine::AdminDatasets::CurationTableRow::CURATOR_IDS', [@curator.id])
     @author = create(:user)
     @document_list = []
   end
@@ -186,7 +187,6 @@ RSpec.feature 'DatasetVersioning', type: :feature do
 
       it 'displays the proper information on the Admin page', js: true do
         within(:css, '.c-lined-table__row') do
-
           # Make sure the appropriate buttons are available
           expect(page).to have_css('button[title="Edit Dataset"]')
           expect(page).to have_css('button[aria-label="Update status"]')

--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -129,6 +129,7 @@ RSpec.feature 'Admin', type: :feature do
 
       it 'allows assigning a curator', js: true do
         @curator = create(:user, role: 'superuser', tenant_id: 'dryad')
+        stub_const('StashEngine::AdminDatasets::CurationTableRow::CURATOR_IDS', [@curator.id])
 
         visit root_path
         find('.o-sites__summary', text: 'Admin').click

--- a/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
+++ b/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
@@ -61,6 +61,8 @@ module StashEngine
       PUBLICATION_CLAUSE = 'seid.value = %{term}'
       IDENTIFIER_CLAUSE = 'sei.id = %{term}'
 
+      CURATOR_IDS = StashEngine::User.curators.map(&:id)
+
       # this method is long, but quite uncomplicated as it mostly just sets variables from the query
       #
       def initialize(result)
@@ -82,7 +84,7 @@ module StashEngine
         @curation_activity_id = result[12]
         @status = result[13]
         @updated_at = result[14]
-        @editor_id = StashEngine::User.curators.map(&:id).include?(result[15].to_i) ? result[15] : nil
+        @editor_id = CURATOR_IDS.include?(result[15].to_i) ? result[15] : nil
         @editor_name = @editor_id ? "#{result[17]} #{result[16]}" : nil
         @author_names = result[18]
         @views = (result[20].nil? ? 0 : result[19] - result[20])


### PR DESCRIPTION
When there is a large number of datasets, we don't want to re-query the DB for the list of curators for every single row in the table.