### PR TITLE
Dashboard for tracking the zenodo failures

### DIFF
--- a/stash/stash_engine/app/assets/javascripts/stash_engine/zenodo_queue.js
+++ b/stash/stash_engine/app/assets/javascripts/stash_engine/zenodo_queue.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/stash/stash_engine/app/assets/stylesheets/stash_engine/zenodo_queue.css
+++ b/stash/stash_engine/app/assets/stylesheets/stash_engine/zenodo_queue.css
@@ -1,0 +1,4 @@
+/*
+  Place all the styles related to the matching controller here.
+  They will automatically be included in application.css.
+*/

--- a/stash/stash_engine/app/controllers/stash_engine/zenodo_queue_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/zenodo_queue_controller.rb
@@ -1,4 +1,4 @@
-require_dependency "stash_engine/application_controller"
+require_dependency 'stash_engine/application_controller'
 
 module StashEngine
   class ZenodoQueueController < ApplicationController
@@ -8,10 +8,10 @@ module StashEngine
 
     before_action :require_superuser
 
-    ALLOWED_SORT = %w[id identifier_id resource_id state updated_at copy_type size error_info]
-    ALLOWED_ORDER = %w[asc desc]
+    ALLOWED_SORT = %w[id identifier_id resource_id state updated_at copy_type size error_info].freeze
+    ALLOWED_ORDER = %w[asc desc].freeze
 
-    BASIC_SQL = <<~SQL
+    BASIC_SQL = <<~SQL.freeze
       SELECT *,
           CASE
             WHEN copy_type LIKE '%software%' THEN
@@ -61,13 +61,13 @@ module StashEngine
       @zenodo_copy = ZenodoCopy.find(params[:id])
       copy_type = @zenodo_copy.copy_type.gsub('_publish', '')
 
-      previous_unfinished = ZenodoCopy.where("id < ?", params[:id])
-                                      .where(identifier_id: @zenodo_copy.identifier_id)
-                                      .where("copy_type LIKE ?", "%#{copy_type}%")
-                                      .where("state != 'finished'").count
+      previous_unfinished = ZenodoCopy.where('id < ?', params[:id])
+        .where(identifier_id: @zenodo_copy.identifier_id)
+        .where('copy_type LIKE ?', "%#{copy_type}%")
+        .where("state != 'finished'").count
 
       if previous_unfinished.positive?
-        render plain: "You may only resubmit a later item in a series after earlier items have successfully processed"
+        render plain: 'You may only resubmit a later item in a series after earlier items have successfully processed'
         return
       end
 
@@ -96,11 +96,11 @@ module StashEngine
     # pass in the zenodo copy
     def running_jobs(zc)
       if zc.copy_type.include?('software')
-        Delayed::Job.where("handler LIKE ?", "%- #{zc.id}%").where(queue: 'zenodo_software')
+        Delayed::Job.where('handler LIKE ?', "%- #{zc.id}%").where(queue: 'zenodo_software')
       elsif zc.copy_type.include?('supp')
-        Delayed::Job.where("handler LIKE ?", "%- #{zc}.id}%").where(queue: 'zenodo_supp')
+        Delayed::Job.where('handler LIKE ?', "%- #{zc}.id}%").where(queue: 'zenodo_supp')
       else
-        Delayed::Job.where("handler LIKE ?", "%- #{zc.resource_id}%").where(queue: 'zenodo_copy')
+        Delayed::Job.where('handler LIKE ?', "%- #{zc.resource_id}%").where(queue: 'zenodo_copy')
       end
     end
 

--- a/stash/stash_engine/app/controllers/stash_engine/zenodo_queue_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/zenodo_queue_controller.rb
@@ -10,28 +10,115 @@ module StashEngine
 
     ALLOWED_SORT = %w[id identifier_id resource_id state updated_at copy_type size error_info]
     ALLOWED_ORDER = %w[asc desc]
-    def index
 
