### PR TITLE
Peer review and edit_url fixes

### DIFF
--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -177,6 +177,7 @@ module StashApi
 
         expect(ident).to be
         expect(ident.publication_name).to eq(hsh[:journal_full_title])
+        expect(res.hold_for_peer_review).to be_truthy
         expect(res.authors.first.author_first_name).to eq(hsh[:authors].first[:first_name])
         expect(res.authors.first.author_last_name).to eq(hsh[:authors].first[:last_name])
         expect(res.authors.first.author_orcid).to eq(hsh[:authors].first[:orcid])

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -224,18 +224,12 @@ module StashApi
 
     # Reformat a `metadata` response object, putting it in the format that Editorial Manager prefers
     def em_reformat_response(metadata)
-      
-#      deposit_url = metadata[:sharingLink] || (if metadata[:_links][:self][:href]
-#                                                 request.protocol + request.host_with_port + metadata[:_links][:self][:href]
-      #                                               end)
-      deposit_url = @stash_identifier.shares&.first&.sharing_link
-      puts "XXXX  sharingLink #{metadata[:sharingLink]} depURL = #{deposit_url}"
+      sharing_link = @stash_identifier.shares&.first&.sharing_link
       edit_url = (request.protocol + request.host_with_port + metadata[:editLink] if metadata[:editLink])
