### PR TITLE
Small fix for edge case where some items fail midway

### DIFF
--- a/stash/stash_engine/lib/stash/zenodo_replicate/copier.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/copier.rb
@@ -96,6 +96,14 @@ module Stash
         resp
       end
       # rubocop:enable Naming/AccessorMethodName
+
+      def previous_deposition_id
+        return @copy.deposition_id unless @copy.deposition_id.blank?
+
+        return @previous_copy.deposition_id unless @previous_copy.nil?
+
+        nil
+      end
     end
   end
 end

--- a/stash/stash_engine/lib/stash/zenodo_replicate/copier_mixin.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/copier_mixin.rb
@@ -31,12 +31,6 @@ module Stash
         raise ZenodoError, "identifier_id #{@copy.identifier_id}: Cannot replicate when a previous replication for the " \
               'identifier has not finished yet. Items must replicate in order.'
       end
-
-      def previous_deposition_id
-        return @previous_copy.deposition_id unless @previous_copy.nil?
-
-        nil
-      end
     end
   end
 end


### PR DESCRIPTION
- Moves method from mixin class to individual class since it isn't used outside one class right now
- If a deposition_id (zenodo id) is already set for an item it doesn't try to find it from a previous deposit or reset it to nothing.