### PR TITLE
Improve robustness of email parsing

### DIFF
--- a/stash/stash_engine/app/services/stash_engine/email_parser.rb
+++ b/stash/stash_engine/app/services/stash_engine/email_parser.rb
@@ -211,7 +211,7 @@ module StashEngine
       return if regex.blank?
 
       msid = @hash['ms reference number']
-      return if msid.match(regex).blank?
+      return if msid.blank? || msid.match(regex).blank?
 
       result = msid.match(regex)[1]
       @hash['ms reference number'] = result if result.present?

--- a/stash/stash_engine/lib/stash/google/journal_gmail.rb
+++ b/stash/stash_engine/lib/stash/google/journal_gmail.rb
@@ -88,12 +88,16 @@ module Stash
       end
 
       def self.remove_processing_label(message:)
+        return unless processing_label
+
         mod_request = ::Google::Apis::GmailV1::ModifyMessageRequest.new
         mod_request.remove_label_ids = [processing_label.id]
         gmail.modify_message('me', message.id, mod_request)
       end
 
       def self.add_error_label(message:)
+        return unless error_label
+
         mod_request = ::Google::Apis::GmailV1::ModifyMessageRequest.new
         mod_request.add_label_ids = [error_label.id]
         gmail.modify_message('me', message.id, mod_request)
@@ -191,7 +195,7 @@ module Stash
         end
 
         def error_label
-          @error_lable ||= label_by_name(name: APP_CONFIG[:google][:journal_error_label])
+          @error_label ||= label_by_name(name: APP_CONFIG[:google][:journal_error_label])
         end
 
       end


### PR DESCRIPTION
Adds some extra protection against malformed metadata emails from journals. It was possible to create an email message that had enough metadata to start parsing, but if it did not have a manuscript number, the parsing would error and prevent subsequent messages from being processed.

