### PR TITLE
Default sort to title

### DIFF
--- a/stash/stash_engine/app/controllers/stash_engine/journals_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/journals_controller.rb
@@ -8,9 +8,9 @@ module StashEngine
 
     def index
       params.permit(:q)
-
+      params[:sort] = 'title' if params[:sort].blank?
       @all_journals = Journal.all
-      @journals = Journal.joins(:sponsor).where.not(payment_plan_type: [nil, '']).order(helpers.sortable_table_order, id: :asc)
+      @journals = Journal.joins(:sponsor).where.not(payment_plan_type: [nil, '']).order(helpers.sortable_table_order, title: :asc)
 
       respond_to do |format|
         format.html


### PR DESCRIPTION
The SortableTableHelper defaults sort order to `created_at`, which is useful for most models, but not for journals. This changes the journal screen's default sort and secondary sort to use `title`.