-      sort = (ALLOWED_SORT & [params[:sort]]).first || 'identifier_id'
-      order = (ALLOWED_ORDER & [params[:direction]]).first || 'asc'
-      sql = <<~SQL
-        SELECT *,
+    BASIC_SQL = <<~SQL
+      SELECT *,
           CASE
             WHEN copy_type LIKE '%software%' THEN
               (SELECT sum(upload_file_size) FROM stash_engine_generic_files
-                WHERE resource_id = stash_engine_zenodo_copies.resource_id AND file_state != 'deleted' AND type = 'StashEngine::SoftwareFile')
+                WHERE resource_id = stash_engine_zenodo_copies.resource_id AND file_state = 'created' AND type = 'StashEngine::SoftwareFile')
             WHEN copy_type LIKE '%supp%' THEN
               (SELECT sum(upload_file_size) from stash_engine_generic_files
-                WHERE resource_id = stash_engine_zenodo_copies.resource_id AND file_state != 'deleted' AND type = 'StashEngine::SuppFile')
+                WHERE resource_id = stash_engine_zenodo_copies.resource_id AND file_state = 'created' AND type = 'StashEngine::SuppFile')
             ELSE
               (SELECT sum(upload_file_size) FROM stash_engine_generic_files
                 WHERE resource_id = stash_engine_zenodo_copies.resource_id AND file_state != 'deleted' AND type = 'StashEngine::DataFile')
           END as size
         FROM stash_engine_zenodo_copies
+    SQL
+
+    def index
+      sort = (ALLOWED_SORT & [params[:sort]]).first || 'identifier_id'
+      order = (ALLOWED_ORDER & [params[:direction]]).first || 'asc'
+      sql = <<~SQL
+        #{BASIC_SQL}
         WHERE state != "finished"
         ORDER BY #{sort} #{order};
       SQL
       @zenodo_copies = ZenodoCopy.find_by_sql(sql)
+    end
+
+    def item_details
+      @zenodo_copy = ZenodoCopy.find(params[:id])
+
+      @delayed_jobs = running_jobs(@zenodo_copy)
+
+      # this is an error if it shows a different state
+      if @delayed_jobs.count == 0 && !%w[error deferred].include?(@zenodo_copy.state)
+        @zenodo_copy.update(state: 'error')
+      end
+    end
+
+    def identifier_details
+      sort = (ALLOWED_SORT & [params[:sort]]).first || 'identifier_id'
+      order = (ALLOWED_ORDER & [params[:direction]]).first || 'asc'
+      sql = <<~SQL
+        #{BASIC_SQL}
+        WHERE state != "finished" AND identifier_id = ?
+        ORDER BY #{sort} #{order};
+      SQL
+
+      @zenodo_copies = ZenodoCopy.find_by_sql([sql, params[:id]])
+      @identifier = Identifier.find(params[:id])
+    end
+
+    def resubmit_job
+      @zenodo_copy = ZenodoCopy.find(params[:id])
+      copy_type = @zenodo_copy.copy_type.gsub('_publish', '')
+
+      previous_unfinished = ZenodoCopy.where("id < ?", params[:id])
+                                      .where(identifier_id: @zenodo_copy.identifier_id)
+                                      .where("copy_type LIKE ?", "%#{copy_type}%")
+                                      .where("state != 'finished'").count
+
+      if previous_unfinished.positive?
+        render plain: "You may only resubmit a later item in a series after earlier items have successfully processed"
+        return
+      end
+
+      if running_jobs(@zenodo_copy).count.positive?
+        render plain: "This job is still in the delayed job runner so shouldn't be restarted right now"
+        return
+      end
+
+      resend_job
+    end
+
+    def set_errored
+      sql = <<~SQL
+        #{BASIC_SQL}
+        WHERE state != "finished";
+      SQL
+      @zenodo_copies = ZenodoCopy.find_by_sql(sql)
+
+      @zenodo_copies.each do |zc|
+        zc.update(state: 'error') unless running_jobs(zc).count.positive?
+      end
+    end
+
+    private
+
+    # pass in the zenodo copy
+    def running_jobs(zc)
+      if zc.copy_type.include?('software')
+        Delayed::Job.where("handler LIKE ?", "%- #{zc.id}%").where(queue: 'zenodo_software')
+      elsif zc.copy_type.include?('supp')
+        Delayed::Job.where("handler LIKE ?", "%- #{zc}.id}%").where(queue: 'zenodo_supp')
+      else
+        Delayed::Job.where("handler LIKE ?", "%- #{zc.resource_id}%").where(queue: 'zenodo_copy')
+      end
+    end
+
+    # uses @zenodo_copy
+    def resend_job
+      @zenodo_copy.update(state: 'enqueued')
+      if @zenodo_copy.copy_type.include?('software')
+        ZenodoSoftwareJob.perform_later(@zenodo_copy.id)
+      elsif @zenodo_copy.copy_type.include?('supp')
+        ZenodoSuppJob.perform_later(@zenodo_copy.id)
+      else
+        ZenodoCopyJob.perform_later(@zenodo_copy.resource_id)
+      end
     end
   end
 end

