### PR TITLE
Add absolute URLs for EM

### DIFF
--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -189,12 +189,12 @@ module StashApi
       deposit_url = if metadata[:_links][:self][:href]
                       request.protocol + request.host_with_port + metadata[:_links][:self][:href]
                     else
-                      null
+                      nil
                     end
       edit_url = if metadata[:editLink]
                    request.protocol + request.host_with_port + metadata[:editLink]
                  else
-                   null
+                   nil
                  end
 
       {

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -186,11 +186,23 @@ module StashApi
 
     # Reformat a `metadata` response object, putting it in the format that Editorial Manager prefers
     def em_reformat_response(metadata)
+      deposit_url = if metadata[:_links][:self][:href]
+                      request.protocol + request.host_with_port + metadata[:_links][:self][:href]
+                    else
+                      null
+                    end
+      edit_url = if metadata[:editLink]
+                   request.protocol + request.host_with_port + metadata[:editLink]
+                 else
+                   null
+                 end
+
       {
         deposit_id: @stash_identifier.identifier,
         deposit_doi: @stash_identifier.identifier,
-        deposit_url: metadata[:_links][:self][:href],
-        deposit_edit_url: metadata[:editLink],
+        deposit_url: deposit_url,
+        deposit_edit_url: edit_url,
+        deposit_upload_url: edit_url,
         status: 'Success'
       }.compact
     end

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -186,16 +186,8 @@ module StashApi
 
     # Reformat a `metadata` response object, putting it in the format that Editorial Manager prefers
     def em_reformat_response(metadata)
-      deposit_url = if metadata[:_links][:self][:href]
-                      request.protocol + request.host_with_port + metadata[:_links][:self][:href]
-                    else
-                      nil
-                    end
-      edit_url = if metadata[:editLink]
-                   request.protocol + request.host_with_port + metadata[:editLink]
-                 else
-                   nil
-                 end
+      deposit_url = (request.protocol + request.host_with_port + metadata[:_links][:self][:href] if metadata[:_links][:self][:href])
+      edit_url = (request.protocol + request.host_with_port + metadata[:editLink] if metadata[:editLink])
 
       {
         deposit_id: @stash_identifier.identifier,


### PR DESCRIPTION
Editorial Manager wants absolute URLs instead of relative URLs. (Note that this change only applies to the EM API calls, so it does not affect anyone else.)