### PR TITLE
EM updates for the review url

### DIFF
--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -79,7 +79,8 @@ module StashApi
       art_params = params['article']
       manu = art_params['manuscript_number'] unless art_params.blank?
       disposition = params['article']['final_disposition']
-      sharing_link = @stash_identifier&.shares&.first&.sharing_link
+      sharing_link = @stash_identifier&.shares&.first&.sharing_link ||
+                     "/api/v2/datasets/#{CGI.escape(@stash_identifier.to_s)}"
 
       # Reject general metadata updates
       unless manu.present? ||


### PR DESCRIPTION
Two updates for Editorial Manager:
- re-order processing for requests that come in after a user has edited the dataset, and only return an error when no valid changes are requested
- for the field `deposit_url`, use the sharing link if one is available