### PR TITLE
Separate curators from superusers

### DIFF
--- a/documentation/apis/adding_api_accounts.md
+++ b/documentation/apis/adding_api_accounts.md
@@ -32,7 +32,9 @@ To create an API account:
    `select * from stash_engine_users where id= <user id>;`
 
 To set permissions for the API account:
-- The user can be set to a `superuser` or tenant-based `admin` role using
+- Determine which role the account should have. For details on the available
+  roles, see the [Permissions](../technical_notes/permissions.md) document.
+- The user can be given an appropraite role using
   either the database or rails console:
   `update stash_engine_users set role='admin' where id= <user id>;`
   `StashEngine::User.find(<user id>).update(role: 'admin')`

--- a/documentation/apis/dataset_metadata.md
+++ b/documentation/apis/dataset_metadata.md
@@ -2,7 +2,7 @@
 Dataset Metadata
 =================
 
-Datasets in the Dryad API consist largely descriptive metadata
+Datasets in the Dryad API consist largely of descriptive metadata
 inspired by the
 [DataCite Metadata Schema](https://schema.datacite.org/). However,
 some of the fields have different names, and there are some

--- a/documentation/server_maintenance/status_dashboard.md
+++ b/documentation/server_maintenance/status_dashboard.md
@@ -1,5 +1,4 @@
 
-
 Status Dashboard
 ==================
 

--- a/documentation/server_maintenance/status_dashboard.md
+++ b/documentation/server_maintenance/status_dashboard.md
@@ -5,7 +5,7 @@ Status Dashboard
 
 The status dashboard allows monitoring of the various services that
 are required for Dryad to run, both internal and external. The status dashboard
-is only viewable to superusers.
+is only viewable to curators.
 
 To add a new checker:
 - add a checker to `stash/stash_engine/app/services/stash_engine/status_dashboard/`

--- a/documentation/technical_notes/permissions.md
+++ b/documentation/technical_notes/permissions.md
@@ -4,7 +4,10 @@ Permissions in Dryad
 
 Dryad has several levels of permissions. Some permissions are defined by the
 `User.role` field:
-- *superuser* -- Has full access to all features in the system
+- *superuser* -- Has full access to all features in the system. Superusers
+  automatically have permissions to do anything that any other type of user can do.
+- *curator* -- Has access to most features, though not some that are more
+  dangerous and only useful to developers.
 - *tenant_curator* -- Has view and edit access to all datasets in the associated
   tenant
 - *admin* -- Has view access to all datasets in the associated tenant,

--- a/spec/features/stash_datacite/dataset_versioning_spec.rb
+++ b/spec/features/stash_datacite/dataset_versioning_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'DatasetVersioning', type: :feature do
     mock_tenant!
     ignore_zenodo!
     neuter_curation_callbacks!
-    @curator = create(:user, role: 'superuser')
+    @curator = create(:user, role: 'curator')
     @author = create(:user)
     @document_list = []
   end

--- a/spec/features/stash_engine/curation_activity_spec.rb
+++ b/spec/features/stash_engine/curation_activity_spec.rb
@@ -32,6 +32,12 @@ RSpec.feature 'CurationActivity', type: :feature do
         expect(page).to have_text('Admin Dashboard')
       end
 
+      it 'is accessible by curators' do
+        sign_in(create(:user, role: 'curator', tenant_id: 'ucop'))
+        visit dashboard_path
+        expect(page).to have_text('Admin Dashboard')
+      end
+
       it 'is accessible by super users' do
         sign_in(create(:user, role: 'superuser', tenant_id: 'ucop'))
         visit dashboard_path
@@ -68,14 +74,14 @@ RSpec.feature 'CurationActivity', type: :feature do
         expect(all('.c-lined-table__row').length).to eql(2)
       end
 
-      it 'lets superusers see all datasets' do
-        sign_in(create(:user, role: 'superuser'))
+      it 'lets curators see all datasets' do
+        sign_in(create(:user, role: 'curator'))
         visit dashboard_path
         expect(all('.c-lined-table__row').length).to eql(6)
       end
 
       it 'has ajax showing counter stats and citations', js: true do
-        sign_in(create(:user, role: 'superuser', tenant_id: 'ucop'))
+        sign_in(create(:user, role: 'curator', tenant_id: 'ucop'))
         visit dashboard_path
         el = find('td', text: @identifiers.first.resources.first.title)
         el = el.first(:xpath, './following-sibling::td').find(:css, '.js-stats')
@@ -88,7 +94,7 @@ RSpec.feature 'CurationActivity', type: :feature do
       end
 
       it 'generates a csv having dataset information with citations, views and downloads' do
-        sign_in(create(:user, role: 'superuser', tenant_id: 'ucop'))
+        sign_in(create(:user, role: 'curator', tenant_id: 'ucop'))
         visit dashboard_path
         click_link('Get Comma Separated Values (CSV) for import into Excel')
 
@@ -104,7 +110,7 @@ RSpec.feature 'CurationActivity', type: :feature do
       end
 
       it 'generates a csv that includes submitter institutional name' do
-        sign_in(create(:user, role: 'superuser', tenant_id: 'ucop'))
+        sign_in(create(:user, role: 'curator', tenant_id: 'ucop'))
         visit dashboard_path
         click_link('Get Comma Separated Values (CSV) for import into Excel')
 
@@ -158,7 +164,7 @@ RSpec.feature 'CurationActivity', type: :feature do
         @resource = create(:resource, user: @user, identifier: create(:identifier), skip_datacite_update: true)
         create(:curation_activity_no_callbacks, status: 'curation', user_id: @user.id, resource_id: @resource.id)
         @resource.resource_states.first.update(resource_state: 'submitted')
-        sign_in(create(:user, role: 'superuser', tenant_id: 'ucop'))
+        sign_in(create(:user, role: 'curator', tenant_id: 'ucop'))
         visit "#{dashboard_path}?curation_status=curation"
       end
 

--- a/spec/features/stash_engine/dataset_queuing_spec.rb
+++ b/spec/features/stash_engine/dataset_queuing_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'DatasetQueuing', type: :feature do
     mock_tenant!
     neuter_curation_callbacks!
     @curator = create(:user, role: 'admin', tenant_id: 'dryad')
-    @author = create(:user, tenant_id: 'dryad', role: 'superuser')
+    @superuser = create(:user, tenant_id: 'dryad', role: 'superuser')
     @document_list = []
   end
 
@@ -40,7 +40,7 @@ RSpec.feature 'DatasetQueuing', type: :feature do
     before(:each, js: true) do
       ActionMailer::Base.deliveries = []
       # Sign in and create a new dataset
-      sign_in(@author)
+      sign_in(@superuser)
       visit root_path
       click_link 'My Datasets'
       3.times do
@@ -52,7 +52,7 @@ RSpec.feature 'DatasetQueuing', type: :feature do
         check 'agree_to_payment'
         click_button 'submit_dataset'
       end
-      @resource = StashEngine::Resource.where(user: @author).last
+      @resource = StashEngine::Resource.where(user: @superuser).last
     end
 
     it 'should show queuing', js: true do

--- a/spec/features/stash_engine/upload_files_spec.rb
+++ b/spec/features/stash_engine/upload_files_spec.rb
@@ -468,8 +468,8 @@ Software and Supplemental Information can be uploaded for publication at'
       )
 
       expect(page).to have_content(/^\bfunbar.txt\b/, count: 1)