--- a/stash/stash_engine/app/controllers/stash_engine/zenodo_queue_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/zenodo_queue_controller.rb
@@ -1,0 +1,37 @@
+require_dependency "stash_engine/application_controller"
+
+module StashEngine
+  class ZenodoQueueController < ApplicationController
+
+    include SharedSecurityController
+    helper SortableTableHelper
+
+    before_action :require_superuser
+
+    ALLOWED_SORT = %w[id identifier_id resource_id state updated_at copy_type size error_info]
+    ALLOWED_ORDER = %w[asc desc]
+    def index
+
+      sort = (ALLOWED_SORT & [params[:sort]]).first || 'identifier_id'
+      order = (ALLOWED_ORDER & [params[:direction]]).first || 'asc'
+      sql = <<~SQL
+        SELECT *,
+          CASE
+            WHEN copy_type LIKE '%software%' THEN
+              (SELECT sum(upload_file_size) FROM stash_engine_generic_files
+                WHERE resource_id = stash_engine_zenodo_copies.resource_id AND file_state != 'deleted' AND type = 'StashEngine::SoftwareFile')
+            WHEN copy_type LIKE '%supp%' THEN
+              (SELECT sum(upload_file_size) from stash_engine_generic_files
+                WHERE resource_id = stash_engine_zenodo_copies.resource_id AND file_state != 'deleted' AND type = 'StashEngine::SuppFile')
+            ELSE
+              (SELECT sum(upload_file_size) FROM stash_engine_generic_files
+                WHERE resource_id = stash_engine_zenodo_copies.resource_id AND file_state != 'deleted' AND type = 'StashEngine::DataFile')
+          END as size
+        FROM stash_engine_zenodo_copies
+        WHERE state != "finished"
+        ORDER BY #{sort} #{order};
+      SQL
+      @zenodo_copies = ZenodoCopy.find_by_sql(sql)
+    end
+  end
+end

--- a/stash/stash_engine/app/controllers/stash_engine/zenodo_queue_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/zenodo_queue_controller.rb
@@ -42,11 +42,6 @@ module StashEngine
       @zenodo_copy = ZenodoCopy.find(params[:id])
 
       @delayed_jobs = running_jobs(@zenodo_copy)
-
-      # this is an error if it shows a different state
-      if @delayed_jobs.count == 0 && !%w[error deferred].include?(@zenodo_copy.state)
-        @zenodo_copy.update(state: 'error')
-      end
     end
 
     def identifier_details

--- a/stash/stash_engine/app/helpers/stash_engine/zenodo_queue_helper.rb
+++ b/stash/stash_engine/app/helpers/stash_engine/zenodo_queue_helper.rb
@@ -1,0 +1,4 @@
+module StashEngine
+  module ZenodoQueueHelper
+  end
+end

--- a/stash/stash_engine/app/views/stash_engine/pages/_nav.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/pages/_nav.html.erb
@@ -21,6 +21,7 @@
               <%= link_to 'Publication Updater', stash_url_helpers.publication_updater_path, class: 'o-sites__group-item' %>
               <%= link_to 'Status Dashboard', stash_url_helpers.status_dashboard_path, class: 'o-sites__group-item' %>
               <%= link_to 'Submission Queue', stash_url_helpers.url_for(controller: 'stash_engine/submission_queue', action: 'index', only_path: true), class: 'o-sites__group-item' %>
+              <%= link_to 'Zenodo Submissions', stash_url_helpers.zenodo_queue_path, class: 'o-sites__group-item' %>
             </div>
           </details>
         </div>

