### PR TITLE
In EM API, only return the deposit_upload_url for "deposit" calls

### DIFF
--- a/spec/responses/stash_api/datasets_controller_spec.rb
+++ b/spec/responses/stash_api/datasets_controller_spec.rb
@@ -182,6 +182,7 @@ module StashApi
         expect(res.authors.first.author_last_name).to eq(hsh[:authors].first[:last_name])
         expect(res.authors.first.author_orcid).to eq(hsh[:authors].first[:orcid])
         expect(res.authors.first.author_email).to eq(hsh[:authors].first[:email])
+        expect(output[:deposit_upload_url]).to be_truthy
       end
 
       it 'creates a new dataset from EM submission metadata' do
@@ -199,6 +200,7 @@ module StashApi
 
         dd = hsh['deposit_data']
         expect(res.title).to eq(dd['deposit_description'])
+        expect(output[:deposit_upload_url]).to be_falsey
       end
 
       it 'allows update of deposit metadata with new submission metadata' do

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -54,6 +54,7 @@ module StashApi
       # reformatted before and after the normal processing.
       respond_to do |format|
         format.any do
+          deposit_request = params['article'].blank?
           if @stash_identifier&.first_submitted_resource.present?
             # Once the dataset has been submitted by an author, only update selected fields,
             # but don't fully process the metadata from EM
@@ -72,7 +73,7 @@ module StashApi
             @stash_identifier.latest_resource.update(hold_for_peer_review: true)
 
             ds = Dataset.new(identifier: @stash_identifier.to_s, user: @user) # sets up display objects
-            render json: em_reformat_response(ds.metadata), status: 201
+            render json: em_reformat_response(metadata: ds.metadata, deposit_request: deposit_request), status: 201
           end
         end
       end
@@ -223,7 +224,7 @@ module StashApi
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
 
     # Reformat a `metadata` response object, putting it in the format that Editorial Manager prefers
-    def em_reformat_response(metadata)
+    def em_reformat_response(metadata:, deposit_request:)
       sharing_link = @stash_identifier.shares&.first&.sharing_link
       edit_url = (request.protocol + request.host_with_port + metadata[:editLink] if metadata[:editLink])
       {
@@ -231,7 +232,7 @@ module StashApi
         deposit_doi: @stash_identifier.identifier,
         deposit_url: sharing_link,
         deposit_edit_url: edit_url,
-        deposit_upload_url: edit_url,
+        deposit_upload_url: deposit_request ? edit_url : nil,
         status: 'Success'
       }.compact
     end


### PR DESCRIPTION
EM sends two types of requests: "desposit" and "submission". The requests and responses for these requests are virtually identical, with the primary difference being that the "deposit" call typically includes less metadata. In Dryad, the two calls are treated the same. 

EM has recently had difficulty handling a response for "submission" calls when the response includes the field `deposit_upload_url`. This PR suppresses that field when the request is not a "deposit" request.