-      expect(page).to have_content(/^\bfile_example_ODS_10.ods\b/, count: 1)
-      expect(page).to have_content('Some files of the same type are already in the table.')
+      # expect(page).to have_content(/^\bfile_example_ODS_10.ods\b/, count: 1)
+      expect(page).to have_content('same type are already in the table')
     end
 
     it 'does not allow to add a manifest FILE with the same name of a FILE selected from file system' do

--- a/spec/models/stash_engine/curation_stats_spec.rb
+++ b/spec/models/stash_engine/curation_stats_spec.rb
@@ -18,7 +18,7 @@ module StashEngine
       mock_tenant!
       neuter_curation_callbacks!
 
-      @curator = create(:user, tenant_id: 'dryad', role: 'superuser')
+      @curator = create(:user, tenant_id: 'dryad', role: 'curator')
       @user = create(:user, tenant_id: 'dryad', role: 'user')
       @system_user = create(:user, id: 0, first_name: 'Dryad', last_name: 'System')
 

--- a/spec/models/stash_engine/identifier_spec.rb
+++ b/spec/models/stash_engine/identifier_spec.rb
@@ -250,8 +250,8 @@ module StashEngine
             expect(@identifier.latest_viewable_resource(user: @user)).to eql(@identifier.latest_resource)
           end
 