--- a/stash/stash_engine/app/views/stash_engine/zenodo_queue/_status_table.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/zenodo_queue/_status_table.html.erb
@@ -15,6 +15,9 @@
     <th class="<%= sort_display('updated_at') %>">
       <%= sortable_column_head sort_field: 'updated_at', title: 'Updated at' %>
     </th>
+    <th class="<%= sort_display('created_at') %>">
+      <%= sortable_column_head sort_field: 'created_at', title: 'Created at' %>
+    </th>
     <th class="<%= sort_display('copy_type') %>">
       <%= sortable_column_head sort_field: 'copy_type', title: 'Copy Type' %>
     </th>
@@ -24,19 +27,23 @@
     <th class="<%= sort_display('error_info') %>">
       <%= sortable_column_head sort_field: 'error_info', title: 'Error Info' %>
     </th>
-
+    <th>Actions</th>
 
   </tr>
   <% @zenodo_copies.each do |zc| %>
     <tr class="c-lined-table__row">
-      <td><%= zc.id %></td>
-      <td><%= zc.identifier_id %></td>
+      <td><%= link_to(zc.id, zenodo_queue_item_details_path(zc.id)) %></td>
+      <td><%= link_to(zc.identifier_id, zenodo_queue_identifier_details_path(zc.identifier_id)) %></td>
       <td><%= zc.resource_id %></td>
       <td><%= zc.state %></td>
       <td><%= formatted_datetime(zc.updated_at) %></td>
-      <td><%= zc.copy_type %></td>
+      <td><%= formatted_datetime(zc.created_at) %></td>
+      <td><%= zc.copy_type.gsub('_', ' ') %></td>
       <td><%= filesize(zc.size) %></td>
-      <td><%= link_to truncate(zc.error_info, length: 20), '#', title: zc.error_info %></td>
+      <td><%= link_to truncate(zc.error_info || 'null', length: 20), zenodo_queue_item_details_path(zc.id), title: zc.error_info %></td>
+      <td>
+        <%= button_to('resend', zenodo_queue_resubmit_job_path(id: zc.id)) %>
+      </td>
     </tr>
   <% end %>
 </table>

--- a/stash/stash_engine/app/views/stash_engine/zenodo_queue/_status_table.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/zenodo_queue/_status_table.html.erb
@@ -1,0 +1,42 @@
+<table class="c-lined-table">
+  <tr class="c-lined-table__head">
+    <th class="<%= sort_display('id') %>">
+      <%= sortable_column_head sort_field: 'id', title: 'ID' %>
+    </th>
+    <th class="<%= sort_display('identifier_id') %>">
+      <%= sortable_column_head sort_field: 'identifier_id', title: 'Ident.Id' %>
+    </th>
+    <th class="<%= sort_display('resource_id') %>">
+      <%= sortable_column_head sort_field: 'resource_id', title: 'Res.Id' %>
+    </th>
+    <th class="<%= sort_display('state') %>">
+      <%= sortable_column_head sort_field: 'state', title: 'State' %>
+    </th>
+    <th class="<%= sort_display('updated_at') %>">
+      <%= sortable_column_head sort_field: 'updated_at', title: 'Updated at' %>
+    </th>
+    <th class="<%= sort_display('copy_type') %>">
+      <%= sortable_column_head sort_field: 'copy_type', title: 'Copy Type' %>
+    </th>
+    <th class="<%= sort_display('size') %>">
+      <%= sortable_column_head sort_field: 'size', title: 'Size' %>
+    </th>
+    <th class="<%= sort_display('error_info') %>">
+      <%= sortable_column_head sort_field: 'error_info', title: 'Error Info' %>
+    </th>
+
+
+  </tr>
+  <% @zenodo_copies.each do |zc| %>
+    <tr class="c-lined-table__row">
+      <td><%= zc.id %></td>
+      <td><%= zc.identifier_id %></td>
+      <td><%= zc.resource_id %></td>
+      <td><%= zc.state %></td>
+      <td><%= formatted_datetime(zc.updated_at) %></td>
+      <td><%= zc.copy_type %></td>
+      <td><%= filesize(zc.size) %></td>
+      <td><%= link_to truncate(zc.error_info, length: 20), '#', title: zc.error_info %></td>
+    </tr>
+  <% end %>
+</table>

