### PR TITLE
Migrate over 50gb

### DIFF
--- a/lib/tasks/zenodo.rake
+++ b/lib/tasks/zenodo.rake
@@ -9,7 +9,7 @@ namespace :zenodo do
     end
 
     # try to only fill the queue to this level, will be re-filled frequently, anyway
-    max_feed_queue = 8
+    max_feed_queue = 1  # only start another long (50GB+) when nothing much is happening since these take forever, don't monopolize queue
 
     sql = <<~SQL.strip
       SELECT ids.* FROM stash_engine_identifiers ids
@@ -17,7 +17,7 @@ namespace :zenodo do
         ON ids.id = cops.identifier_id
       WHERE ids.pub_state = 'published'
         AND cops.id IS NULL
-        AND ids.storage_size < 1e+10
+        AND ids.storage_size < 1e+50
       ORDER BY RAND()
       LIMIT #{max_feed_queue};
     SQL

--- a/lib/tasks/zenodo.rake
+++ b/lib/tasks/zenodo.rake
@@ -9,7 +9,7 @@ namespace :zenodo do
     end
 
     # try to only fill the queue to this level, will be re-filled frequently, anyway
-    max_feed_queue = 1  # only start another long (50GB+) when nothing much is happening since these take forever, don't monopolize queue
+    max_feed_queue = 1 # only start another long (50GB+) when nothing much is happening since these take forever, don't monopolize queue
 
     sql = <<~SQL.strip
       SELECT ids.* FROM stash_engine_identifiers ids

--- a/lib/tasks/zenodo.rake
+++ b/lib/tasks/zenodo.rake
@@ -17,7 +17,7 @@ namespace :zenodo do
         ON ids.id = cops.identifier_id
       WHERE ids.pub_state = 'published'
         AND cops.id IS NULL
-        AND ids.storage_size < 1e+50
+        AND ids.storage_size > 5e+10
       ORDER BY RAND()
       LIMIT #{max_feed_queue};
     SQL

--- a/stash/stash_engine/config/initializers/delayed_job_config.rb
+++ b/stash/stash_engine/config/initializers/delayed_job_config.rb
@@ -3,8 +3,8 @@ require 'delayed_job_active_record'
 
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.sleep_delay = 60
-Delayed::Worker.max_attempts = 2
-Delayed::Worker.max_run_time = 6.hours
+Delayed::Worker.max_attempts = 1 # fail for now because trying again during a time of unreliablity doesn't help
+Delayed::Worker.max_run_time = 24.hours
 # Was going to change, but looks like read ahead is ignored for MySQL and if using priority, anyway.
 # https://stackoverflow.com/questions/35734246/how-does-priority-interact-with-read-ahead-in-delayed-job
 Delayed::Worker.read_ahead = 5


### PR DESCRIPTION
Very small pull request:
- change queue feeder to > 50GB
- only add one of the super-monopolizer datasets when nothing else is running.  They take a worker forever, maybe up to 24 hours until they free that worker again.
- Timeout up to 24-hours for the overall worker (we have read and write timeouts on http requests that are much shorter and I hope we now catch all the common errors).
- Don't have delayed_job auto-retry stuff since we have lots of internal retrying already for requests and also we have a cron that retries daily.  Also doing some manual retrying.