### PR TITLE
Remove related works for zenodo after all files are removed for resource

### DIFF
--- a/spec/models/stash_datacite/related_identifier_spec.rb
+++ b/spec/models/stash_datacite/related_identifier_spec.rb
@@ -140,9 +140,9 @@ module StashDatacite
         expect(re.added_by).to eq('zenodo')
       end
 
-      it "removes an existing relation if all files have been removed from zenodo" do
+      it 'removes an existing relation if all files have been removed from zenodo' do
         create(:zenodo_copy, resource_id: @resource.id, identifier_id: @resource.identifier_id,
-               copy_type: 'software', software_doi: @test_doi)
+                             copy_type: 'software', software_doi: @test_doi)
         sfw_file = create(:software_file, resource_id: @resource.id)
         expect(@resource.related_identifiers.count).to eq(0)
         StashDatacite::RelatedIdentifier.set_latest_zenodo_relations(resource: @resource)

--- a/spec/models/stash_datacite/related_identifier_spec.rb
+++ b/spec/models/stash_datacite/related_identifier_spec.rb
@@ -139,6 +139,21 @@ module StashDatacite
         expect(re.verified).to be(true)
         expect(re.added_by).to eq('zenodo')
       end
+
+      it "removes an existing relation if all files have been removed from zenodo" do
+        create(:zenodo_copy, resource_id: @resource.id, identifier_id: @resource.identifier_id,
+               copy_type: 'software', software_doi: @test_doi)
+        sfw_file = create(:software_file, resource_id: @resource.id)
+        expect(@resource.related_identifiers.count).to eq(0)
+        StashDatacite::RelatedIdentifier.set_latest_zenodo_relations(resource: @resource)
+        # adds it becauase it has a file
+        expect(@resource.related_identifiers.count).to eq(1)
+
+        sfw_file.destroy!
+        StashDatacite::RelatedIdentifier.set_latest_zenodo_relations(resource: @resource)
+        # removes it because the file is gone now
+        expect(@resource.related_identifiers.count).to eq(0)
+      end
     end
 
     describe 'self.remove_zenodo_relation' do

--- a/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
@@ -132,8 +132,9 @@ module StashDatacite
     def self.set_latest_zenodo_relations(resource:)
       resource.related_identifiers.where(added_by: 'zenodo').destroy_all
 
-      sfw_copy = StashEngine::ZenodoCopy.last_copy_with_software(identifier_id: resource.identifier.id)
-      if sfw_copy.present?
+      # sfw_copy = StashEngine::ZenodoCopy.last_copy_with_software(identifier_id: resource.identifier.id)
+      # if sfw_copy.present?
+      if resource.software_files.present_files.count.positive?
         doi = standardize_doi(sfw_copy.software_doi)
         create(related_identifier: doi,
                related_identifier_type: 'doi',
@@ -144,8 +145,9 @@ module StashDatacite
                added_by: 'zenodo')
       end
 
-      supp_copy = StashEngine::ZenodoCopy.last_copy_with_supp(identifier_id: resource.identifier.id)
-      return unless supp_copy.present?
+      # supp_copy = StashEngine::ZenodoCopy.last_copy_with_supp(identifier_id: resource.identifier.id)
+      # return unless supp_copy.present?
+      return unless resource.supp_files.present_files.count.positive?
 
       doi = standardize_doi(supp_copy.software_doi)
       create(related_identifier: doi,

--- a/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
@@ -134,6 +134,7 @@ module StashDatacite
 
       # sfw_copy = StashEngine::ZenodoCopy.last_copy_with_software(identifier_id: resource.identifier.id)
       # if sfw_copy.present?
+      sfw_copy = resource.zenodo_copies.software.first
       if resource.software_files.present_files.count.positive?
         doi = standardize_doi(sfw_copy.software_doi)
         create(related_identifier: doi,
@@ -148,6 +149,8 @@ module StashDatacite
       # supp_copy = StashEngine::ZenodoCopy.last_copy_with_supp(identifier_id: resource.identifier.id)
       # return unless supp_copy.present?
       return unless resource.supp_files.present_files.count.positive?
+
+      supp_copy = resource.zenodo_copies.supp.first
 
       doi = standardize_doi(supp_copy.software_doi)
       create(related_identifier: doi,

--- a/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
@@ -132,8 +132,6 @@ module StashDatacite
     def self.set_latest_zenodo_relations(resource:)
       resource.related_identifiers.where(added_by: 'zenodo').destroy_all
 
-      # sfw_copy = StashEngine::ZenodoCopy.last_copy_with_software(identifier_id: resource.identifier.id)
-      # if sfw_copy.present?
       sfw_copy = resource.zenodo_copies.software.first
       if resource.software_files.present_files.count.positive?
         doi = standardize_doi(sfw_copy.software_doi)
@@ -146,8 +144,6 @@ module StashDatacite
                added_by: 'zenodo')
       end
 
-      # supp_copy = StashEngine::ZenodoCopy.last_copy_with_supp(identifier_id: resource.identifier.id)
-      # return unless supp_copy.present?
       return unless resource.supp_files.present_files.count.positive?
 
       supp_copy = resource.zenodo_copies.supp.first


### PR DESCRIPTION
Before now, the relations would set the last available relationship that had been sent to zenodo.  It was defined that way in the ticket info.

Now we are removing the relationship if someone removes all the files at zenodo and it doesn't point to an older relationship that is still there for an older version.

To test:

- Upload  a file to either supplemental or software and submit the dataset.
- Wait for replication to complete to zenodo (usually quick on their sandbox)
- Check that the relationship exists for that external zenodo item. ✅ 
- Edit the dataset in a new version
- Remove the supplemental or software file you added earlier and then submit the dataset again
- Wait for updates (should happen fast)
- Check to see that the relationship for the zenodo dataset with all files removed has been removed from relationships.  ✅ 