### PR TITLE
Frictionless validation status

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,6 +114,8 @@ group :test do
   gem 'selenium-webdriver', '~> 3.142.0'
   # Making tests easy on the fingers and eyes (https://github.com/thoughtbot/shoulda)
   gem 'shoulda'
+  # Simple one-liner tests for common Rails functionality (https://github.com/thoughtbot/shoulda-matchers)
+  gem 'shoulda-matchers', '~> 4.0'
   # Code coverage for Ruby 1.9+ with a powerful configuration library and automatic merging of coverage across test suites (http://github.com/colszowka/simplecov)
   gem 'simplecov', require: false
   # used by some of the engines and for some reason causes errors without it in the main Gemfile, also.

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'capistrano', '~> 3.11'
 gem 'capistrano-rails', '~> 1.4'
 gem 'rubocop', '~> 0.90.0'
 # Use Puma as the app server
-gem "puma", group: :puma, require: false
+gem 'puma', group: :puma, require: false
 # Our homegrown artisinal SSM gem
 gem 'uc3-ssm', git: 'https://github.com/CDLUC3/uc3-ssm', branch: '0.3.0rc0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -971,6 +971,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver (~> 3.142.0)
   shoulda
+  shoulda-matchers (~> 4.0)
   simplecov
   simplecov-console
   spring

--- a/app/javascript/components/FileList/File/File.js
+++ b/app/javascript/components/FileList/File/File.js
@@ -1,25 +1,18 @@
 import React from 'react';
 
+import { TabularCheckStatus } from "../../../containers/UploadFiles";
+
 import ellipsize from '../../../lib/string_patch';
 
 import classes from './File.module.css';