--- a/stash/stash_engine/app/views/stash_engine/zenodo_queue/identifier_details.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/zenodo_queue/identifier_details.html.erb
@@ -1,0 +1,7 @@
+<h2>identifier details for doi:<%= @identifier.identifier %></h2>
+
+<div id="status_table">
+  <%= render partial: 'status_table' %>
+</div>
+
+<%= link_to('back to queue list', zenodo_queue_path) %>

--- a/stash/stash_engine/app/views/stash_engine/zenodo_queue/index.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/zenodo_queue/index.html.erb
@@ -1,0 +1,6 @@
+<h2>Information about the current queue for Zenodo</h2>
+
+
+<div id="status_table">
+  <%= render partial: 'status_table' %>
+</div>

--- a/stash/stash_engine/app/views/stash_engine/zenodo_queue/index.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/zenodo_queue/index.html.erb
@@ -10,3 +10,27 @@
 <div id="status_table">
   <%= render partial: 'status_table' %>
 </div>
+
+<h3>Information</h3>
+
+<ul>
+  <li>
+    Click an <em>id</em> or <em>error</em> to see the full information in the Zenodo Copies table as
+    well as any delayed job worker queue information.
+  </li>
+  <li>
+    Clicking an identifier id shows all the errored submissions for one dataset.  This can be useful if you want to troubleshoot
+    just one dataset or resubmit items in order.
+  </li>
+  <li>
+    Hovering over an error displays more information.
+  </li>
+  <li>
+    Clicking <em>resend</em> will re-insert a job into the delayed job worker queue to send to Zenodo again.
+  </li>
+  <li>
+    The <em>Reset stalled to error state</em> button will look through the items in the list and reset any that are not
+    in the active delayed job queue (ie actively replicating or waiting to replicate) to an error state.  This makes the
+    list more accurate for stalled items.
+  </li>
+</ul>

--- a/stash/stash_engine/app/views/stash_engine/zenodo_queue/index.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/zenodo_queue/index.html.erb
@@ -1,6 +1,12 @@
 <h2>Information about the current queue for Zenodo</h2>
 
+<p>
+  <%= @zenodo_copies.count %> items in list
+</p>
 
+<p>
+  <%= button_to('Reset stalled to error state', zenodo_queue_set_errored_path) %>
+</p>
 <div id="status_table">
   <%= render partial: 'status_table' %>
 </div>

--- a/stash/stash_engine/app/views/stash_engine/zenodo_queue/item_details.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/zenodo_queue/item_details.html.erb
@@ -1,0 +1,28 @@
+<h2>Item details for Zenodo Copy ID <%= @zenodo_copy.id %>, doi:<%= @zenodo_copy&.identifier&.identifier %></h2>
+
+<h3>Delayed Job Info</h3>
+
+<% if @delayed_jobs.count.positive? %>
+  <table class="c-lined-table">
+    <% @delayed_jobs.first.attributes.each_pair do |k, v| %>
+      <tr class="c-lined-table__row">
+        <td style="width: 10em; font-weight: bolder"><%= k %></td>
+        <td><pre style="margin: 0; padding: 0;"><%= v || ' ' %></pre></td>
+      </tr>
+    <% end %>
+  </table>
+<% else %>
+  <p>This item isn't currently processing in the delayed job runner.</p>
+<% end %>
+
+<h3>Zenodo Copy Info</h3>
+<table class="c-lined-table">
+  <% @zenodo_copy.attributes.each_pair do |k, v| %>
+    <tr class="c-lined-table__row">
+      <td style="width: 10em; font-weight: bolder"><%= k %></td>
+      <td><pre style="margin: 0; padding: 0;"><%= v || ' ' %></pre></td>
+    </tr>
+  <% end %>
+</table>
+
+<%= link_to('back to queue list', zenodo_queue_path) %>

--- a/stash/stash_engine/app/views/stash_engine/zenodo_queue/resubmit_job.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/zenodo_queue/resubmit_job.html.erb
@@ -1,0 +1,3 @@
+<p>The job for zenodo copy id <%= @zenodo_copy.id %> was submitted to delayed job.</p>
+
+<%= link_to('back to queue list', zenodo_queue_path) %>

