### PR TITLE
Reconfiguring priority according to the Delayed Job docs

### DIFF
--- a/stash/stash_engine/config/initializers/delayed_job_config.rb
+++ b/stash/stash_engine/config/initializers/delayed_job_config.rb
@@ -3,10 +3,20 @@ require 'delayed_job_active_record'
 
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.sleep_delay = 60
-Delayed::Worker.max_attempts = 3
+Delayed::Worker.max_attempts = 2
 Delayed::Worker.max_run_time = 6.hours
-Delayed::Worker.read_ahead = 10
+# Was going to change, but looks like read ahead is ignored for MySQL and if using priority, anyway.
+# https://stackoverflow.com/questions/35734246/how-does-priority-interact-with-read-ahead-in-delayed-job
+Delayed::Worker.read_ahead = 5
 Delayed::Worker.default_queue_name = 'default'
 Delayed::Worker.delay_jobs = !Rails.env.test?
 Delayed::Worker.raise_signal_exceptions = :term
 Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
+
+# when there are jobs in the software and supplemental queues, give them priority, apparently lower numbers are higher priority
+# See https://github.com/collectiveidea/delayed_job/tree/v4.1.9
+Delayed::Worker.queue_attributes = {
+  zenodo_software: { priority: -10 },
+  zenodo_supp: { priority: -10 },
+  zenodo_copy: { priority: 10 }
+}


### PR DESCRIPTION
Gives different queues different priorities and we give each type of submission a named queue.

This should basically make the data replication happen after supplemental and software.

Also, changed delayed job retries to 2 since at times when Zenodo has issues we might want to reduce retrying right then and wait for our cron to re-launch the errors for retry the next day.