### PR TITLE
Save tempfiles in binary mode

### DIFF
--- a/stash/stash_engine/app/models/stash_engine/generic_file.rb
+++ b/stash/stash_engine/app/models/stash_engine/generic_file.rb
@@ -185,7 +185,7 @@ module StashEngine
     def write_tempfile(result)
       # It's required file to have csv extension for frictionless to return
       # correct validation report
-      tempfile = Tempfile.new([upload_file_name, '.csv'], Rails.root.join('tmp'))
+      tempfile = Tempfile.new([upload_file_name, '.csv'], Rails.root.join('tmp'), binmode: true)
       tempfile.write(result.body.to_s)
       tempfile.rewind
       tempfile


### PR DESCRIPTION
Avoids any weirdnesses with encoding which we really don't want to deal with and should keep file as is without changes.

https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1323