### PR TITLE
Small tweaks that I hope make Zenodo replication better

### DIFF
--- a/stash/stash_engine/lib/stash/zenodo_replicate/copier_mixin.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/copier_mixin.rb
@@ -12,7 +12,7 @@ module Stash
       # return an error if replicating already, shouldn't start another replication
       def error_if_replicating
         repli_count = @resource.identifier.zenodo_copies.send(@dataset_type).where(state: %w[replicating error])
-          .where('stash_engine_zenodo_copies.resource_id <= ?', @resource.id).where('stash_engine_zenodo_copies.id < ?', @copy.id).count
+          .where('stash_engine_zenodo_copies.resource_id <= ?', @resource.id).where('stash_engine_zenodo_copies.id <= ?', @copy.id).count
         # rubocop goes bonkers on this and suggests guardclause but when you do it suggests an if statement
         # rubocop:disable Style/GuardClause
         if repli_count.positive?

--- a/stash/stash_engine/lib/stash/zenodo_replicate/copier_mixin.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/copier_mixin.rb
@@ -12,7 +12,7 @@ module Stash
       # return an error if replicating already, shouldn't start another replication
       def error_if_replicating
         repli_count = @resource.identifier.zenodo_copies.send(@dataset_type).where(state: %w[replicating error])
-          .where('stash_engine_zenodo_copies.resource_id <= ?', @resource.id).count
+          .where('stash_engine_zenodo_copies.resource_id <= ?', @resource.id).where('stash_engine_zenodo_copies.id < ?', @copy.id).count
         # rubocop goes bonkers on this and suggests guardclause but when you do it suggests an if statement
         # rubocop:disable Style/GuardClause
         if repli_count.positive?

--- a/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/stash/stash_engine/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -32,7 +32,7 @@ module Stash
         begin
           resp = nil
           http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
-            .timeout(connect: 30, read: 60, write: 60).follow(max_hops: 10)
+            .timeout(connect: 30, read: 180, write: 180).follow(max_hops: 10)
 
           my_params = { access_token: APP_CONFIG[:zenodo][:access_token] }.merge(args.fetch(:params, {}))
           my_headers = { 'Content-Type': 'application/json' }.merge(args.fetch(:headers, {}))

--- a/stash/stash_engine/lib/stash/zenodo_software/copier.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/copier.rb
@@ -175,7 +175,7 @@ module Stash
           copy_record = res.zenodo_copies.where('copy_type like ?', "#{@dataset_type}%").first
           if copy_record.nil? || copy_record.state != 'finished'
             raise ZE, "identifier_id #{@resource.identifier.id}: Cannot replicate a later version until earlier " \
-              'versions with files have replicated. An earlier is missing or incomplete in the ZenodoCopies table.'
+              "versions with files have replicated. Resource id #{res.id} is incomplete or not present in the ZenodoCopies table."
           end
         end
       end

--- a/stash/stash_engine/lib/stash/zenodo_software/streamer.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/streamer.rb
@@ -41,7 +41,7 @@ module Stash
         write_pipe.binmode
 
         http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
-          .timeout(connect: 30, read: 60, write: 60).follow(max_hops: 10)
+          .timeout(connect: 30, read: 180, write: 180).follow(max_hops: 10)
         response = http.get(@file_model.zenodo_replication_url)
 
         put_response = nil


### PR DESCRIPTION
- Up read and write timeouts to 3 minutes (for chunks or smaller requests, not for the whole request)
- Add additional clause so it ignores later items in same resource for zenodo deposit (publication action after uploading if both had errors or aren't complete)
- If previous version with files for Zenodo never replicated, then include information about which one is the problem in the error message