### PR TITLE
Any frictionless error when calling external service saved as status "error"

### DIFF
--- a/spec/responses/stash_engine/generic_files_controller_spec.rb
+++ b/spec/responses/stash_engine/generic_files_controller_spec.rb
@@ -473,6 +473,9 @@ module StashEngine
         end
 
         it 'creates report with status "error", because the file does not exist when calling validation' do
+          # When calling frictionless there're various error that can happen, besides
+          # the errors for the validation per se. This test is just an example showing
+          # the "errors" key with possible error. And the 'scheme-error'.
           allow_any_instance_of(GenericFile).to receive(:call_frictionless).and_return(
             '{
   "version": "4.10.0",
@@ -483,7 +486,7 @@ module StashEngine
       "name": "Scheme Error",
       "tags": [],
       "note": "[Errno 2] No such file or directory: \'/tmp/invalid.csv\'",
-      "message": "The data source could not be successfully loaded: [Errno 2] No such file or directory: \'/tmp/invlaid.csv\'",
+      "message": "The data source could not be successfully loaded: [Errno 2] No such file or directory: \'/tmp/invalid.csv\'",
       "description": "Data reading error because of incorrect scheme."
     }
   ],
@@ -501,7 +504,7 @@ module StashEngine
           assert_requested :get, /#{@s3_domain}.*/, body: @body, times: 1
 
           report = @file.frictionless_report
-          expect(report.report).to be(nil)
+          expect(report.report).to include('scheme-error')
           expect(report.status).to eq('error')
         end
       end

--- a/stash/stash_engine/app/models/stash_engine/generic_file.rb
+++ b/stash/stash_engine/app/models/stash_engine/generic_file.rb
@@ -153,21 +153,21 @@ module StashEngine
     def validate_frictionless
       result = download_file
       if result.instance_of?(HTTP::Error)
-        @report.update(generic_file_id: id, status: 'error')
+        @report.update(status: 'error')
         return
       end
       result = write_tempfile(result)
       if result.instance_of?(Errno::ENOENT)
-        @report.update(generic_file_id: id, status: 'error')
+        @report.update(status: 'error')
         return
       end
-      # TODO(#1296): rescue from errors here!
       result = call_frictionless(result)
       # Add 'report' top level key that is required for calling
       # React frictionless-components
       result_hash = { report: JSON.parse(result) }
       if validation_error(result_hash[:report])
-        @report.update(status: 'error')
+        @report.update(report: result_hash.to_json, status: 'error')
+        puts "Some error occurred calling frictionless. See database for report_id #{@report.id}"
         return
       end
       status = if validation_issues_not_found(result_hash)
@@ -227,7 +227,11 @@ module StashEngine
     end
 
     def validation_error(result)
-      !result['errors'].empty? && result['errors'].first['code'] == 'scheme-error'
+      # See https://framework.frictionlessdata.io/docs/references/errors-reference/
+      # for an extensive list of all possible error. Note that there are the errors
+      # specific to the validation of a tabular file and the errors for another reason.
+      # This method test for errors others than the validation errors.
+      !result['errors'].empty?
     end
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/generic_file.rb
+++ b/stash/stash_engine/app/models/stash_engine/generic_file.rb
@@ -167,7 +167,7 @@ module StashEngine
       result_hash = { report: JSON.parse(result) }
       if validation_error(result_hash[:report])
         @report.update(report: result_hash.to_json, status: 'error')
-        puts "Some error occurred calling frictionless. See database for report_id #{@report.id}"
+        logger.error "Some error occurred calling frictionless. See database for report_id #{@report.id}"
         return
       end
       status = if validation_issues_not_found(result_hash)
@@ -186,7 +186,7 @@ module StashEngine
       begin
         http.get(dl_url)
       rescue HTTP::Error => e
-        puts "Error downloading file: #{e.message}"
+        logger.error "Error downloading file: #{e.message}"
         e
       end
     end
@@ -199,7 +199,7 @@ module StashEngine
       tempfile.rewind
       tempfile
     rescue Errno::ENOENT => e
-      puts "Error writing to file: #{e.message}"
+      logger.error "Error writing to file: #{e.message}"
       e
     end
 


### PR DESCRIPTION
Save status error for any kind of error not related with the normal tabular validation. This is supposed to occur very rarely, but if occurs, display "error" for the user. Furthermore, puts in `stdout` a message telling about the error, and saves the report with the error. So it can be inspected.