### PR TITLE
Frictionless file size limit

### DIFF
--- a/app/javascript/containers/UploadFiles.js
+++ b/app/javascript/containers/UploadFiles.js
@@ -115,7 +115,7 @@ class UploadFiles extends React.Component {
     }
 
     setTabularCheckStatus = (file) => {
-        if (!this.isTabular(file)) {
+        if (!this.isValidTabular(file)) {
             return TabularCheckStatus['na'];
         } else if (file.frictionless_report) {
             return TabularCheckStatus[file.frictionless_report.status]
@@ -169,6 +169,7 @@ class UploadFiles extends React.Component {
             file.url = null;
             file.uploadType = uploadType;
             file.manifest = false;
+            file.upload_file_size = file.size;
             file.sizeKb = formatSizeUnits(file.size);
         });
         this.updateFileList(newFiles);
@@ -220,7 +221,7 @@ class UploadFiles extends React.Component {
                             }).then(response => {
                                 console.log(response);
                                 this.updateFileData(response.data.new_file, index);
-                                this.isTabular(this.state.chosenFiles[index]) ?
+                                this.isValidTabular(this.state.chosenFiles[index]) ?
                                     this.validateFrictionless([this.state.chosenFiles[index]]) :
                                     null;
                             }).catch(error => console.log(error));
@@ -273,7 +274,7 @@ class UploadFiles extends React.Component {
         }
         const newManifestFiles = this.transformData(successfulUrls);
         this.updateFileList(newManifestFiles);
-        const tabularFiles = newManifestFiles.filter(file => this.isTabular(file));
+        const tabularFiles = newManifestFiles.filter(file => this.isValidTabular(file));
         this.validateFrictionless(tabularFiles);
     }
 
@@ -337,13 +338,14 @@ class UploadFiles extends React.Component {
 
     labelNonTabular = (files) => {
         files.map(file => {
-            file.tabularCheckStatus = this.isTabular(file) ? null : TabularCheckStatus['na']
+            file.tabularCheckStatus = this.isValidTabular(file) ? null : TabularCheckStatus['na']
         });
     }
 
-    isTabular = (file) => {
-        return ValidTabular['extensions'].includes(file.sanitized_name.split('.').pop())
-            || ValidTabular['mime_types'].includes(file.upload_content_type)
+    isValidTabular = (file) => {
+        return (ValidTabular['extensions'].includes(file.sanitized_name.split('.').pop())
+            || ValidTabular['mime_types'].includes(file.upload_content_type))
+            && (file.upload_file_size <= this.props.frictionless.size_limit);
     }
 
     removeFileHandler = (index) => {

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -168,6 +168,8 @@ defaults: &DEFAULTS
     merritt_size: 300_000_000_000
     zenodo_size: 50_000_000_000
     files: 1000
+  frictionless:
+    size_limit: 6291456
 
 development: &DEVELOPMENT
   <<: *DEFAULTS

--- a/dryad-config-example/app_config.yml
+++ b/dryad-config-example/app_config.yml
@@ -152,6 +152,8 @@ defaults: &DEFAULTS
     merritt_size: 3.0e+10
     zenodo_size: 5.0e+9
     files: 100
+  frictionless:
+    size_limit: 6291456
 
 development: &DEVELOPMENT
   <<: *DEFAULTS

--- a/spec/features/stash_engine/frictionless_validation_spec.rb
+++ b/spec/features/stash_engine/frictionless_validation_spec.rb
@@ -60,12 +60,23 @@ RSpec.feature 'UploadFiles', type: :feature, js: true do
       @file = create(:generic_file,
                      resource_id: StashEngine::Resource.last.id,
                      upload_content_type: @tabular_mime_type,
+                     upload_file_size: APP_CONFIG[:frictionless][:size_limit],
                      status_code: 200,
                      file_state: 'created')
     end
 
-    it 'shows N/A for non-plain-text tabular data files' do
+    it 'shows N/A for non-tabular files' do
       @file.update(upload_file_name: 'non_tabular', upload_content_type: 'application/pdf')
+      sleep 1
+      click_link 'Upload Files'
+
+      within('table') do
+        expect(page).to have_content('N/A')
+      end
+    end
+
+    it 'shows N/A for tabular files greater than the size limit' do
+      @file.update(upload_file_size: APP_CONFIG[:frictionless][:size_limit] + 1)
       sleep 1
       click_link 'Upload Files'
 

--- a/spec/responses/stash_engine/resources_controller_spec.rb
+++ b/spec/responses/stash_engine/resources_controller_spec.rb
@@ -17,6 +17,7 @@ module StashEngine
           assert_equal @resource.data_files.first.attributes, props[:file_uploads].first.stringify_keys
           assert_equal APP_CONFIG[:s3].to_h.except(:secret), props[:app_config_s3][:table]
           assert_equal @resource.s3_dir_name(type: 'base'), props[:s3_dir_name]
+          assert_equal APP_CONFIG[:frictionless].to_h, props[:frictionless]
         end
       end
 

--- a/stash/stash_engine/app/views/stash_engine/resources/upload.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/resources/upload.html.erb
@@ -18,7 +18,8 @@
     methods: :type, include: { frictionless_report: { only: [:report, :status] } }
   ),
   app_config_s3: APP_CONFIG[:s3].to_h.except(:secret).to_ostruct,
-  s3_dir_name: @resource.s3_dir_name(type: 'base')
+  s3_dir_name: @resource.s3_dir_name(type: 'base'),
+  frictionless: APP_CONFIG[:frictionless].to_h
 }) %>
 
 <div class="o-dataset-nav">


### PR DESCRIPTION
I opened a new entry in `app_config` for setting up the max file size limit that triggers the frictionless validation.

I put 6MB as the max size, but it's just a matter of changing the value -- with this limit I'm getting something like 7 to 10 seconds for each file chosen from file system in my local machine (I guess I observed more or less these same times for a couple of manual tests in dev server). For the files that come from URL's, this time has to be added for each file that go to the table.