### PR TITLE
Improve ISSN robustness

### DIFF
--- a/stash/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
+++ b/stash/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
@@ -17,9 +17,6 @@ function loadPublications() {
 			event.preventDefault();
 		    }
 		    // else do the normal tab actions, which will retain the values if one was just selected
-                } else {
-		    $("#internal_datum_publication_issn").val(''); // clear any ISSN that was saved previously, so user selection can overwrite it
-		}
             })
             .autocomplete({
 		// when page is loaded, IF the dataset has been filled in already,
@@ -45,6 +42,7 @@ function loadPublications() {
                 source: function (request, response) {
 		    // save the user's typed request in the database with an asterisk, in case they don't click on an autocomplete result
 		    $("#internal_datum_publication_name").val(request.term + "*");
+		    $("#internal_datum_publication_issn").val(''); // clear any ISSN that was saved previously
 		    var form = $(this.form);
                     $(form).trigger('submit.rails');
 		    $.ajax({

--- a/stash/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
+++ b/stash/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
@@ -17,6 +17,7 @@ function loadPublications() {
 			event.preventDefault();
 		    }
 		    // else do the normal tab actions, which will retain the values if one was just selected
+		}
             })
             .autocomplete({
 		// when page is loaded, IF the dataset has been filled in already,


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1282

When submitters are entering a journal name in the autocomplete box:
- Only erase an existing ISSN when a non-recognized journal name is being saved. This prevents shortcuts like CMD+Tab from erasing the ISSN when it would otherwise be valid.
- When a non-recognized journal name is being saved, first check whether it exactly matches a known name (just with the extra asterisk). This allows the journal to be recorded properly if users type it exactly, but don't actually click on the autocomplete.