-
-// TODO: remove constant duplicate from UploadFiles component
-const TabularCheckStatus = {
-    'checking': 'Checking...',
-    'view_issues': 'View issues',
-    'passed': 'Passed',
-    'na': 'N/A',
-    'error_validating': 'Validation error'
-}
 
 const statusCss = (status) => {
     switch (status) {
         case TabularCheckStatus['checking']:
             return classes.Blinking
-        case TabularCheckStatus['passed']:
+        case TabularCheckStatus['noissues']:
             return classes.Passed
-        case TabularCheckStatus['error_validating']:
+        case TabularCheckStatus['error']:
             return classes.ValidationError
         default:
             return null
@@ -32,7 +25,7 @@ const file = (props) => {
             <th scope='row'>{props.file.sanitized_name}</th>
             <td id={`status_${props.index}`} className='c-uploadtable__status'>{props.file.status}</td>
             <td><span className={statusCss(props.file.tabularCheckStatus)}>
-                {props.file.tabularCheckStatus === TabularCheckStatus['view_issues']
+                {props.file.tabularCheckStatus === TabularCheckStatus['issues']
                     ? <a href="#!" onClick={props.clickValidationReport}>{props.file.tabularCheckStatus}</a>
                     : props.file.tabularCheckStatus}
             </span></td>

--- a/app/javascript/containers/UploadFiles.js
+++ b/app/javascript/containers/UploadFiles.js
@@ -33,12 +33,12 @@ const Messages = {
     'fileAlreadySelected': 'A file of the same type is already in the table.',
     'filesAlreadySelected': 'Some files of the same type are already in the table.'
 }
-const TabularCheckStatus = {
+export const TabularCheckStatus = {
     'checking': 'Checking...',
-    'view_issues': 'View issues',
-    'passed': 'Passed',
+    'issues': 'View issues',
+    'noissues': 'Passed',
     'na': 'N/A',
-    'error_validating': 'Validation error'
+    'error': 'Validation error'
 }
 
 class UploadFiles extends React.Component {
@@ -109,12 +109,8 @@ class UploadFiles extends React.Component {
     setTabularCheckStatus = (file) => {
         if (!this.isCsv(file)) {
             return TabularCheckStatus['na'];
-        } else {
-            return file.frictionless_report ?
-                file.frictionless_report.report ?
-                    TabularCheckStatus['view_issues'] :
-                    TabularCheckStatus['error_validating'] :
-                TabularCheckStatus['passed']
+        } else if (file.frictionless_report) {
+            return TabularCheckStatus[file.frictionless_report.status]
         }
     }
 

--- a/spec/features/stash_engine/frictionless_validation_spec.rb
+++ b/spec/features/stash_engine/frictionless_validation_spec.rb
@@ -58,9 +58,11 @@ RSpec.feature 'UploadFiles', type: :feature, js: true do
       end
     end
 
-    it 'shows "View issues" if file is plain-text and tabular and there is a report for it' do
+    it 'shows "View issues" if file is plain-text and status is "issues"' do
       @file.update(upload_content_type: 'text/csv')
-      @report = StashEngine::FrictionlessReport.create(report: '[{errors: errors}]', generic_file: @file)
+      @report = StashEngine::FrictionlessReport.create!(
+        report: '[{errors: errors}]', generic_file: @file, status: 'issues'
+      )
       sleep 1
       click_link 'Upload Files'
 
@@ -69,24 +71,25 @@ RSpec.feature 'UploadFiles', type: :feature, js: true do
       end
     end
 
-    it 'shows "Validation error" if file is plain-text and tabular, there is a report for it but it is empty' do
+    it 'shows "Passed" if file is plain-text and tabular, and the status is "noissues"' do
       @file.update(upload_content_type: 'text/csv')
-      @report = StashEngine::FrictionlessReport.create(report: nil, generic_file: @file)
-      sleep 1
-      click_link 'Upload Files'
-
-      within(:xpath, '//table/tbody/tr/td[2]') do
-        expect(text).to eq('Validation error')
-      end
-    end
-
-    it 'shows "Passed" if file is plain-text and tabular and there is not a report' do
-      @file.update(upload_content_type: 'text/csv')
+      @report = StashEngine::FrictionlessReport.create!(generic_file: @file, status: 'noissues')
       sleep 1
       click_link 'Upload Files'
 
       within(:xpath, '//table/tbody/tr/td[2]') do
         expect(text).to eq('Passed')
+      end
+    end
+
+    it 'shows "Validation error" if file is plain-text and tabular, and the status is "error"' do
+      @file.update(upload_content_type: 'text/csv')
+      @report = StashEngine::FrictionlessReport.create!(generic_file: @file, status: 'error')
+      sleep 1
+      click_link 'Upload Files'
+
+      within(:xpath, '//table/tbody/tr/td[2]') do
+        expect(text).to eq('Validation error')
       end
     end
   end

--- a/spec/models/stash_engine/frictionless_report_spec.rb
+++ b/spec/models/stash_engine/frictionless_report_spec.rb
@@ -2,14 +2,28 @@ require 'rails_helper'
 
 module StashEngine
   RSpec.describe FrictionlessReport, type: :model do
+    before(:each) do
+      @resource = create(:resource)
+      @file = create(:generic_file, resource_id: @resource.id)
+    end
 
-    describe 'default values' do
-      it 'creates model instance' do
-        @resource = create(:resource)
-        @file = create(:generic_file, resource_id: @resource.id)
-        @frictionless_report = create(:frictionless_report, generic_file_id: @file.id)
+    describe 'associations' do
+      it { should belong_to(:generic_file) }
+    end
 
-        expect(@file.frictionless_report).to eq(@frictionless_report)
+    describe 'validations' do
+      it { should validate_presence_of(:generic_file) }
+      it 'is not valid without a status' do
+        fr = FrictionlessReport.new(generic_file: @file, status: nil)
+        expect(fr).to_not be_valid
+      end
+      it {
+        should define_enum_for(:status).with_values(
+          { valid_: 'valid', invalid_: 'invalid', checking: 'checking', error: 'error' }
+        ).backed_by_column_of_type(:string)
+      }
+      it 'is valid with valid attributes' do
+        expect(FrictionlessReport.new(generic_file: @file, status: 'valid')).to be_valid
       end
     end
   end

--- a/spec/models/stash_engine/frictionless_report_spec.rb
+++ b/spec/models/stash_engine/frictionless_report_spec.rb
@@ -19,11 +19,11 @@ module StashEngine
       end
       it {
         should define_enum_for(:status).with_values(
-          { valid_: 'valid', invalid_: 'invalid', checking: 'checking', error: 'error' }
+          %w[issues noissues checking error].map { |i| [i.to_sym, i] }.to_h
         ).backed_by_column_of_type(:string)
       }
       it 'is valid with valid attributes' do
-        expect(FrictionlessReport.new(generic_file: @file, status: 'valid')).to be_valid
+        expect(FrictionlessReport.new(generic_file: @file, status: 'checking')).to be_valid
       end
     end
   end

--- a/spec/responses/stash_engine/resources_controller_spec.rb
+++ b/spec/responses/stash_engine/resources_controller_spec.rb
@@ -6,10 +6,10 @@ module StashEngine
       before(:each) do
         create_basic_dataset!
         allow_any_instance_of(ResourcesController).to receive(:session).and_return({ user_id: @user.id }.to_ostruct)
+        @resource.current_resource_state.update(resource_state: 'in_progress')
       end
 
-      it 'asserts react root component' do
-        @resource.current_resource_state.update(resource_state: 'in_progress')
+      it 'loads react root component' do
         get "/stash/resources/#{@resource.id}/upload"
 
         assert_react_component 'UploadFiles' do |props|
@@ -17,6 +17,20 @@ module StashEngine
           assert_equal @resource.data_files.first.attributes, props[:file_uploads].first.stringify_keys
           assert_equal APP_CONFIG[:s3].to_h.except(:secret), props[:app_config_s3][:table]
           assert_equal @resource.s3_dir_name(type: 'base'), props[:s3_dir_name]
+        end
+      end
+
+      it 'loads files with respective frictionless reports if they exist' do
+        file = @resource.generic_files.first
+        StashEngine::FrictionlessReport.create(
+          report: '[{errors: errors}]', generic_file: file, status: 'issues'
+        )
+
+        get "/stash/resources/#{@resource.id}/upload"
+
+        assert_react_component 'UploadFiles' do |props|
+          assert_equal file.frictionless_report.status,
+                       props[:file_uploads].first[:frictionless_report][:status]
         end
       end
     end

--- a/stash/stash_engine/app/controllers/stash_engine/generic_files_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/generic_files_controller.rb
@@ -57,6 +57,7 @@ module StashEngine
         return
       end
 
+      files.each(&:set_checking_status)
       files.each(&:validate_frictionless)
       render json: files.as_json(
         methods: :type, include: { frictionless_report: { only: %w[report status] } }

--- a/stash/stash_engine/app/controllers/stash_engine/generic_files_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/generic_files_controller.rb
@@ -59,7 +59,7 @@ module StashEngine
 
       files.each(&:validate_frictionless)
       render json: files.as_json(
-        methods: :type, include: { frictionless_report: { only: [:report] } }
+        methods: :type, include: { frictionless_report: { only: %w[report status] } }
       )
     end
 

--- a/stash/stash_engine/app/models/stash_engine/frictionless_report.rb
+++ b/stash/stash_engine/app/models/stash_engine/frictionless_report.rb
@@ -5,6 +5,6 @@ module StashEngine
     validates_presence_of :generic_file
     validates_presence_of :status
 
-    enum status: { valid_: 'valid', invalid_: 'invalid', checking: 'checking', error: 'error' }
+    enum status: %w[issues noissues checking error].map { |i| [i.to_sym, i] }.to_h
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/frictionless_report.rb
+++ b/stash/stash_engine/app/models/stash_engine/frictionless_report.rb
@@ -1,5 +1,10 @@
 module StashEngine
   class FrictionlessReport < ApplicationRecord
-    belongs_to :generic_file
+    belongs_to :generic_file, class_name: 'StashEngine::GenericFile'
+
+    validates_presence_of :generic_file
+    validates_presence_of :status
+
+    enum status: { valid_: 'valid', invalid_: 'invalid', checking: 'checking', error: 'error' }
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/generic_file.rb
+++ b/stash/stash_engine/app/models/stash_engine/generic_file.rb
@@ -140,6 +140,7 @@ module StashEngine
       if download_result.instance_of?(HTTP::Error) || download_result.instance_of?(Errno::ENOENT)
         FrictionlessReport.create(report: nil, generic_file_id: id)
       else
+        # TODO(#1296): rescue from errors here!
         result = call_frictionless(download_result)
         # Add 'report' top level key that is required for calling React frictionless-components
         result_hash = { report: JSON.parse(result) }

--- a/stash/stash_engine/app/models/stash_engine/generic_file.rb
+++ b/stash/stash_engine/app/models/stash_engine/generic_file.rb
@@ -135,12 +135,15 @@ module StashEngine
       sanitized.gsub(/,|;|'|"|\u007F/, '').strip.gsub(/\s+/, '_')
     end
 
+    def set_checking_status
+      @report = FrictionlessReport.create(generic_file_id: id, status: 'checking')
+    end
+
     def validate_frictionless
       download_result = download_file
       if download_result.instance_of?(HTTP::Error) || download_result.instance_of?(Errno::ENOENT)
-        FrictionlessReport.create(generic_file_id: id, status: 'error')
+        @report.update(generic_file_id: id, status: 'error')
       else
-        report = FrictionlessReport.create(generic_file_id: id, status: 'checking')
         # TODO(#1296): rescue from errors here!
         result = call_frictionless(download_result)
         # Add 'report' top level key that is required for calling
@@ -151,7 +154,7 @@ module StashEngine
                  else
                    'issues'
                  end
-        report.update(report: result_hash.to_json, status: status)
+        @report.update(report: result_hash.to_json, status: status)
       end
     end
 

--- a/stash/stash_engine/app/views/stash_engine/resources/upload.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/resources/upload.html.erb
@@ -15,7 +15,7 @@
 <%= react_component('UploadFiles', {
   resource_id: @resource.id,
   file_uploads: @resource.generic_files.validated_table.as_json(
-    methods: :type, include: { frictionless_report: { only: [:report] } }
+    methods: :type, include: { frictionless_report: { only: [:report, :status] } }
   ),
   app_config_s3: APP_CONFIG[:s3].to_h.except(:secret).to_ostruct,
   s3_dir_name: @resource.s3_dir_name(type: 'base')

--- a/stash/stash_engine/db/migrate/20210611134305_add_status_to_stash_engine_frictionless_reports.rb
+++ b/stash/stash_engine/db/migrate/20210611134305_add_status_to_stash_engine_frictionless_reports.rb
@@ -1,6 +1,6 @@
 class AddStatusToStashEngineFrictionlessReports < ActiveRecord::Migration[5.2]
   def change
     add_column :stash_engine_frictionless_reports, :status,
-               "ENUM('valid','invalid', 'checking', 'errors')", limit: 15
+               "ENUM('issues','noissues', 'checking', 'error')"
   end
 end

--- a/stash/stash_engine/db/migrate/20210611134305_add_status_to_stash_engine_frictionless_reports.rb
+++ b/stash/stash_engine/db/migrate/20210611134305_add_status_to_stash_engine_frictionless_reports.rb
@@ -1,0 +1,6 @@
+class AddStatusToStashEngineFrictionlessReports < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stash_engine_frictionless_reports, :status,
+               "ENUM('valid','invalid', 'checking', 'errors')", limit: 15
+  end
+end


### PR DESCRIPTION
Now the frictionless report is created even the validation process returned no issues. Explaining: the frictionless report validation returns the results of validation for the tabular file being analyzed - this analyses (in the json file) has features of the file, like the types of columns and other information that can be useful on the future.

The FrictionlessReport model includes another column now (status). This status can be:  'checking', 'issues', 'noissues', 'error'. Before this commit, the status were catched by the UI implicitly (report == nil: interpreted as the validation passed; report with json content: validation found issues; tabular file without report: some error occurred in validation).
So that's the worflow now:
- Application receives request to validate the tabular files.
- It creates an entry in the database for the FrictionlessReport model with report == nil, status: 'checking' for all the files that were submitted.
- It starts the validation. If the validation succeed, if the file has issues, saves the report and change the status to 'issues', else if the file has no issues, saves the report and change the status to 'noissues'. If the validation failed, change the status to 'error'.

**UI**:
- Behavior before: if the user reloads the page after the request is sent to the application, the column "Tabular Data Check" will lose the status "Checking...", and will be replaced by the status "Passed". After the application finishes validation and return the response. If the validation found issues the same column will change to  "View issues", confusing the user.
- Behavior expected now: if the user reloads the page after the request is sent, the column "Tabular Data Check" correctly display the status "Checking...".
- What is missing: send ajax requests to get the new status after the validation process finishes with or without success. Now the user has to refresh the page to catch the new status after the process finishes.