-
       {
         deposit_id: @stash_identifier.identifier,
         deposit_doi: @stash_identifier.identifier,
-        deposit_url: deposit_url,
+        deposit_url: sharing_link,
         deposit_edit_url: edit_url,
         deposit_upload_url: edit_url,
         status: 'Success'

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -67,6 +67,10 @@ module StashApi
                    DatasetParser.new(hash: em_reformat_request, id: nil, user: @user)
                  end
             @stash_identifier = dp.parse
+
+            # By default, we select the peer review checkbox, since EM will be using the review URL
+            @stash_identifier.latest_resource.update(hold_for_peer_review: true)
+
             ds = Dataset.new(identifier: @stash_identifier.to_s, user: @user) # sets up display objects
             render json: em_reformat_response(ds.metadata), status: 201
           end

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -224,17 +224,20 @@ module StashApi
 
     # Reformat a `metadata` response object, putting it in the format that Editorial Manager prefers
     def em_reformat_response(metadata)
-      deposit_url = metadata[:sharingLink] || (if metadata[:_links][:self][:href]
-                                                 request.protocol + request.host_with_port + metadata[:_links][:self][:href]
-                                               end)
+      
+#      deposit_url = metadata[:sharingLink] || (if metadata[:_links][:self][:href]
+#                                                 request.protocol + request.host_with_port + metadata[:_links][:self][:href]
+      #                                               end)
+      deposit_url = @stash_identifier.shares&.first&.sharing_link
+      puts "XXXX  sharingLink #{metadata[:sharingLink]} depURL = #{deposit_url}"
       edit_url = (request.protocol + request.host_with_port + metadata[:editLink] if metadata[:editLink])
 
       {
-        deposit_id: @stash_identifier.identifier + "DEPOSIT_ID",
-        deposit_doi: @stash_identifier.identifier + "DEPOSIT_DOI",
-        deposit_url: deposit_url + "DEPOSIT_URL",
-        deposit_edit_url: edit_url + "EDIT_URL",
-        deposit_upload_url: edit_url + "DEPOSIT_UPLOAD_URL",
+        deposit_id: @stash_identifier.identifier,
+        deposit_doi: @stash_identifier.identifier,
+        deposit_url: deposit_url,
+        deposit_edit_url: edit_url,
+        deposit_upload_url: edit_url,
         status: 'Success'
       }.compact
     end

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -230,11 +230,11 @@ module StashApi
       edit_url = (request.protocol + request.host_with_port + metadata[:editLink] if metadata[:editLink])
 
       {
-        deposit_id: @stash_identifier.identifier,
-        deposit_doi: @stash_identifier.identifier,
-        deposit_url: deposit_url,
-        deposit_edit_url: edit_url,
-        deposit_upload_url: edit_url,
+        deposit_id: @stash_identifier.identifier + "DEPOSIT_ID",
+        deposit_doi: @stash_identifier.identifier + "DEPOSIT_DOI",
+        deposit_url: deposit_url + "DEPOSIT_URL",
+        deposit_edit_url: edit_url + "EDIT_URL",
+        deposit_upload_url: edit_url + "DEPOSIT_UPLOAD_URL",
         status: 'Success'
       }.compact
     end

--- a/stash/stash_api/app/models/stash_api/version/metadata.rb
+++ b/stash/stash_api/app/models/stash_api/version/metadata.rb
@@ -47,20 +47,16 @@ module StashApi
       end
 
       def sharing_link
-        puts "XXXXXX making sharing link!!!"
         curation_activity = StashEngine::CurationActivity.latest(resource: @resource)
         case curation_activity.status
         when 'in_progress'
-          puts "a #{@resource.identifier.shares.first.sharing_link}"
           # if it's in_progress, return the sharing_link for the previous submitted version
           prev_submitted_res = @resource&.identifier&.last_submitted_resource
           prev_submitted_res&.identifier&.shares&.first&.sharing_link
         when 'embargoed', 'withdrawn'
-          puts "b"
         # suppress the link -- even if the user has the rights to view
         # the metadata, they should not be downloading it
         else
-          puts "c"
           @resource&.identifier&.shares&.first&.sharing_link
         end
       end

--- a/stash/stash_api/app/models/stash_api/version/metadata.rb
+++ b/stash/stash_api/app/models/stash_api/version/metadata.rb
@@ -47,16 +47,20 @@ module StashApi
       end
 
       def sharing_link
+        puts "XXXXXX making sharing link!!!"
         curation_activity = StashEngine::CurationActivity.latest(resource: @resource)
         case curation_activity.status
         when 'in_progress'
+          puts "a #{@resource.identifier.shares.first.sharing_link}"
           # if it's in_progress, return the sharing_link for the previous submitted version
           prev_submitted_res = @resource&.identifier&.last_submitted_resource
           prev_submitted_res&.identifier&.shares&.first&.sharing_link
         when 'embargoed', 'withdrawn'
+          puts "b"
         # suppress the link -- even if the user has the rights to view
         # the metadata, they should not be downloading it
         else
+          puts "c"
           @resource&.identifier&.shares&.first&.sharing_link
         end
       end

--- a/stash/stash_engine/app/controllers/stash_engine/metadata_entry_pages_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/metadata_entry_pages_controller.rb
@@ -61,7 +61,11 @@ module StashEngine
         redirect_to choose_sso_path and return if current_user.tenant_id.blank?
       end
 
-      redirect_to(metadata_entry_pages_find_or_create_path(resource_id: resource.id))
+      if @resource&.current_resource_state&.resource_state != 'in_progress'
+        new_version
+      else
+        redirect_to(metadata_entry_pages_find_or_create_path(resource_id: resource.id))
+      end
     end
     # rubocop:enable Metrics/AbcSize
 

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -68,7 +68,7 @@ module StashEngine
       # once we receive a notification from the journal, we know that the manuscript is no longer in
       # review, so remove the hold_for_peer_review setting
       resource.update(hold_for_peer_review: false)
-      
+
       StashEngine::CurationActivity.create(resource: resource,
                                            status: target_status,
                                            user_id: 0,  # system user

--- a/stash/stash_engine/app/models/stash_engine/manuscript.rb
+++ b/stash/stash_engine/app/models/stash_engine/manuscript.rb
@@ -65,6 +65,10 @@ module StashEngine
 
       return unless target_status
 
+      # once we receive a notification from the journal, we know that the manuscript is no longer in
+      # review, so remove the hold_for_peer_review setting
+      resource.update(hold_for_peer_review: false)
+      
       StashEngine::CurationActivity.create(resource: resource,
                                            status: target_status,
                                            user_id: 0,  # system user

--- a/stash/stash_engine/app/views/stash_engine/downloads/share.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/downloads/share.html.erb
@@ -10,7 +10,7 @@
   for this dataset that is currently private for peer review.
 </p>
 
-<p>If the download process does not begin automatically within several seconds, click the link above to start the download.</p>
+<p>If the download process does not begin automatically within several minutes, click the link above to start the download.</p>
 
 <%
     sfw = @resource.software_files.present_files


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1364 and https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1339

Several little fixes for curators and EM:
- When dataset status is updated by a journal metadata email, remove hold_for_peer_review (aka the PPR checkbox)
- When dataset is created by the EM API, default the PPR checkbox to "true"
- Ensure EM receives the sharing_link, regardless of the dataset's status. It won't return much until the dataset is actually submitted, but EM caches this URL early in their process, so they need it even with the initial API call
- When a user visits the EM edit_url, allow them to edit the dataset, regardless of its status, creating a new version if needed