### PR TITLE
Disable navigation while frictionless is validating

### DIFF
--- a/app/javascript/components/FileList/BadList/BadList.js
+++ b/app/javascript/components/FileList/BadList/BadList.js
@@ -1,0 +1,55 @@
+import React from "react";
+
+const badList = (props) => {
+  const errorFiles = filterForStatus("error", props.chosenFiles);
+  const issueFiles = filterForStatus("issues", props.chosenFiles);
+  if(errorFiles.length + issueFiles.length < 1) return (null);
+
+  let errorMsg = '';
+  let issueMsg = '';
+
+  if(errorFiles.length > 0){
+    errorMsg = <p>Our tabular format checker couldn't read {makeAndString(errorFiles)} correctly.
+      Please check that file type is set correctly and the file appears correct.
+    </p>;
+  }
+
+  if(issueFiles.length > 0){
+    issueMsg = <p>Our tabular format checker found formatting issues in {makeAndString(issueFiles)}.
+      Please view the issues from the links below and correct
+      the issues, if appropriate.
+    </p>;
+  }
+
+  return <div className="js-alert c-alert--error" role="alert">
+      <div className="c-alert__text">
+        {errorMsg}
+        {issueMsg}
+      </div>
+      <button aria-label="close" className="js-alert__close o-button__close c-alert__close"></button>
+    </div>;
+}
+
+// checks files to see if they have validation and also status
+const filterForStatus = (status, files) => {
+  let fns = files.map(file => {
+    if (!file.hasOwnProperty("frictionless_report")) return null;
+
+    if (file.frictionless_report?.status === status) return file.upload_file_name;
+
+    return null;
+  });
+
+  // only return non-null
+  return fns.filter(n => n);
+}
+
+const makeAndString = (arr) => {
+  if (arr.length === 0) return "";
+  if (arr.length === 1) return arr[0];
+  const firsts = arr.slice(0, arr.length - 1);
+  const last = arr[arr.length - 1];
+  return firsts.join(', ') + ' and ' + last;
+}
+
+export default badList;