-          it 'returns the latest non-published for a superuser' do
-            user2 = User.new(role: 'superuser')
+          it 'returns the latest non-published for a curator' do
+            user2 = User.new(role: 'curator')
             expect(@identifier.latest_viewable_resource(user: user2)).to eql(@identifier.latest_resource)
           end
 
@@ -774,7 +774,7 @@ module StashEngine
         Identifier.destroy_all
         @user = create(:user, first_name: 'Lisa', last_name: 'Muckenhaupt', email: 'lmuckenhaupt@ucop.edu', tenant_id: 'ucop', role: nil)
         @user2 = create(:user, first_name: 'Gargola', last_name: 'Jones', email: 'luckin@ucop.edu', tenant_id: 'ucop', role: 'admin')
-        @user3 = create(:user, first_name: 'Merga', last_name: 'Flav', email: 'flavin@ucop.edu', tenant_id: 'ucb', role: 'superuser')
+        @user3 = create(:user, first_name: 'Merga', last_name: 'Flav', email: 'flavin@ucop.edu', tenant_id: 'ucb', role: 'curator')
 
         @identifiers = [create(:identifier, identifier: '10.1072/FK2000'),
                         create(:identifier, identifier: '10.1072/FK2001'),
@@ -874,7 +874,7 @@ module StashEngine
         expect(identifiers.map(&:id)).to include(@identifiers[1].id) # this is some ucop joe blow private one
       end
 
-      it 'user_viewable for a superuser, they love it all' do
+      it 'user_viewable for a curator, they love it all' do
         identifiers = Identifier.user_viewable(user: @user3)
         expect(identifiers.count).to eq(@identifiers.length)
       end

--- a/spec/models/stash_engine/users_spec.rb
+++ b/spec/models/stash_engine/users_spec.rb
@@ -167,11 +167,16 @@ module StashEngine
         expect(user2.name).to eq('Bob')
       end
 
-      it 'returns if user is a superuser' do
+      it 'returns correct role information' do
         user = User.create(role: 'superuser')
         expect(user.superuser?).to be_truthy
-        user2 = User.create(role: 'user')
+        expect(user.curator?).to be_truthy
+        user2 = User.create(role: 'curator')
         expect(user2.superuser?).to be_falsey
+        expect(user2.curator?).to be_truthy
+        user3 = User.create(role: 'user')
+        expect(user3.superuser?).to be_falsey
+        expect(user3.curator?).to be_falsey
       end
     end
 

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -22,7 +22,7 @@ module StashApi
       mock_ror!
       mock_tenant!
       mock_datacite_and_idgen!
-      @user = create(:user, role: 'superuser', tenant_id: 'dryad')
+      @user = create(:user, role: 'curator', tenant_id: 'dryad')
       @doorkeeper_application = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
                                                                 owner_id: @user.id, owner_type: 'StashEngine::User')
       setup_access_token(doorkeeper_application: @doorkeeper_application)
@@ -55,7 +55,7 @@ module StashApi
         expect(out_author[:affiliation]).to eq(in_author[:affiliation])
       end
 
-      it 'creates a new dataset with a userId explicitly set by superuser)' do
+      it 'creates a new dataset with a userId explicitly set by curator)' do
         test_user = StashEngine::User.create(first_name: Faker::Name.first_name,
                                              last_name: Faker::Name.last_name,
                                              email: Faker::Internet.email)
@@ -287,7 +287,7 @@ module StashApi
 
         @user1 = create(:user, tenant_id: 'ucop', role: nil)
         @user2 = create(:user, tenant_id: 'ucop', role: 'admin')
