### PR TITLE
Small change to not cause error if descriptions are missing

### DIFF
--- a/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/metadata_generator.rb
@@ -61,7 +61,7 @@ module Stash
       end
 
       def description
-        @resource.descriptions.where(description_type: 'abstract').first.description || 'No abstract available'
+        @resource.descriptions.where(description_type: 'abstract')&.first&.description || 'No abstract available'
       end
 
       def access_right


### PR DESCRIPTION
Uses the safe navigation ampersand to prevent previous error.