--- a/app/javascript/components/FileList/File/File.js
+++ b/app/javascript/components/FileList/File/File.js
@@ -37,7 +37,7 @@ const file = (props) => {
           tabularInfo = <div style={{display: 'flex', alignItems: 'center'}}>
                 <img src="../../../images/emblem-important.png" alt="Warning icon" style={{padding: 0, width: '1.5rem'}} />
                 <button className="o-button__plain-text5" onClick={props.clickValidationReport}
-                        type="button" style={{padding: '10px'}}>{jsReport?.report?.stats?.errors} issues</button>
+                        type="button" style={{padding: '10px'}}>View {jsReport?.report?.stats?.errors} issues</button>
               </div>;
           break;
         default:

--- a/app/javascript/components/FileList/File/File.js
+++ b/app/javascript/components/FileList/File/File.js
@@ -30,9 +30,14 @@ const file = (props) => {
           </div>;
           break;
         case TabularCheckStatus['issues']:
+          let jsReport = "";
+          try {
+            jsReport = JSON.parse(props.file.frictionless_report.report);
+          }catch(e){ console.log(e) }
           tabularInfo = <div style={{display: 'flex', alignItems: 'center'}}>
                 <img src="../../../images/emblem-important.png" alt="Warning icon" style={{padding: 0, width: '1.5rem'}} />
-                <button className="o-button__plain-text5" onClick={props.clickValidationReport} type="button" style={{padding: '10px'}}>{props.file.tabularCheckStatus}</button>
+                <button className="o-button__plain-text5" onClick={props.clickValidationReport}
+                        type="button" style={{padding: '10px'}}>{jsReport?.report?.stats?.errors} issues</button>
               </div>;
           break;
         default:

--- a/app/javascript/components/FileList/FileList.js
+++ b/app/javascript/components/FileList/FileList.js
@@ -1,11 +1,13 @@
 import React from "react";
 
 import File from "./File/File";
+import BadList from "./BadList/BadList"
 
 const file_list = (props) => {
     return (
         <div>
             <h2 className="o-heading__level2">Files</h2>
+            <BadList chosenFiles={props.chosenFiles} />
             <table className="c-uploadtable">
                 <thead>
                 <tr>

--- a/spec/features/stash_engine/frictionless_validation_spec.rb
+++ b/spec/features/stash_engine/frictionless_validation_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature 'UploadFiles', type: :feature, js: true do
       end
     end
 
-    it 'shows "View issues" if file is tabular and status is "issues"' do
+    it 'shows "issues" if file is tabular and status is "issues"' do
       @report = StashEngine::FrictionlessReport.create!(
         report: '[{errors: errors}]', generic_file: @file, status: 'issues'
       )
@@ -93,7 +93,7 @@ RSpec.feature 'UploadFiles', type: :feature, js: true do
       click_link 'Upload Files'
 
       within(:xpath, '//table/tbody/tr/td[2]') do
-        expect(text).to eq('View issues')
+        expect(text).to include('issues')
       end
     end
 

--- a/spec/fixtures/frictionless_report_example.json
+++ b/spec/fixtures/frictionless_report_example.json
@@ -1,0 +1,256 @@
+{
+  "report": {
+    "version": "4.10.6",
+    "time": 0.024,
+    "errors": [],
+    "tasks": [
+      {
+        "resource": {
+          "path": "/Users/sfisher/workspace/direct-to-cdl-dryad/dryad-app/tmp/invalid2.csv20210630-5513-1tapmfb.csv",
+          "name": "invalid2.csv20210630-5513-1tapmfb",
+          "profile": "tabular-data-resource",
+          "scheme": "file",
+          "format": "csv",
+          "hashing": "md5",
+          "encoding": "utf-8",
+          "schema": {
+            "fields": [
+              {
+                "name": "id",
+                "type": "integer"
+              },
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "field3",
+                "type": "integer"
+              },
+              {
+                "name": "name2",
+                "type": "integer"
+              }
+            ]
+          },
+          "stats": {
+            "hash": "5e367f12152a0e59243f6011931dfba1",
+            "bytes": 56,
+            "fields": 4,
+            "rows": 4
+          }
+        },
+        "time": 0.024,
+        "scope": [
+          "hash-count-error",
+          "byte-count-error",
+          "field-count-error",
+          "row-count-error",
+          "blank-header",
+          "extra-label",
+          "missing-label",
+          "blank-label",
+          "duplicate-label",
+          "incorrect-label",
+          "blank-row",
+          "primary-key-error",
+          "foreign-key-error",
+          "extra-cell",
+          "missing-cell",
+          "type-error",
+          "constraint-error",
+          "unique-error"
+        ],
+        "partial": false,
+        "errors": [
+          {
+            "label": "",
+            "fieldName": "field3",
+            "fieldNumber": 3,
+            "fieldPosition": 3,
+            "labels": [
+              "id",
+              "name",
+              "",
+              "name"
+            ],
+            "rowPositions": [
+              1
+            ],
+            "code": "blank-label",
+            "name": "Blank Label",
+            "tags": [
+              "#table",
+              "#header",
+              "#label"
+            ],
+            "note": "",
+            "message": "Label in the header in field at position \"3\" is blank",
+            "description": "A label in the header row is missing a value. Label should be provided and not be blank."
+          },
+          {
+            "label": "name",
+            "fieldName": "name2",
+            "fieldNumber": 4,
+            "fieldPosition": 4,
+            "labels": [
+              "id",
+              "name",
+              "",
+              "name"
+            ],
+            "rowPositions": [
+              1
+            ],
+            "code": "duplicate-label",
+            "name": "Duplicate Label",
+            "tags": [
+              "#table",
+              "#header",
+              "#label"
+            ],
+            "note": "at position \"2\"",
+            "message": "Label \"name\" in the header at position \"4\" is duplicated to a label: at position \"2\"",
+            "description": "Two columns in the header row have the same value. Column names should be unique."
+          },
+          {
+            "cell": "",
+            "fieldName": "field3",
+            "fieldNumber": 3,
+            "fieldPosition": 3,
+            "cells": [
+              "1",
+              "portuguese"
+            ],
+            "rowNumber": 1,
+            "rowPosition": 2,
+            "code": "missing-cell",
+            "name": "Missing Cell",
+            "tags": [
+              "#table",
+              "#row",
+              "#cell"
+            ],
+            "note": "",
+            "message": "Row at position \"2\" has a missing cell in field \"field3\" at position \"3\"",
+            "description": "This row has less values compared to the header row (the first row in the data source). A key concept is that all the rows in tabular data must have the same number of columns."
+          },
+          {
+            "cell": "",
+            "fieldName": "name2",
+            "fieldNumber": 4,
+            "fieldPosition": 4,
+            "cells": [
+              "1",
+              "portuguese"
+            ],
+            "rowNumber": 1,
+            "rowPosition": 2,
+            "code": "missing-cell",
+            "name": "Missing Cell",
+            "tags": [
+              "#table",
+              "#row",
+              "#cell"
+            ],
+            "note": "",
+            "message": "Row at position \"2\" has a missing cell in field \"name2\" at position \"4\"",
+            "description": "This row has less values compared to the header row (the first row in the data source). A key concept is that all the rows in tabular data must have the same number of columns."
+          },
+          {
+            "cell": "",
+            "fieldName": "field3",
+            "fieldNumber": 3,
+            "fieldPosition": 3,
+            "cells": [
+              "1",
+              "portuguese"
+            ],
+            "rowNumber": 2,
+            "rowPosition": 3,
+            "code": "missing-cell",
+            "name": "Missing Cell",
+            "tags": [
+              "#table",
+              "#row",
+              "#cell"
+            ],
+            "note": "",
+            "message": "Row at position \"3\" has a missing cell in field \"field3\" at position \"3\"",
+            "description": "This row has less values compared to the header row (the first row in the data source). A key concept is that all the rows in tabular data must have the same number of columns."
+          },
+          {
+            "cell": "",
+            "fieldName": "name2",
+            "fieldNumber": 4,
+            "fieldPosition": 4,
+            "cells": [
+              "1",
+              "portuguese"
+            ],
+            "rowNumber": 2,
+            "rowPosition": 3,
+            "code": "missing-cell",
+            "name": "Missing Cell",
+            "tags": [
+              "#table",
+              "#row",
+              "#cell"
+            ],
+            "note": "",
+            "message": "Row at position \"3\" has a missing cell in field \"name2\" at position \"4\"",
+            "description": "This row has less values compared to the header row (the first row in the data source). A key concept is that all the rows in tabular data must have the same number of columns."
+          },
+          {
+            "cells": [],
+            "rowNumber": 3,
+            "rowPosition": 4,
+            "code": "blank-row",
+            "name": "Blank Row",
+            "tags": [
+              "#table",
+              "#row"
+            ],
+            "note": "",
+            "message": "Row at position \"4\" is completely blank",
+            "description": "This row is empty. A row should contain at least one value."
+          },
+          {
+            "cell": "3",
+            "fieldName": "",
+            "fieldNumber": 4,
+            "fieldPosition": 5,
+            "cells": [
+              "2",
+              "german",
+              "1",
+              "2",
+              "3"
+            ],
+            "rowNumber": 4,
+            "rowPosition": 5,
+            "code": "extra-cell",
+            "name": "Extra Cell",
+            "tags": [
+              "#table",
+              "#row",
+              "#cell"
+            ],
+            "note": "",
+            "message": "Row at position \"5\" has an extra value in field at position \"5\"",
+            "description": "This row has more values compared to the header row (the first row in the data source). A key concept is that all the rows in tabular data must have the same number of columns."
+          }
+        ],
+        "stats": {
+          "errors": 8
+        },
+        "valid": false
+      }
+    ],
+    "stats": {
+      "errors": 8,
+      "tasks": 1
+    },
+    "valid": false
+  }
+}

--- a/spec/javascript/components/FileList/BadList/BadList.test.js
+++ b/spec/javascript/components/FileList/BadList/BadList.test.js
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import ReactDOM, {unmountComponentAtNode} from "react-dom";
+import React from 'react';
+import {act} from 'react-dom/test-utils';
+import BadList from "../../../../../app/javascript/components/FileList/BadList/BadList";
+
+let container = null;
+beforeEach(() => {
+  // setup a DOM element as a render target
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  // cleanup on exiting
+  unmountComponentAtNode(container);
+  container.remove();
+  container = null;
+});
+
+describe('BadList', () => {
+  it("displays errors if couldn't read a file", () => {
+    const testBad = [
+      {
+        "upload_file_name": "cat.csv",
+        "frictionless_report": {
+          "status": "error"
+        }
+      }
+    ];
+
+    act(() => {
+      ReactDOM.render(<BadList chosenFiles={testBad} />, container);
+    });
+
+    expect(container.textContent).toContain("couldn't read cat.csv");
+  });
+
+  it("displays issues if they are present", () => {
+    const testIssue = [
+      {
+        "upload_file_name": "simon.csv",
+        "frictionless_report": {
+          "status": "issues"
+        }
+      }
+    ];
+
+    act(() => {
+      ReactDOM.render(<BadList chosenFiles={testIssue} />, container);
+    });
+
+    expect(container.textContent).toContain("Please view the issues");
+  });
+
+  it("doesn't display anything if no frictionless on file", () => {
+    const testFiles = [
+      {
+        "upload_file_name": "cassandra.jpg",
+      }
+    ];
+
+    act(() => {
+      ReactDOM.render(<BadList chosenFiles={testFiles} />, container);
+    });
+
+    expect(container.textContent).toBe('');
+  });
+
+  it("doesn't display anything if frictionless passed", () => {
+    const testFiles = [
+      {
+        "upload_file_name": "awesome.csv",
+        "frictionless_report": {
+          "status": "noissues"
+        }
+      }
+    ];
+
+    act(() => {
+      ReactDOM.render(<BadList chosenFiles={testFiles} />, container);
+    });
+
+    expect(container.textContent).toBe('');
+  });
+});

--- a/spec/javascript/containers/UploadFiles.test.js
+++ b/spec/javascript/containers/UploadFiles.test.js
@@ -13,6 +13,9 @@ https://www.valentinog.com/blog/testing-react/
 https://reactjs.org/docs/test-renderer.html
 
 const uploadFiles = require('UploadFiles.js');
+
+to run try 'yarn jest'
+if you need to see console.log output, do 'yarn jest --verbose false'
  */
 
 import ReactDOM, {unmountComponentAtNode} from "react-dom";

--- a/stash/stash_engine/app/views/stash_engine/resources/upload.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/resources/upload.html.erb
@@ -29,15 +29,17 @@
 
 <!-- it's a little squidgy to have this in here, but it isn't used in any other page and doesn't need to be precompiled or put anywhere else -->
 <div id="popup_dialog" style="display:none;">
-  <p>
-    Your files have not yet finished uploading, please click <strong>Upload pending files</strong> or
-    allow your uploads to finish before proceeding.
-  </p>
 </div>
 
 <script>
-  $('.js-nav-out').click(function(e) {
+  $('.js-nav-out').on('click', function(e) {
     if( $("td.c-uploadtable__status:contains('Pending')").length > 0 || $("td.c-uploadtable__status>progress").length > 0){
+      var text = `
+        <p>
+          Your files have not yet finished uploading, please click <strong>Upload pending files</strong> or
+          allow your uploads to finish before proceeding.
+        </p>`;
+      $("#popup_dialog").html(text);
       e.preventDefault();
       $("#popup_dialog").dialog({
         autoOpen: true,
@@ -45,6 +47,23 @@
         width: '500px',
         modal: true,
         title: 'Finish upload before proceeding'
+      });
+    }
+
+    if( $(".js-tabular-checking").length > 0){
+      var text = `
+        <p>
+          Your tabular files are currently being checked for formatting and consistency issues. Please wait for the checks
+          to complete before navigating away from this page.
+        </p>`;
+      $("#popup_dialog").html(text);
+      e.preventDefault();
+      $("#popup_dialog").dialog({
+        autoOpen: true,
+        height: 'auto',
+        width: '500px',
+        modal: true,
+        title: 'Allow tabular consistency checks to complete'
       });
     }
   });


### PR DESCRIPTION
*includes code from previous pull requests, so the diff should be more clear if you accept those in the order they were put in*

This pops up a dialog asking people to wait if they attempt navigation away while frictionless checks are happening.

to test:
- Upload a frictionless type such as csv or xls.
- While the spinners under the frictionless column are spinning, click the button to navigate to the review page or someplace.
- Should see message asking you to wait to navigate away.