### PR TITLE
Tune timeouts retries

### DIFF
--- a/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -33,7 +33,7 @@ module Stash
         begin
           resp = nil
           http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
-            .timeout(connect: 30, read: 60, write: 60).timeout(24.hours.to_i).follow(max_hops: 10)
+            .timeout(connect: 30, read: 60, write: 60).follow(max_hops: 10)
 
           my_params = { access_token: APP_CONFIG[:zenodo][:access_token] }.merge(args.fetch(:params, {}))
           my_headers = { 'Content-Type': 'application/json' }.merge(args.fetch(:headers, {}))

--- a/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -22,7 +22,6 @@ module Stash
         false
       end
 
-      # rubocop:disable Metrics/AbcSize
       def self.standard_request(method, url, **args)
         retries = 0
 
@@ -67,7 +66,6 @@ module Stash
           # rubocop:enable Style/GuardClause
         end
       end
-      # rubocop:enable Metrics/AbcSize
 
       # NOTE: Alex suggested we use a URL like https://sandbox.zenodo.org/api/deposit/depositions?q=doi:%2210.7959/dryad.bzkh1894f%22
       # to do lookups by DOIs to see they exist before proceeding with a retry on a POST request.

--- a/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -11,7 +11,7 @@ module Stash
     module ZenodoConnection
 
       SLEEP_TIME = 15
-      RETRY_LIMIT = 20
+      RETRY_LIMIT = 5
       ZENODO_PADDING_TIME = 2
 
       # checks that can access API with token and return boolean
@@ -33,7 +33,7 @@ module Stash
         begin
           resp = nil
           http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
-            .timeout(connect: 30, read: 60).timeout(6.hours.to_i).follow(max_hops: 10)
+            .timeout(connect: 30, read: 60, write: 60).timeout(24.hours.to_i).follow(max_hops: 10)
 
           my_params = { access_token: APP_CONFIG[:zenodo][:access_token] }.merge(args.fetch(:params, {}))
           my_headers = { 'Content-Type': 'application/json' }.merge(args.fetch(:headers, {}))

--- a/stash/stash_engine/lib/stash/zenodo_software/streamer.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/streamer.rb
@@ -32,7 +32,7 @@ module Stash
       # This takes an argument of the digests types you want returned as an array, see DIGEST_INITIALIZERS for types.  It returns
       # the zenodo response and the hexdigests for the types you specify
 
-      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
       def stream(digest_types: [])
         digests_obj = Digests.new(digest_types: digest_types)
 
@@ -83,7 +83,7 @@ module Stash
         raise Stash::ZenodoReplicate::ZenodoError, "Error retrieving HTTP URL for duplication #{@file_model.zenodo_replication_url}\n" \
             "Original error: #{e}\n#{e.backtrace.join("\n")}"
       end
-      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/stash/stash_engine/lib/stash/zenodo_software/streamer.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/streamer.rb
@@ -41,7 +41,7 @@ module Stash
         write_pipe.binmode
 
         http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
-          .timeout(connect: 30, read: 60, write: 60).timeout(24.hours.to_i).follow(max_hops: 10)
+          .timeout(connect: 30, read: 60, write: 60).follow(max_hops: 10)
         response = http.get(@file_model.zenodo_replication_url)
 
         put_response = nil

--- a/stash/stash_engine/lib/stash/zenodo_software/streamer.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/streamer.rb
@@ -41,7 +41,7 @@ module Stash
         write_pipe.binmode
 
         http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
-          .timeout(connect: 30, read: 60).timeout(6.hours.to_i).follow(max_hops: 10)
+          .timeout(connect: 30, read: 60, write: 60).timeout(24.hours.to_i).follow(max_hops: 10)
         response = http.get(@file_model.zenodo_replication_url)
 
         put_response = nil


### PR DESCRIPTION
- Only retry 5 times in a row instead of 20 which takes forever and if Zenodo is that unstable maybe error and try again later instead of now.
- Add write timeout for 60.
- I don't believe the overall timeout is for the full request, but only for each chunk sent.  I don't think setting this to 6 hours helped.