### PR TITLE
Feeds the queue to replicate old data replications

### DIFF
--- a/lib/tasks/zenodo.rake
+++ b/lib/tasks/zenodo.rake
@@ -2,7 +2,7 @@ namespace :zenodo do
   desc 'Queue feeder that keeps migration items going to the delayed job queue with sleep in between'
   task feed_queue: :environment do
     trap('SIGINT') do
-      puts "Exiting zenodo feeder"
+      puts 'Exiting zenodo feeder'
       exit
     end
 
@@ -20,13 +20,14 @@ namespace :zenodo do
       LIMIT #{max_feed_queue};
     SQL
 
-    while true do
+    loop do
       puts Time.new.iso8601
       StashEngine::Identifier.find_by_sql(sql).each do |identifier|
         break if Delayed::Job.count >= max_feed_queue
+
         resource = identifier.latest_resource_with_public_download
         resource.send_to_zenodo(note: 'Sent by migration')
-        puts "  inserting #{identifier.to_s}"
+        puts "  inserting #{identifier}"
         sleep 0.5
       end
       sleep 30

--- a/lib/tasks/zenodo.rake
+++ b/lib/tasks/zenodo.rake
@@ -1,0 +1,35 @@
+namespace :zenodo do
+  desc 'Queue feeder that keeps migration items going to the delayed job queue with sleep in between'
+  task feed_queue: :environment do
+    trap('SIGINT') do
+      puts "Exiting zenodo feeder"
+      exit
+    end
+
+    # try to only fill the queue to this level, will be re-filled frequently, anyway
+    max_feed_queue = 8
+
+    sql = <<~SQL.strip
+      SELECT ids.* FROM stash_engine_identifiers ids
+        LEFT JOIN stash_engine_zenodo_copies cops
+        ON ids.id = cops.identifier_id
+      WHERE ids.pub_state = 'published'
+        AND cops.id IS NULL
+        AND ids.storage_size < 1e+10
+      ORDER BY RAND()
+      LIMIT #{max_feed_queue};
+    SQL
+
+    while true do
+      puts Time.new.iso8601
+      StashEngine::Identifier.find_by_sql(sql).each do |identifier|
+        break if Delayed::Job.count >= max_feed_queue
+        resource = identifier.latest_resource_with_public_download
+        resource.send_to_zenodo(note: 'Sent by migration')
+        puts "  inserting #{identifier.to_s}"
+        sleep 0.5
+      end
+      sleep 30
+    end
+  end
+end

--- a/lib/tasks/zenodo.rake
+++ b/lib/tasks/zenodo.rake
@@ -11,7 +11,7 @@ namespace :zenodo do
 
     sql = <<~SQL.strip
       SELECT ids.* FROM stash_engine_identifiers ids
-        LEFT JOIN stash_engine_zenodo_copies cops
+        LEFT JOIN (SELECT id, identifier_id FROM stash_engine_zenodo_copies WHERE copy_type = 'data') cops
         ON ids.id = cops.identifier_id
       WHERE ids.pub_state = 'published'
         AND cops.id IS NULL

--- a/lib/tasks/zenodo.rake
+++ b/lib/tasks/zenodo.rake
@@ -26,7 +26,10 @@ namespace :zenodo do
         break if Delayed::Job.count >= max_feed_queue
 
         resource = identifier.latest_resource_with_public_download
-        resource.send_to_zenodo(note: 'Sent by migration')
+        resource&.send_to_zenodo(note: 'Sent by migration')
+
+        # set retries to 10 so our daily retries for old migrations don't overwhelm current items and we can retry manually
+        ZenodoCopy.where(resource_id: resource.id, copy_type: 'data').update(retries: 10)
         puts "  inserting #{identifier}"
         sleep 0.5
       end

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -700,10 +700,10 @@ module StashEngine
     end
 
     # this just sends a **COPY** job to zenodo (ie Merritt duplication), not for replication which could be sfw or supp
-    def send_to_zenodo
+    def send_to_zenodo(note: nil)
       return if data_files.empty? # no files? Then don't send to Zenodo for duplication.
 
-      ZenodoCopy.create(state: 'enqueued', identifier_id: identifier_id, resource_id: id, copy_type: 'data') if zenodo_copies.data.empty?
+      ZenodoCopy.create(state: 'enqueued', identifier_id: identifier_id, resource_id: id, copy_type: 'data', note: note) if zenodo_copies.data.empty?
       ZenodoCopyJob.perform_later(id)
     end
 

--- a/stash/stash_engine/db/migrate/20210611215505_add_notes_to_stash_engine_zenodo_copies.rb
+++ b/stash/stash_engine/db/migrate/20210611215505_add_notes_to_stash_engine_zenodo_copies.rb
@@ -1,0 +1,6 @@
+class AddNotesToStashEngineZenodoCopies < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stash_engine_zenodo_copies, :note, :text
+    add_index :stash_engine_zenodo_copies, :note, length: 30
+  end
+end


### PR DESCRIPTION
- Added note column which can be set on the ZenodoCopies table (make it easier to track what we're doing leave notes or which process submitted something)
- The main rake task
  - Sets a max queue size
  - Queries for published datasets that don't have data copy records in the zenodo_copy table
    - random order
    - limited to return only the max results we will insert into the queu
  - Loop and insert items until the Delayed Job queue is at the target number for refilling
  - Wait 30 seconds and fill to desired level again and repeat until CTRL-C is pressed
  