### PR TITLE
Do not display or count citations for random URLs that don't have citation metadata

### DIFF
--- a/spec/models/stash_engine/counter_citation_spec.rb
+++ b/spec/models/stash_engine/counter_citation_spec.rb
@@ -9,7 +9,7 @@ module StashEngine
       it 'returns nil if citation unable to be generated' do
         doi = '10.1010/12345.67890'
 
-        expect(Stash::DataciteMetadata).to receive(:new).with(doi: doi).and_return({html_citation: nil}.to_ostruct)
+        expect(Stash::DataciteMetadata).to receive(:new).with(doi: doi).and_return({ html_citation: nil }.to_ostruct)
         expect(CounterCitation.citation_metadata(doi: doi, stash_identifier: @identifier)).to be_nil
       end
     end

--- a/spec/models/stash_engine/counter_citation_spec.rb
+++ b/spec/models/stash_engine/counter_citation_spec.rb
@@ -1,0 +1,17 @@
+module StashEngine
+  describe CounterCitation do
+
+    before(:each) do
+      @identifier = create(:identifier)
+    end
+
+    describe 'self.citation_metadata(doi:, stash_identifier:)' do
+      it 'returns nil if citation unable to be generated' do
+        doi = '10.1010/12345.67890'
+
+        expect(Stash::DataciteMetadata).to receive(:new).with(doi: doi).and_return({html_citation: nil}.to_ostruct)
+        expect(CounterCitation.citation_metadata(doi: doi, stash_identifier: @identifier)).to be_nil
+      end
+    end
+  end
+end

--- a/stash/stash_engine/app/models/stash_engine/counter_citation.rb
+++ b/stash/stash_engine/app/models/stash_engine/counter_citation.rb
@@ -9,9 +9,10 @@ module StashEngine
       # logger.debug('before getting citation events')
       dois = cite_events.results
       # logger.debug('after getting citation events')
+      # dois, but eliminate blank citations
       dois.map do |citation_event|
         citation_metadata(doi: citation_event, stash_identifier: stash_identifier)
-      end
+      end.reject(&:nil?)
     end
 
     # gets cached citation or retrieves a new one
@@ -22,7 +23,8 @@ module StashEngine
 
       datacite_metadata = Stash::DataciteMetadata.new(doi: doi)
       html_citation = datacite_metadata.html_citation
-      html_citation = "Citation text unavailable for <a href=\"#{doi}\" target=\"_blank\">#{doi}</a>" if html_citation.blank?
+      return nil if html_citation.blank?  # do not save to database and return nil early
+
       create(citation: html_citation, doi: doi, identifier_id: stash_identifier.id)
     end
   end


### PR DESCRIPTION
We were displaying citations for some items in DataCite Eventdata that had non-doi citations like random links to github or other places.

- if the html citation text is unavailable for lookup from datacite then return a nil
- where it maps citations, it is rejecting blanks which will eliminate those nils
- I manually ran a couple of queries to remove the non-doi citations and to update the counts in our database
- Added a test for this returning nil when no citation available, seems like this class didn't have tests yet.

https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1285