--- a/stash/stash_engine/app/views/stash_engine/zenodo_queue/set_errored.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/zenodo_queue/set_errored.html.erb
@@ -1,0 +1,3 @@
+<p>The stalled items that were not in the delayed job queue have been set to 'error' state.</p>
+
+<%= link_to('back to queue list', zenodo_queue_path) %>

--- a/stash/stash_engine/config/routes.rb
+++ b/stash/stash_engine/config/routes.rb
@@ -138,7 +138,11 @@ StashEngine::Engine.routes.draw do
   get 'submission_queue/ungraceful_start', to: 'submission_queue#ungraceful_start'
 
   # routing for zenodo_queue
-  get 'zenodo_queue', to: 'zenodo_queue#index'
+  get 'zenodo_queue', to: 'zenodo_queue#index', as: 'zenodo_queue'
+  get 'zenodo_queue/item_details/:id', to: 'zenodo_queue#item_details', as: 'zenodo_queue_item_details'
+  get 'zenodo_queue/identifier_details/:id', to: 'zenodo_queue#identifier_details', as: 'zenodo_queue_identifier_details'
+  post 'zenodo_queue/resubmit_job', to: 'zenodo_queue#resubmit_job', as: 'zenodo_queue_resubmit_job'
+  post 'zenodo_queue/set_errored', to: 'zenodo_queue#set_errored', as: 'zenodo_queue_set_errored'
 
   # Administrative Status Dashboard that displays statuses of external dependencies
   get 'status_dashboard', to: 'status_dashboard#show'

--- a/stash/stash_engine/config/routes.rb
+++ b/stash/stash_engine/config/routes.rb
@@ -137,6 +137,9 @@ StashEngine::Engine.routes.draw do
   get 'submission_queue/graceful_start', to: 'submission_queue#graceful_start'
   get 'submission_queue/ungraceful_start', to: 'submission_queue#ungraceful_start'
 
+  # routing for zenodo_queue
+  get 'zenodo_queue', to: 'zenodo_queue#index'
+
   # Administrative Status Dashboard that displays statuses of external dependencies
   get 'status_dashboard', to: 'status_dashboard#show'
 

--- a/stash/stash_engine/test/controllers/stash_engine/zenodo_queue_controller_test.rb
+++ b/stash/stash_engine/test/controllers/stash_engine/zenodo_queue_controller_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+module StashEngine
+  class ZenodoQueueControllerTest < ActionDispatch::IntegrationTest
+    include Engine.routes.url_helpers
+
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end


### PR DESCRIPTION
We need to deal with problems at Zenodo, especially if they go on for a while.  It is a pain to deal with them and figure out what is going on from the database.  Also, when I use my 350 hours of vacation, someone else will need to deal with at least the urgent things sometimes.  ;-)  Zenodo also seems to frequently have problems during their nighttime.  Errored items get attempts at resubmission on a cron, but it may not catch everything.

This should make it quite a bit easier to at least resubmit, see and diagnose problems.

- Adds menu for superusers "Zenodo Submissions"
- Shows all items that aren't finished, pretty much using the same query I've been using for months manually.
- Clicking the ID gives full details for delayed job and our internal zenodo job information.
- Clicking identifier id gives just the errors for that dataset.  Sometimes it's a lot easier to just see one dataset so you can submit things in order if there is more than one failure backed up.
  - (Each update to software & supplemental goes in zenodo and creates versions there.)
  - (Only published changes update for extra copies in zenodo.)
- Error info in mouseover or by clicking into details.
- Action to resend an item into the delayed job queue.
- Action to set state to *error* for stalled items which happens when Zenodo has problems or huge submissions .  It detects stalled items when they've dropped out of the delayed job queue, but are in non-error states in the zenodo job history.


Probably to test, you can look at our development and we have a bunch of junk data in there already that has failed.  You'll see pre-failed things you can try submitting or look at.

You can also submit a dataset.  The supplemental or software should show up right after being submitted and then disappear once successful.  The data replication should show up briefly after publishing.

I haven't done a lot as far as testing of this and most is very simple and basically views into the database.  If you'd like I can go back and add some tests, but I just wanted to get something out there we can begin using so it's not such a burden to deal with the failures.