### PR TITLE
Removes the javascript that hides the remove link

### DIFF
--- a/spec/support/helpers/ckeditor_helper.rb
+++ b/spec/support/helpers/ckeditor_helper.rb
@@ -27,12 +27,11 @@ module CkeditorHelper
         ckeditor.focusManager.blur( true );
         // ckeditor.updateElement();
     SCRIPT
+
     # the blur() above is needed because capybara behaves oddly. https://makandracards.com/makandra/12661-how-to-solve-selenium-focus-issues
     page.execute_script script_text
     expect(first('.cke').present?).to eql(true)
-    # aargh this is annoying, but it turns out it needs time to start the ajax request and the wait_for_ajax wasn't enough by itself
-    sleep 0.5
-    wait_for_ajax
+    # wait_for_ajax
   end
 
 end

--- a/spec/support/helpers/ckeditor_helper.rb
+++ b/spec/support/helpers/ckeditor_helper.rb
@@ -30,7 +30,9 @@ module CkeditorHelper
     # the blur() above is needed because capybara behaves oddly. https://makandracards.com/makandra/12661-how-to-solve-selenium-focus-issues
     page.execute_script script_text
     expect(first('.cke').present?).to eql(true)
-    # wait_for_ajax
+    # aargh this is annoying, but it turns out it needs time to start the ajax request and the wait_for_ajax wasn't enough by itself
+    sleep 0.5
+    wait_for_ajax
   end
 
 end

--- a/stash/stash_datacite/app/assets/javascripts/stash_datacite/contributor.js
+++ b/stash/stash_datacite/app/assets/javascripts/stash_datacite/contributor.js
@@ -60,13 +60,3 @@ function loadContributors() {
     });
 };
 
-function hideRemoveLinkContributors() {
-  if($('.js-funders').length < 2)
-  {
-   $('.js-funders').first().parent().parent().find('.remove_record').hide();
-  }
-  else
-  {
-   $('.js-funders').first().parent().parent().find('.remove_record').show();
-  }
-};

--- a/stash/stash_datacite/app/assets/javascripts/stash_datacite/contributor.js
+++ b/stash/stash_datacite/app/assets/javascripts/stash_datacite/contributor.js
@@ -60,3 +60,15 @@ function loadContributors() {
     });
 };
 
+/*
+function hideRemoveLinkContributors() {
+  if($('.js-funders').length < 2)
+  {
+   $('.js-funders').first().parent().parent().find('.remove_record').hide();
+  }
+  else
+  {
+   $('.js-funders').first().parent().parent().find('.remove_record').show();
+  }
+};
+*/

--- a/stash/stash_datacite/app/views/stash_datacite/contributors/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/contributors/_form.html.erb
@@ -12,7 +12,8 @@
 		<%= f.label "award_number_#{my_suffix}", "Award Number", class: 'c-input__label' %>
 		<%= f.text_field :award_number, id: "contributor_award_number_#{my_suffix}", class: "js-award_number c-input__text" %>
 	</div>
-	<%= link_to 'remove', stash_datacite.contributors_delete_path(contributor.id || 'new'), method: :delete, remote: true, data: { confirm: 'Are you sure you want to remove this funder?' }, class: 'remove_record t-describe__remove-button o-button__remove' %>
+	<%= link_to 'remove', stash_datacite.contributors_delete_path(contributor.id || 'new'), method: :delete, remote: true,
+							data: { confirm: 'Are you sure you want to remove this funder?' }, class: 'remove_record t-describe__remove-button o-button__remove' %>
 	<%= f.hidden_field :contributor_type, value: :funder %>
 	<%= f.hidden_field :resource_id %>
 	<%= f.hidden_field :id %>

--- a/stash/stash_datacite/app/views/stash_datacite/contributors/create.js.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/contributors/create.js.erb
@@ -11,4 +11,3 @@ $('<input>').attr({
   name: '_method',
   value: 'patch'
 }).appendTo(form);
-hideRemoveLinkContributors();

--- a/stash/stash_datacite/app/views/stash_datacite/contributors/delete.js.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/contributors/delete.js.erb
@@ -1,4 +1,3 @@
 $('.remove_record').bind('ajax:success', function() {
   $(this).closest('form').remove();
-  hideRemoveLinkContributors();
 });

--- a/stash/stash_datacite/app/views/stash_datacite/contributors/new.js.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/contributors/new.js.erb
@@ -1,5 +1,4 @@
 $('.js-contributors_form').append("<%= escape_javascript(render partial: "stash_datacite/contributors/form",
       locals: { contributor: @contributor, path: stash_datacite.contributors_create_path }) %>");
 loadContributors();
-hideRemoveLinkContributors();
 addSavingDisplay();

--- a/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/find_or_create.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/find_or_create.html.erb
@@ -11,7 +11,6 @@ $(function() {
   loadDescriptions();
   loadContributors();
   loadPublications();
-  hideRemoveLinkContributors();
   loadSubjects();
   loadRelatedIdentifiers();
   hideRemoveLinkRelatedIdentifiers();

--- a/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/find_or_create.js.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/find_or_create.js.erb
@@ -7,7 +7,6 @@ hideRemoveLinkAuthors();
 hideRemoveRequiredLabelAuthors()
 loadContributors();
 loadPublications();
-hideRemoveLinkContributors();
 loadDescriptions();
 loadSubjects();
 loadRelatedIdentifiers();


### PR DESCRIPTION
People were not allowed to remove all of them because some items require at least one, but for funders it is optional so it is fine to remove the last one.

You can always click the + button if you want to add one and they've all been removed.  Loading the page also creates a blank one that can be edited.
