### PR TITLE
Clean out temporary content

### DIFF
--- a/cron/monthly.sh
+++ b/cron/monthly.sh
@@ -19,3 +19,6 @@ export FORCE_SUBMISSION="`date --date="$(date +%Y-%m-15) - 1 month" "+%Y-%m"`"
 
 # run the script with the above settings, this is just a ruby script (no rails)
 /apps/dryad/apps/ui/current/stash/script/counter-uploader/main.rb >> /apps/dryad/apps/ui/shared/cron/logs/counter-uploader.log 2>&1
+
+# Clean outdated content from the database and temporary S3 store
+bundle exec rails identifiers:remove_old_versions >> /apps/dryad/apps/ui/shared/cron/logs/remove_old_versions.log 2>&1

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -132,6 +132,7 @@ namespace :identifiers do
     # Remove resources that have been "in progress" for more than a year without updates
     StashEngine::Resource.in_progress.each do |res|
       next unless res.updated_at < 1.year.ago
+      next unless res.current_curation_status == 'in_progress'
 
       ident = res.identifier
       s3_dir = res.s3_dir_name(type: 'base')

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -168,8 +168,9 @@ namespace :identifiers do
 
       if StashEngine::Resource.exists?(id: res_id)
         r = StashEngine::Resource.find(res_id)
-        if r.submitted? && r.updated_at < 1.month.ago
-          # if the resource is state == submitted and has been for a month (so zenodo has processed), delete the data
+        if r.submitted? &&
+           (r.zenodo_copies.where("copy_type LIKE 'software%' OR copy_type like 'supp%'").where.not(state: 'finished').count == 0)
+          # if the resource is state == submitted and all zenodo transfers have completed, delete the data
           puts "   resource is submitted -- DELETE s3 dir #{id_prefix}"
           Stash::Aws::S3.delete_dir(s3_key: id_prefix) unless dry_run
         end

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -136,7 +136,7 @@ namespace :identifiers do
 
       ident = res.identifier
       s3_dir = res.s3_dir_name(type: 'base')
-      puts "#{ident.id} Res #{res.id} -- #{res.updated_at}"
+      puts "ident #{ident.id} Res #{res.id} -- updated_at #{res.updated_at}"
       puts "   DESTROY s3 #{s3_dir}"
       ## Stash::Aws::S3.delete_dir(s3_key: s3_dir)
       puts "   DESTROY resource #{res.id}"
@@ -154,26 +154,24 @@ namespace :identifiers do
                   ''
                 end
     Stash::Aws::S3.objects(starts_with: s3_prefix).each do |s3o|
-      # - get resource ID from it
       id_prefix = s3o.key.split('/').first
       res_id = if id_prefix.include?('-')
                  id_prefix.split('-').last
                else
                  id_prefix
                end
-      puts "key is #{s3o.key} -- #{id_prefix} -- #{res_id}"
+      puts "checking S3 key #{s3o.key} -- id_prefix #{id_prefix} -- res_id #{res_id}"
 
-      # - check if the resource exists
       if StashEngine::Resource.exists?(id: res_id)
         r = StashEngine::Resource.find(res_id)
         if r.submitted? && r.updated_at < 1.month.ago
           # if the resource is state == submitted and has been for a month (so zenodo has processed), delete the data
-          puts "   submitted -- DELETE s3 dir #{id_prefix}"
+          puts "   resource is submitted -- DELETE s3 dir #{id_prefix}"
           ##  Stash::Aws::S3.delete_dir(s3_key: id_prefix)
         end
       else
         # there is no reasource, delete the files
-        puts "   deleted -- DELETE s3 dir #{id_prefix}"
+        puts "   resource is deleted -- DELETE s3 dir #{id_prefix}"
         ##  Stash::Aws::S3.delete_dir(s3_key: id_prefix)
       end
     end

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -127,7 +127,7 @@ namespace :identifiers do
     end
   end
 
-  desc 'remove in_progress versions that have lingered for too long'
+  desc 'remove in_progress versions and temporary files that have lingered for too long'
   task remove_old_versions: :environment do
     dry_run = ENV['DRY_RUN'] == 'true'
     if dry_run


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/560

Rake task to clean old datasets and temporary files. If a resource has been `in_progress` for more than a year, it is removed. If this resource is the only one attached to a given identifier, the identifier is removed as well. After cleaning the resources, the script cleans directories on S3. An S3 directory is removed if it (a) does not have a corresponding resource, or (b) the corresponding resource entered `submitted` status more than a month ago. (We don't want to delete S3 directories immediately after the resource is submitted, because we need to allow time for copying to Zenodo, possibly recovering from a failure of the transfer.)

To run:
`bundle exec rails identifiers:remove_old_versions`

If you set the environment variable `DRY_RUN=true`, you can run this script without actually deleting content, to see the output indicating which items will be deleted.