### PR TITLE
Improve caching of curator_ids

### DIFF
--- a/spec/features/stash_datacite/dataset_versioning_spec.rb
+++ b/spec/features/stash_datacite/dataset_versioning_spec.rb
@@ -21,7 +21,6 @@ RSpec.feature 'DatasetVersioning', type: :feature do
     ignore_zenodo!
     neuter_curation_callbacks!
     @curator = create(:user, role: 'superuser')
-    stub_const('StashEngine::AdminDatasets::CurationTableRow::CURATOR_IDS', [@curator.id])
     @author = create(:user)
     @document_list = []
   end

--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -129,7 +129,6 @@ RSpec.feature 'Admin', type: :feature do
 
       it 'allows assigning a curator', js: true do
         @curator = create(:user, role: 'superuser', tenant_id: 'dryad')
-        stub_const('StashEngine::AdminDatasets::CurationTableRow::CURATOR_IDS', [@curator.id])
 
         visit root_path
         find('.o-sites__summary', text: 'Admin').click

--- a/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
+++ b/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
@@ -61,11 +61,9 @@ module StashEngine
       PUBLICATION_CLAUSE = 'seid.value = %{term}'
       IDENTIFIER_CLAUSE = 'sei.id = %{term}'
 
-      CURATOR_IDS = StashEngine::User.curators.map(&:id)
-
       # this method is long, but quite uncomplicated as it mostly just sets variables from the query
       #
-      def initialize(result)
+      def initialize(result, curator_ids)
         return unless result.is_a?(Array) && result.length >= 22
 
         # Convert the array of results into attribute values
@@ -84,7 +82,7 @@ module StashEngine
         @curation_activity_id = result[12]
         @status = result[13]
         @updated_at = result[14]
-        @editor_id = CURATOR_IDS.include?(result[15].to_i) ? result[15] : nil
+        @editor_id = curator_ids.include?(result[15].to_i) ? result[15] : nil
         @editor_name = @editor_id ? "#{result[17]} #{result[16]}" : nil
         @author_names = result[18]
         @views = (result[20].nil? ? 0 : result[19] - result[20])
@@ -128,7 +126,8 @@ module StashEngine
                                  identifier_id: identifier_id)}
             #{build_order_clause(column, params.fetch(:direction, ''), params.fetch(:q, ''))}
           "
-          results = ApplicationRecord.connection.execute(query).map { |result| new(result) }
+          curator_ids = StashEngine::User.curators.map(&:id)
+          results = ApplicationRecord.connection.execute(query).map { |result| new(result, curator_ids) }
           # If the user is trying to sort by author names, then
           (column == 'author_names' ? sort_by_author_names(results, params.fetch(:direction, '')) : results)
         end


### PR DESCRIPTION
Sorry to change this around... the approach in https://github.com/CDL-Dryad/dryad-app/pull/495 had the major drawback of not updating the list of curators until the server restarted. So instead of using a constant, I moved the cached value into the `where` method.