### PR TITLE
Frictionless integration doc

### DIFF
--- a/app/javascript/components/ValidateFiles/ValidateFiles.js
+++ b/app/javascript/components/ValidateFiles/ValidateFiles.js
@@ -5,7 +5,7 @@ const validate_files = (props) => {
     if (props.checkConfirmed) {
         checkConfirm =
             <div>
-                <input id={props.id} type="checkbox" name="confirm_to_upload" onChange={props.changed} />
+                <input id={props.id} type="checkbox" name="confirm_to_upload" onChange={props.changed} checked={!props.disabled} />
                 <strong style={{'color': 'red'}}> *</strong>
                 <label htmlFor={props.id}> I confirm that no
                     Personal Health Information or Sensitive Data are being uploaded with this submission.</label>

--- a/app/javascript/containers/UploadFiles.js
+++ b/app/javascript/containers/UploadFiles.js
@@ -160,7 +160,7 @@ class UploadFiles extends React.Component {
     }
 
     addFilesHandler = (event, uploadType) => {
-        this.setState({warningMessage: null});
+        this.setState({warningMessage: null, submitButtonFilesDisabled: true});
         const newFiles = this.discardFilesAlreadyChosen([...event.target.files], uploadType);
         // TODO: make a function?; future: unify adding file attributes
         newFiles.map(file => {

--- a/documentation/frictionless_integration/INSTALL.md
+++ b/documentation/frictionless_integration/INSTALL.md
@@ -19,12 +19,16 @@ $ pip install frictionless
 $ pip install frictionless[excel]
 $ pip install frictionless[json]
 ```
+2. Upgrading
+```bash
+$ pip install frictionless --upgrade
+```
 
 Obs.: it's common to have Python 2 and Python 3 installed in the same system.
 In this case, it's possible that you have to use `pip3` instead of `pip` in the
 command above.
 
-### Project level installation
+### Project level installation and upgrading
 You can create a virtual environment to wrap a specific python environment for the project.
 (Note: on our servers we are using pyenv and some annoying hacks to get it working
 within the systemd setup.)
@@ -43,15 +47,23 @@ $ virtualenv [-p <python3_path>] <env_dir>
 $ <env_dir>/bin/activate
 ```
 
-4. Install frictionless framework
+4. Install frictionless framework plugins for all the tabular packages that you want to validate.
+- See a list of all the types on https://framework.frictionlessdata.io > Tutorials > Formats Tutorials
 ```bash
 $ pip install frictionless
+$ pip install frictionless[excel]
+$ pip install frictionless[json]
+```
+
+5. Upgrade frictionless package
+```bash
+$ pip install frictionless --upgrade
 ```
 
 ### Run frictionless from inside ruby/rails code
 - Place the call for frictionless between backticks, e.g.:
 ```ruby
-result = `frictionless validate <tabular_file_path>`
+result = `frictionless validate --path <tabular_file_path>`
 ```
 However note, that additional code has been added (for production) to
 1. Be sure pyenv has loaded correctly

--- a/spec/responses/stash_engine/generic_files_controller_spec.rb
+++ b/spec/responses/stash_engine/generic_files_controller_spec.rb
@@ -473,6 +473,9 @@ module StashEngine
         end
 
         it 'creates report with status "error", because the file does not exist when calling validation' do
+          # When calling frictionless there're various error that can happen, besides
+          # the errors for the validation per se. This test is just an example showing
+          # the "errors" key with possible error. And the 'scheme-error'.
           allow_any_instance_of(GenericFile).to receive(:call_frictionless).and_return(
             '{
   "version": "4.10.0",
@@ -483,7 +486,7 @@ module StashEngine
       "name": "Scheme Error",
       "tags": [],
       "note": "[Errno 2] No such file or directory: \'/tmp/invalid.csv\'",
-      "message": "The data source could not be successfully loaded: [Errno 2] No such file or directory: \'/tmp/invlaid.csv\'",
+      "message": "The data source could not be successfully loaded: [Errno 2] No such file or directory: \'/tmp/invalid.csv\'",
       "description": "Data reading error because of incorrect scheme."
     }
   ],
@@ -501,7 +504,7 @@ module StashEngine
           assert_requested :get, /#{@s3_domain}.*/, body: @body, times: 1
 
           report = @file.frictionless_report
-          expect(report.report).to be(nil)
+          expect(report.report).to include('scheme-error')
           expect(report.status).to eq('error')
         end
       end

--- a/stash/stash_engine/app/models/stash_engine/generic_file.rb
+++ b/stash/stash_engine/app/models/stash_engine/generic_file.rb
@@ -153,21 +153,21 @@ module StashEngine
     def validate_frictionless
       result = download_file
       if result.instance_of?(HTTP::Error)
-        @report.update(generic_file_id: id, status: 'error')
+        @report.update(status: 'error')
         return
       end
       result = write_tempfile(result)
       if result.instance_of?(Errno::ENOENT)
-        @report.update(generic_file_id: id, status: 'error')
+        @report.update(status: 'error')
         return
       end
-      # TODO(#1296): rescue from errors here!
       result = call_frictionless(result)
       # Add 'report' top level key that is required for calling
       # React frictionless-components
       result_hash = { report: JSON.parse(result) }
       if validation_error(result_hash[:report])
-        @report.update(status: 'error')
+        @report.update(report: result_hash.to_json, status: 'error')
+        puts "Some error occurred calling frictionless. See database for report_id #{@report.id}"
         return
       end
       status = if validation_issues_not_found(result_hash)
@@ -227,7 +227,11 @@ module StashEngine
     end
 
     def validation_error(result)
-      !result['errors'].empty? && result['errors'].first['code'] == 'scheme-error'
+      # See https://framework.frictionlessdata.io/docs/references/errors-reference/
+      # for an extensive list of all possible error. Note that there are the errors
+      # specific to the validation of a tabular file and the errors for another reason.
+      # This method test for errors others than the validation errors.
+      !result['errors'].empty?
     end
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/generic_file.rb
+++ b/stash/stash_engine/app/models/stash_engine/generic_file.rb
@@ -167,7 +167,7 @@ module StashEngine
       result_hash = { report: JSON.parse(result) }
       if validation_error(result_hash[:report])
         @report.update(report: result_hash.to_json, status: 'error')
-        puts "Some error occurred calling frictionless. See database for report_id #{@report.id}"
+        logger.error "Some error occurred calling frictionless. See database for report_id #{@report.id}"
         return
       end
       status = if validation_issues_not_found(result_hash)
@@ -186,7 +186,7 @@ module StashEngine
       begin
         http.get(dl_url)
       rescue HTTP::Error => e
-        puts "Error downloading file: #{e.message}"
+        logger.error "Error downloading file: #{e.message}"
         e
       end
     end
@@ -199,7 +199,7 @@ module StashEngine
       tempfile.rewind
       tempfile
     rescue Errno::ENOENT => e
-      puts "Error writing to file: #{e.message}"
+      logger.error "Error writing to file: #{e.message}"
       e
     end
 


### PR DESCRIPTION
Include instruction for upgrading the frictionless.

Change the instruction for running frictionless inside ruby/rails (already in the call from code).

Before:
```bash
result = `frictionless validate <tabular_file_path>`
```
After:
```bash
result = `frictionless validate --path <tabular_file_path>`
```
Note that `--path` was included as a flag for the `frictionless validate` command. This is necessary for `json` files. But it's not hurt to add that always, so the call to frictionless stay unified.