### PR TITLE
Fixes trying to upload the same file more than once in a row

### DIFF
--- a/app/javascript/components/UploadType/UploadType.js
+++ b/app/javascript/components/UploadType/UploadType.js
@@ -11,7 +11,7 @@ const upload_type = (props) => {
 
             <div className="c-choose">
                 <label htmlFor={props.type} className="c-choose__input-file-label">{props.buttonFiles}</label>
-                <input id={props.type} className="c-choose__input-file" type='file' onChange={props.changed} multiple={true} />
+                <input id={props.type} className="c-choose__input-file" type='file' onClick={props.clicked} onChange={props.changed} multiple={true} />
             </div>
             <button id={props.type + '_manifest'} className="js-uploadmodal__button-show-modal" onClick={props.clicked}>{props.buttonURLs}</button>
         </section>

--- a/app/javascript/containers/UploadFiles.js
+++ b/app/javascript/containers/UploadFiles.js
@@ -491,7 +491,14 @@ class UploadFiles extends React.Component {
                         return <UploadType
                             key={upload_type.type}
                             changed={(event) => this.addFilesHandler(event, upload_type.type)}
-                            clicked={() => this.showModal(upload_type.type)}
+                            clicked={(event) => {
+                                if(event.target.id.includes('manifest')){
+                                    this.showModal(upload_type.type);
+                                }else{
+                                    // triggers change to reset file uploads to null before onChange to allow files to be added again
+                                    event.target.value = null;
+                                }
+                            } }
                             type={upload_type.type}
                             logo={upload_type.logo}
                             name={upload_type.name}

--- a/app/javascript/containers/UploadFiles.js
+++ b/app/javascript/containers/UploadFiles.js
@@ -493,7 +493,7 @@ class UploadFiles extends React.Component {
                             changed={(event) => this.addFilesHandler(event, upload_type.type)}
                             clicked={(event) => {
                                 if(event.target.id.includes('manifest')){
-                                    this.showModal(upload_type.type);
+                                    this.showModal(upload_type.type); // for manifest upload dialog
                                 }else{
                                     // triggers change to reset file uploads to null before onChange to allow files to be added again
                                     event.target.value = null;


### PR DESCRIPTION
https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1268

Before the upload button wouldn't work if you tried uploading the same file.

Steps to reproduce:

1. Click the "choose files" button and try to upload a file that already exists (or a new file).  If it already existed you'll get a warning that the file already exists.
2. (optional): Now remove the file like you want to remove it to upload it again.
3. Click the "choose files" button and choose the same file you selected previously to try uploading it again.

- Previous (bug): Nothing happens  (no warning, no error, just doesn't do anything).

- Now: It should add the file to the list again and allow you to upload without shenanigans like reloading the whole page or adding other files first.

It was caused by a change event that didn't see re-adding the same file as previously as a change.

