### PR TITLE
Allow EM to update more fields

### DIFF
--- a/spec/fixtures/stash_api/em_metadata.rb
+++ b/spec/fixtures/stash_api/em_metadata.rb
@@ -20,15 +20,24 @@ module Fixtures
       end
 
       def make_deposit_metadata
+        add_title
         add_journal_name
         add_author
       end
 
       def make_submission_metadata
+        add_title
         add_journal_name
         add_embargo_info
         add_article
         add_author
+      end
+
+      def add_title
+        title = Faker::Book.title
+        dd = ActiveSupport::HashWithIndifferentAccess.new
+        dd.merge!(deposit_description: title)
+        @metadata[:deposit_data] = dd
       end
 
       def add_journal_name
@@ -63,11 +72,11 @@ module Fixtures
         article.merge!(abstract: Faker::Lorem.paragraph)
         article.merge!(final_disposition: 'ACCEPT')
         article.merge!(keywords: [Faker::Cosmere.aon, Faker::Cosmere.metal, Faker::Cosmere.spren])
-        article.merge!(funding_source: [{
-                         "funder": 'National Institutes of Health',
-                         "funder_id": 'http://dx.doi.org/10.13039/100000002',
-                         "award_number": '12345',
-                         "grant_recipient": '33182'
+        article.merge!(funding_information: [{
+                         "funder": Faker::Company.name,
+                         "funder_id": Faker::Pid.doi,
+                         "award_number": Faker::Alphanumeric.alphanumeric(number: 8, min_alpha: 2, min_numeric: 4),
+                         "grant_recipient": Faker::Alphanumeric.alphanumeric(number: 8, min_alpha: 2, min_numeric: 4)
                        }])
 
         @metadata[:article] = article

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -23,6 +23,7 @@ module StashApi
       mock_tenant!
       mock_datacite_and_idgen!
       @user = create(:user, role: 'superuser', tenant_id: 'dryad')
+      @system_user = create(:user, id: 0, first_name: 'Dryad', last_name: 'System')
       @doorkeeper_application = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
                                                                 owner_id: @user.id, owner_type: 'StashEngine::User')
       setup_access_token(doorkeeper_application: @doorkeeper_application)

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -195,8 +195,8 @@ module StashApi
         expect(ident.publication_name).to eq(hsh[:journal_full_title])
         expect(res.authors.first.author_first_name).to eq(hsh[:authors].first[:first_name])
 
-        article = hsh[:article]
-        expect(res.title).to eq(article[:article_title])
+        dd = hsh['deposit_data']
+        expect(res.title).to eq(dd['deposit_description'])
       end
 
       it 'allows update of deposit metadata with new submission metadata' do
@@ -215,8 +215,8 @@ module StashApi
         res.reload
         hsh = @meta.hash
         expect(res.authors.first.author_first_name).to eq(hsh[:authors].first[:first_name])
-        article = hsh[:article]
-        expect(res.title).to eq(article[:article_title])
+        dd = hsh['deposit_data']
+        expect(res.title).to eq(dd['deposit_description'])
       end
 
       it 'allows update of deposit metadata using the raw identifier, without <<doi:>>' do
@@ -235,11 +235,11 @@ module StashApi
         res.reload
         hsh = @meta.hash
         expect(res.authors.first.author_first_name).to eq(hsh[:authors].first[:first_name])
-        article = hsh[:article]
-        expect(res.title).to eq(article[:article_title])
+        dd = hsh['deposit_data']
+        expect(res.title).to eq(dd['deposit_description'])
       end
 
-      it 'does not update core fields after the user has submitted edits' do
+      it 'does not update core fields after the user has submitted edits, but does update selected fields' do
         @meta.make_submission_metadata
         response_code = post '/api/v2/em_submission_metadata', params: @meta.json, headers: default_authenticated_headers
         output = response_body_hash
@@ -247,12 +247,16 @@ module StashApi
         ident = StashEngine::Identifier.where(identifier: output[:deposit_id]).first
         res = ident.latest_resource
         res.resource_states.first.update(resource_state: 'submitted')
-        @meta.make_submission_metadata
+        saved_title = res.title
+        res.contributors = []
+        @meta.make_submission_metadata # creates a new fake title
         response_code = post "/api/v2/em_submission_metadata/doi%3A#{ERB::Util.url_encode(ident.identifier)}",
                              params: @meta.json,
                              headers: default_authenticated_headers
-
-        expect(response_code).to eq(403)
+        expect(response_code).to eq(200)
+        res.reload
+        expect(res.title).to eq(saved_title)
+        expect(res.contributors).not_to be_blank
       end
 
       it 'updates the status of a peer_review item if the final_disposition is present in the submission metadata' do

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -102,25 +102,6 @@ module StashApi
         fields_changed << 'Funders'
       end
 
-      # Add co-authors if they were not added by the submitter
-      if @resource.authors.size < 2 && params['authors'].present?
-        curr_auths = @resource.authors.map(&:author_full_name)
-        params['authors'].each do |auth|
-          next if curr_auths.include?("#{auth['last_name']}, #{auth['first_name']}")
-
-          new_author = StashEngine::Author.create(author_first_name: auth['first_name'],
-                                                  author_last_name: auth['last_name'],
-                                                  author_email: auth['email'],
-                                                  author_orcid: auth['orcid'])
-          if auth['institution'].present?
-            affil = StashDatacite::Affiliation.from_long_name(long_name: auth['institution'])
-            new_author.affiliation = affil
-          end
-          @resource.authors << new_author
-        end
-        fields_changed << 'Authors'
-      end
-
       # Add keywords if they were not added by the submitter
       if @resource.subjects.blank? && art_params['keywords'].present?
         @resource.subjects.clear

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -176,6 +176,9 @@ module StashApi
     def em_reformat_request
       em_params = {}.with_indifferent_access
 
+      # EM doesn't set an item owner, so default it to system, and the actual user will need to claim it
+      em_params['userId'] = 0
+
       em_params['publicationName'] = params['journal_full_title']
       art_params = params['article']
       if art_params

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -74,7 +74,7 @@ module StashApi
       end
     end
 
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
     def em_update_selected_fields
       logger.debug('em_update_selected_fields')
 
@@ -216,7 +216,7 @@ module StashApi
       em_params['authors'] = em_authors if em_authors.present?
       em_params
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
 
     # Reformat a `metadata` response object, putting it in the format that Editorial Manager prefers
     def em_reformat_response(metadata)

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -113,7 +113,7 @@ module StashApi
                                                   author_email: auth['email'],
                                                   author_orcid: auth['orcid'])
           if auth['institution'].present?
-            affil = StashEngine::Affiliation.from_long_name(long_name: auth['institution'])
+            affil = StashDatacite::Affiliation.from_long_name(long_name: auth['institution'])
             new_author.affiliation = affil
           end
           @resource.authors << new_author

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -104,9 +104,9 @@ module StashApi
 
       # Add co-authors if they were not added by the submitter
       if @resource.authors.size < 2 && params['authors'].present?
+        curr_auths = @resource.authors.map(&:author_full_name)
         params['authors'].each do |auth|
-          next if auth['first_name'] == @resource.user.first_name &&
-                  auth['last_name'] == @resource.user.last_name
+          next if curr_auths.include?("#{auth['last_name']}, #{auth['first_name']}")
 
           new_author = StashEngine::Author.create(author_first_name: auth['first_name'],
                                                   author_last_name: auth['last_name'],


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1362

Normally, we don't want API users to change metadata after an author has visited the Dryad UI. However, since EM does not have much metadata until the very end of their process, we want them to be able to update some fields after the author has visited Dryad. This PR allows authors, funders, and keywords to be updated. If any of these fields are updated, a curation note is added to alert curators that the dataset has been updated.