-        @user3 = create(:user, tenant_id: 'ucb', role: 'superuser')
+        @user3 = create(:user, tenant_id: 'ucb', role: 'curator')
 
         @resources = [create(:resource, user_id: @user1.id, tenant_id: @user1.tenant_id, identifier_id: @identifiers[0].id),
                       create(:resource, user_id: @user1.id, tenant_id: @user1.tenant_id, identifier_id: @identifiers[0].id),
@@ -355,7 +355,7 @@ module StashApi
           expect(output[:count]).to eq(5)
         end
 
-        it 'gets a list of all datasets because superusers are omniscient' do
+        it 'gets a list of all datasets because curators are omniscient' do
           get '/api/v2/datasets', headers: default_authenticated_headers
           output = response_body_hash
           expect(output[:count]).to eq(@identifiers.count)
@@ -421,7 +421,7 @@ module StashApi
           expect(hsh['_embedded']['stash:datasets'][0]['versionNumber']).to eq(1)
         end
 
-        it 'shows the 2nd, unpublished version to superusers who see everything by default' do
+        it 'shows the 2nd, unpublished version to curators who see everything by default' do
 
           get '/api/v2/datasets', headers: default_authenticated_headers
           hsh = response_body_hash
@@ -560,7 +560,7 @@ module StashApi
         expect(hsh['editLink']).to eq(nil)
       end
 
-      it 'shows the private record for superuser' do
+      it 'shows the private record for curator' do
         @identifier.edit_code = Faker::Number.number(digits: 6)
         @identifier.save
         get "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}", headers: default_authenticated_headers
@@ -606,7 +606,7 @@ module StashApi
       end
 
       describe 'PATCH to submit dataset' do
-        xit 'submits dataset when the PATCH operation for versionStatus=submitted (superuser & owner)' do
+        xit 'submits dataset when the PATCH operation for versionStatus=submitted (curator & owner)' do
           response_code = patch "/api/v2/datasets/#{CGI.escape(@ds_info['identifier'])}",
                                 params: @patch_body,
                                 headers: default_authenticated_headers.merge('Content-Type' => 'application/json-patch+json')

--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -22,7 +22,7 @@ module StashApi
       mock_ror!
       mock_tenant!
       mock_datacite_and_idgen!
-      @user = create(:user, role: 'curator', tenant_id: 'dryad')
+      @user = create(:user, role: 'superuser', tenant_id: 'dryad')
       @doorkeeper_application = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
                                                                 owner_id: @user.id, owner_type: 'StashEngine::User')
       setup_access_token(doorkeeper_application: @doorkeeper_application)
@@ -55,7 +55,7 @@ module StashApi
         expect(out_author[:affiliation]).to eq(in_author[:affiliation])
       end
 
-      it 'creates a new dataset with a userId explicitly set by curator)' do
+      it 'creates a new dataset with a userId explicitly set by superuser)' do
         test_user = StashEngine::User.create(first_name: Faker::Name.first_name,
                                              last_name: Faker::Name.last_name,
                                              email: Faker::Internet.email)
@@ -355,7 +355,7 @@ module StashApi
           expect(output[:count]).to eq(5)
         end
 
-        it 'gets a list of all datasets because curators are omniscient' do
+        it 'gets a list of all datasets because superusers are omniscient' do
           get '/api/v2/datasets', headers: default_authenticated_headers
           output = response_body_hash
           expect(output[:count]).to eq(@identifiers.count)
@@ -421,7 +421,7 @@ module StashApi
           expect(hsh['_embedded']['stash:datasets'][0]['versionNumber']).to eq(1)
         end
 
-        it 'shows the 2nd, unpublished version to curators who see everything by default' do
+        it 'shows the 2nd, unpublished version to superusers who see everything by default' do
 
           get '/api/v2/datasets', headers: default_authenticated_headers
           hsh = response_body_hash
@@ -560,7 +560,7 @@ module StashApi
         expect(hsh['editLink']).to eq(nil)
       end
 
-      it 'shows the private record for curator' do
+      it 'shows the private record for superuser' do
         @identifier.edit_code = Faker::Number.number(digits: 6)
         @identifier.save
         get "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}", headers: default_authenticated_headers
@@ -606,7 +606,7 @@ module StashApi
       end
 
       describe 'PATCH to submit dataset' do
-        xit 'submits dataset when the PATCH operation for versionStatus=submitted (curator & owner)' do
+        xit 'submits dataset when the PATCH operation for versionStatus=submitted (superuser & owner)' do
           response_code = patch "/api/v2/datasets/#{CGI.escape(@ds_info['identifier'])}",
                                 params: @patch_body,
                                 headers: default_authenticated_headers.merge('Content-Type' => 'application/json-patch+json')

--- a/stash/stash_api/app/controllers/stash_api/application_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/application_controller.rb
@@ -92,13 +92,13 @@ module StashApi
     end
 
     def require_curator
-      return if %w[superuser tenant_curator].include?(@user.role)
+      return if %w[superuser curator tenant_curator].include?(@user.role)
 
       render json: { error: 'unauthorized' }.to_json, status: 401
     end
 
     def require_admin
-      return if %w[superuser admin tenant_curator].include?(@user.role) ||
+      return if %w[superuser curator admin tenant_curator].include?(@user.role) ||
                 @user.journals_as_admin.present?
 
       render json: { error: 'unauthorized' }.to_json, status: 401

