### PR TITLE
Frictionless reports versioning

### DIFF
--- a/spec/factories/stash_engine/frictionless_reports.rb
+++ b/spec/factories/stash_engine/frictionless_reports.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     generic_file
 
     report { Faker::Json.shallow_json }
+    status { %w[issues noissues checking error][rand(4)] }
   end
 end

--- a/spec/models/stash_engine/generic_file_spec.rb
+++ b/spec/models/stash_engine/generic_file_spec.rb
@@ -134,6 +134,20 @@ module StashEngine
         end
 
       end
+
+      describe 'amoeba duplication' do
+        before(:each) do
+          @report = create(:frictionless_report, generic_file: @upload)
+          @resource2 = @resource.amoeba_dup
+          @resource2.save
+          @upload2 = GenericFile.last
+        end
+
+        it 'copies frictionless report' do
+          expect(@upload2.frictionless_report.id).not_to eq(@upload.frictionless_report.id)
+          expect(@upload2.frictionless_report.report).to eq(@upload.frictionless_report.report)
+        end
+      end
     end
   end
 end

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -766,7 +766,7 @@ module StashEngine
             expect(res1.current_state).to eq('error')
             expect(resource.current_state).to eq('submitted')
           end
-          it 'does not call prepare_for_curation when :in_progess' do
+          it 'does not call prepare_for_curation when :in_progress' do
             resource.preserve_curation_status = true
             expect(resource).not_to receive(:prepare_for_curation)
             resource.current_state = 'in_progress'

--- a/stash/stash_engine/app/models/stash_engine/generic_file.rb
+++ b/stash/stash_engine/app/models/stash_engine/generic_file.rb
@@ -8,6 +8,10 @@ module StashEngine
   class GenericFile < ApplicationRecord
     belongs_to :resource, class_name: 'StashEngine::Resource'
     has_one :frictionless_report, dependent: :destroy
+    amoeba do
+      enable
+      propagate
+    end
 
     scope :deleted_from_version, -> { where(file_state: :deleted) }
     scope :newly_created, -> { where("file_state = 'created' OR file_state IS NULL") }


### PR DESCRIPTION
Copies the frictionless reports for the files when making a new Resource version.

Note the propagate method from amoeba gem in GenericFile model. It's the way amoeba works on STI fields.