--- a/stash/stash_api/app/controllers/stash_api/datasets/submission_mixin.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets/submission_mixin.rb
@@ -36,7 +36,7 @@ module SubmissionMixin
 
   def errors_for_completions
     completions = StashDatacite::Resource::Completions.new(@resource)
-    if @resource.loosen_validation && @user.superuser?
+    if @resource.loosen_validation && @user.curator?
       completions.relaxed_warnings
     else
       completions.all_warnings

--- a/stash/stash_datacite/app/views/stash_datacite/authors/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/_form.html.erb
@@ -32,7 +32,7 @@
 	author.author_orcid.blank? &&
 	author.author_email.present? &&
 	author.resource.identifier.pub_state == 'published' &&
-	current_user&.role == 'superuser'
+	current_user&.curator?
     %>
 	<span>
 	    Link to associate ORCID: <%= author.orcid_invite_path %>

--- a/stash/stash_datacite/app/views/stash_datacite/authors/_show.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/_show.html.erb
@@ -1,7 +1,7 @@
 <% unless authors.nil? %>
     <% authors.each do |author| %>
 	<div class="o-metadata__group1">
-	    <% if current_user && current_user.role == 'superuser' %>
+	    <% if current_user && current_user.curator? %>
 		<%= ([ (author.author_full_name ?
 			"<span class='o-metadata__author'>#{h(author.author_full_name)}</span>" : nil) ] +
 		     author.affiliations.map{|i|

--- a/stash/stash_datacite/app/views/stash_datacite/contributors/_show.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/contributors/_show.html.erb
@@ -2,7 +2,7 @@
 <% unless contributors.nil? || contributors.length < 1 %>
   <h2 class="o-heading__level2">Funding</h2>
   <% contributors.each do |contributor| %>
-      <% if current_user && current_user.role == 'superuser' %>
+      <% if current_user && current_user.curator? %>
 	  <p><%= contributor.contributor_name_friendly(show_asterisk: true) %><%= "," %>
       <% else %>
 	  <p><%= contributor.contributor_name_friendly %><%= "," %>

--- a/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_landing_related_works.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_landing_related_works.html.erb
@@ -3,7 +3,7 @@
   <h3 class="o-heading__level3-related-works"><%= (my_ids.count > 1 ? wt.work_type_friendly_plural : wt.work_type_friendly) %></h3>
   <ul class="o-list-related">
     <% my_ids.each do |r| %>
-      <% bad_asterisk = ( (current_user&.role == 'superuser' && !r.verified?) ? ' *' : '') %>
+      <% bad_asterisk = ( (current_user&.curator? && !r.verified?) ? ' *' : '') %>
       <li>
         <% if r.work_type == 'undefined' %>
           This dataset <%= r.relation_name_english %>

--- a/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_show.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_show.html.erb
@@ -3,7 +3,7 @@
   <ul class="o-list">
     <% related_identifiers.each do |r| %>
       <% if r.work_type == 'undefined' %>
-	 <% bad_asterisk = ( (current_user&.role == 'superuser' && !r.verified?) ? ' *' : '') %>
+	 <% bad_asterisk = ( (current_user&.curator? && !r.verified?) ? ' *' : '') %>
         <li>This dataset <%= r.relation_name_english %>
           <%= display_id(type: r.related_identifier_type,
                          my_id: r.related_identifier) %><%= bad_asterisk %></li>

--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -12,13 +12,14 @@ module StashEngine
 
     TENANT_IDS = Tenant.all.map(&:tenant_id)
 
-    # the admin datasets main page showing users and stats, but slightly different in scope for superusers vs tenant admins
+    # the admin datasets main page showing users and stats, but slightly different in scope for curators vs tenant admins
     # rubocop:disable Metrics/AbcSize
     def index
       my_tenant_id = (%w[admin tenant_curator].include?(current_user.role) ? current_user.tenant_id : nil)
       tenant_limit = (%w[admin tenant_curator].include?(current_user.role) ? current_user.tenant : nil)
       journal_limit = (if current_user.role != 'superuser' &&
-                        current_user.journals_as_admin.present?
+                          current_user.role != 'curator' &&
+                          current_user.journals_as_admin.present?
                          current_user.journals_as_admin.map(&:title)
                        end)
 

--- a/stash/stash_engine/app/controllers/stash_engine/landing_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/landing_controller.rb
@@ -20,7 +20,7 @@ module StashEngine
     helper_method :id
 
     # -- gets the resource for display from the identifier --
-    # some users get to see more than the public such as owners, superusers, admins
+    # some users get to see more than the public such as owners, curators, admins
     def resource
       return @resource unless @resource.nil?
 

--- a/stash/stash_engine/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/publication_updater_controller.rb
@@ -6,10 +6,10 @@ module StashEngine
     include SharedSecurityController
     helper SortableTableHelper
 
-    before_action :require_superuser
+    before_action :require_curator
     before_action :setup_paging, only: [:index]
 
-    # the admin datasets main page showing users and stats, but slightly different in scope for superusers vs tenant admins
+    # the admin datasets main page showing users and stats, but slightly different in scope for curators vs tenant admins
     def index
       proposed_changes = StashEngine::ProposedChange.includes(identifier: :resources)
         .joins(identifier: :resources).where(approved: false, rejected: false)

--- a/stash/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
@@ -4,7 +4,7 @@ module StashEngine
     def self.included(c)
       c.helper_method \
         %i[
-          owner? admin? superuser?
+          owner? admin? curator? superuser?
         ]
     end
 
@@ -50,18 +50,18 @@ module StashEngine
     end
 
     def require_curator
-      return if current_user && %w[superuser tenant_curator].include?(current_user.role)
+      return if current_user && %w[superuser curator tenant_curator].include?(current_user.role)
 
       flash[:alert] = 'You must be a curator to view this information.'
       redirect_to stash_engine.dashboard_path
     end
 
     def ajax_require_curator
-      return false unless current_user && %w[superuser tenant_curator].include?(current_user.role)
+      return false unless current_user && %w[superuser curator tenant_curator].include?(current_user.role)
     end
 
     def require_admin
-      return if current_user && (%w[admin superuser tenant_curator].include?(current_user.role) ||
+      return if current_user && (%w[admin superuser curator tenant_curator].include?(current_user.role) ||
                                  current_user.journals_as_admin.present?)
 
       flash[:alert] = 'You must be an administrator to view this information.'
@@ -80,7 +80,7 @@ module StashEngine
     def require_in_progress_editor
       return if valid_edit_code? ||
                 resource.dataset_in_progress_editor.id == current_user.id ||
-                current_user.superuser?
+                current_user.curator?
 
       display_authorization_failure
     end
@@ -102,6 +102,10 @@ module StashEngine
 
     def admin?(resource:)
       resource&.admin_for_this_item?(user: current_user)
+    end
+
+    def curator?
+      current_user.present? && current_user.curator?
     end
 
     def superuser?

--- a/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
+++ b/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
@@ -101,7 +101,7 @@ module StashEngine
         # params are params from the form.
         # The tenant, if set, does two things in conjunction.  it limits to items with a tenant_id of the tenant OR
         # affiliated author institution RORs (may be multiple) for this tenant with additional joins and conditions.
-        # tenant is only set for admins (not superusers).
+        # tenant is only set for tenant admins (not superusers or curators).
         # The journals, if set, limits to items associated with one of the given journals.
         #
         # if resource_id is set then only returns that resource id

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -34,7 +34,7 @@ module StashEngine
     scope :user_viewable, ->(user: nil) do
       if user.nil?
         publicly_viewable
-      elsif user.superuser?
+      elsif user.curator?
         all
       else
         tenant_admin = (user.tenant_id if user.role == 'admin')

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -220,7 +220,7 @@ module StashEngine
     scope :visible_to_user, ->(user:) do
       if user.nil?
         with_visibility(states: %w[published embargoed])
-      elsif user.superuser?
+      elsif user.curator?
         all
       else
         tenant_admin = (user.tenant_id if user.role == 'admin')
@@ -552,13 +552,13 @@ module StashEngine
 
     # can edit means they are not locked out because edits in progress and have permission
     def can_edit?(user:)
-      permission_to_edit?(user: user) && (dataset_in_progress_editor.id == user.id || user.superuser?)
+      permission_to_edit?(user: user) && (dataset_in_progress_editor.id == user.id || user.curator?)
     end
 
     def admin_for_this_item?(user: nil)
       return false if user.nil?
 
-      user.superuser? ||
+      user.curator? ||
         user_id == user.id ||
         (user.tenant_id == tenant_id && user.role == 'tenant_curator') ||
         (user.tenant_id == tenant_id && user.role == 'admin') ||
@@ -570,7 +570,7 @@ module StashEngine
     def permission_to_edit?(user:)
       return false unless user
 
-      # superuser, dataset owner or admin for the same tenant
+      # cuartor, dataset owner or admin for the same tenant
       admin_for_this_item?(user: user)
     end
 

--- a/stash/stash_engine/app/models/stash_engine/user.rb
+++ b/stash/stash_engine/app/models/stash_engine/user.rb
@@ -6,7 +6,7 @@ module StashEngine
     has_many :journals, through: :journal_roles
 
     scope :curators, -> do
-      where(role: %w[superuser tenant_curator])
+      where(role: %w[superuser curator tenant_curator])
     end
 
     def self.from_omniauth_orcid(auth_hash:, emails:)
@@ -34,6 +34,10 @@ module StashEngine
 
     def superuser?
       role == 'superuser'
+    end
+
+    def curator?
+      role == 'superuser' || role == 'curator'
     end
 
     def journals_as_admin

--- a/stash/stash_engine/app/views/stash_engine/admin/_admin_level_form.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin/_admin_level_form.html.erb
@@ -2,7 +2,7 @@
 <div class="o-admin-dialog">
   <p>Choose <%= "#{user.first_name} #{user.last_name}".strip %>&apos;s Role</p>
   <%
-    role_radios = [ ['user', 'User'], ['admin', 'Administrator'], ['superuser', 'Superuser'] ]
+    role_radios = [ ['user', 'User'], ['admin', 'Administrator'], ['curator', 'Curator'], ['superuser', 'Superuser'] ]
     role_radios.pop if current_user.role == 'admin' # don't give admins a choice to make a superuser
   %>
 

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_datasets_row.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_datasets_row.html.erb
@@ -28,7 +28,7 @@
     <% end %>
   </td>
   <td class="c-admin-hide-border-left">
-      <% if (%w[superuser tenant_curator].include?(current_user.role) &&
+      <% if (%w[superuser curator tenant_curator].include?(current_user.role) &&
 	     dataset.resource&.permission_to_edit?(user: current_user) &&
 	     dataset.resource_state == 'submitted') %>
       <%= form_with(url: url_for(controller: '/stash_engine/admin_datasets',
@@ -66,7 +66,7 @@
   <!-- Curation -->
   <td class="c-admin-hide-border-right" id="js-curation-activity-user-<%= dataset.identifier_id %>"><%= dataset.editor_name %></td>
   <td class="c-admin-hide-border-left">
-      <% if (%w[superuser tenant_curator].include?(current_user.role) &&
+      <% if (%w[superuser curator tenant_curator].include?(current_user.role) &&
 	     dataset.resource&.permission_to_edit?(user: current_user) &&
              dataset.resource.curatable?) %>
 	  <%= form_with(url: url_for(controller: '/stash_engine/admin_datasets',

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_edit_dataset_button.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_edit_dataset_button.html.erb
@@ -1,4 +1,4 @@
-<% if %w[superuser tenant_curator].include?(current_user.role) %>
+<% if %w[superuser curator tenant_curator].include?(current_user.role) %>
   <%= form_with(url: metadata_entry_pages_new_version_path, method: :post, local: true) do -%>
     <button class="c-admin-edit-icon js-trap-curator-url" title="Edit Dataset"><i class="fa fa-pencil" aria-hidden="true"></i></button>
     <%= hidden_field_tag :resource_id, resource_id, id: "resource_id_#{resource_id}" %>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_filter.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_filter.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(url: url_for(controller: '/stash_engine/admin_datasets', action: 'index', only_path: true),
               method: 'get', id: 'filter_form', local: true) do -%>
   <label for="tenant" class="c-horizontal-form__input--filter-by">Filter by:</label>
-  <% if current_user.superuser? %>
+  <% if current_user.curator? %>
     <%= select_tag(:tenant, options_for_select( [['Institution', '']] + institution_select, params[:tenant]),
                    class: 'c-horizontal-form__input', onchange: "this.form.submit();" ) %>
 

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/activity_log.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/activity_log.html.erb
@@ -3,7 +3,7 @@
 
 <div>
   <div style="float: left;"><br/><%= @identifier.to_s %></div>
-  <% if %w[admin superuser tenant_curator].include?(current_user.role) %>
+  <% if %w[admin superuser curator tenant_curator].include?(current_user.role) %>
     <div style="float: right;">
       <%= form_with(url: url_for(controller: '/stash_engine/admin_datasets', action: 'note_popup', id: @identifier&.id, only_path: true),
                     method: :get, remote: true) do -%>
@@ -41,7 +41,7 @@
 
 <div id="internal_data">
   <div style="float: left"><h2>Internal Data</h2></div>
-  <% if %w[admin superuser tenant_curator].include?(current_user.role) %>
+  <% if %w[admin superuser curator tenant_curator].include?(current_user.role) %>
     <div style="float: right">
       <br/>
       <%= form_with(url: url_for(controller: '/stash_engine/admin_datasets', action: 'data_popup', id: @identifier.id,
@@ -60,7 +60,7 @@
 <div id="popup_dialog" style="display:none;">
 </div>
 
-<% if current_user.superuser? %>
+<% if current_user.curator? %>
     <div id="dangerous_actions">
 	<div style="float: left"><h2>Dangerous Actions</h2>
 

--- a/stash/stash_engine/app/views/stash_engine/pages/_nav.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/pages/_nav.html.erb
@@ -10,7 +10,7 @@
     <% if current_user && %w[development test local_dev].include?(Rails.env) %>
       <span class="c-header__nav-item" title="<%= current_user.email %>" style="color: blue;">[<%= current_user.name %>@<%= current_tenant&.tenant_id %>]</span>
     <% end %>
-    <% if current_user && current_user.role == 'superuser' %>
+    <% if current_user && current_user.curator? %>
       <div class="c-header__nav-item">
         <div class="o-sites">
           <details class="o-showhide o-sites__details" role="group">
@@ -19,10 +19,12 @@
 		<%= link_to 'Dataset Curation', stash_url_helpers.url_for(controller: 'stash_engine/admin_datasets', action: 'index', only_path: true), class: 'o-sites__group-item' %>
 		<%= link_to 'Curation Stats', stash_url_helpers.curation_stats_path, class: 'o-sites__group-item' %>
 		<%= link_to 'Journals', stash_url_helpers.journals_path, class: 'o-sites__group-item' %>
-              <%= link_to 'Publication Updater', stash_url_helpers.publication_updater_path, class: 'o-sites__group-item' %>
-              <%= link_to 'Status Dashboard', stash_url_helpers.status_dashboard_path, class: 'o-sites__group-item' %>
-              <%= link_to 'Submission Queue', stash_url_helpers.url_for(controller: 'stash_engine/submission_queue', action: 'index', only_path: true), class: 'o-sites__group-item' %>
-              <%= link_to 'Zenodo Submissions', stash_url_helpers.zenodo_queue_path, class: 'o-sites__group-item' %>
+		<%= link_to 'Publication Updater', stash_url_helpers.publication_updater_path, class: 'o-sites__group-item' %>
+		<% if current_user.superuser? %>
+		    <%= link_to 'Status Dashboard', stash_url_helpers.status_dashboard_path, class: 'o-sites__group-item' %>
+		    <%= link_to 'Submission Queue', stash_url_helpers.url_for(controller: 'stash_engine/submission_queue', action: 'index', only_path: true), class: 'o-sites__group-item' %>
+		    <%= link_to 'Zenodo Submissions', stash_url_helpers.zenodo_queue_path, class: 'o-sites__group-item' %>
+		<% end %>
             </div>
           </details>
         </div>

--- a/stash/stash_engine/app/views/stash_engine/sessions/test_login.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/sessions/test_login.html.erb
@@ -28,7 +28,7 @@
 
   <p>
     <%= label_tag(:role, 'Role') %><br/>
-    <%= select_tag :role, options_for_select([ ['User', 'user'], ['Admin', 'admin'], ['Superuser', 'superuser'] ]), class: '.o-select' %>
+    <%= select_tag :role, options_for_select([ ['User', 'user'], ['Admin', 'admin'], ['Curator', 'curator'], ['Superuser', 'superuser'] ]), class: '.o-select' %>
   </p>
 
   <p>

--- a/stash/stash_engine/db/migrate/20210713181140_add_curator_role.rb
+++ b/stash/stash_engine/db/migrate/20210713181140_add_curator_role.rb
@@ -1,0 +1,7 @@
+class AddCuratorRole < ActiveRecord::Migration[5.2]
+  def change
+    execute <<-SQL
+      ALTER TABLE stash_engine_users MODIFY role ENUM('superuser', 'curator', 'admin', 'user', 'tenant_curator')
+    SQL
+  end
+end


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1288

- Adds a new `curator` role
- Converts many `superuser` permissions, allowing them to be accessible by curators
- Tools that are primarily used by developers are now accessible only by `superuser`
