### PR TITLE
Be more aggressive about updating zenodo related works

### DIFF
--- a/spec/lib/stash/zenodo_software/copier_spec.rb
+++ b/spec/lib/stash/zenodo_software/copier_spec.rb
@@ -129,6 +129,15 @@ module Stash
             expect(@zc.error_info).to start_with('Nothing to submit to Zenodo')
           end
 
+          it 'calls to synchronize the zenodo related works, even if there is not software' do
+            @file.destroy
+            expect(StashDatacite::RelatedIdentifier).to receive(:set_latest_zenodo_relations).with(resource: @resource)
+            @zsc.add_to_zenodo
+            @zc.reload
+            expect(@zc.state).to eq('finished')
+            expect(@zc.error_info).to start_with('Nothing to submit to Zenodo')
+          end
+
           it "rejects a submission if earlier software versions haven't been replicated" do
             # use the default replication as the earlier version but without any replication info in zenodo_copy table
             @zc.destroy

--- a/stash/stash_engine/lib/stash/zenodo_software/copier.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/copier.rb
@@ -106,6 +106,9 @@ module Stash
         @copy.update(deposition_id: @resp[:id], software_doi: @resp[:metadata][:prereserve_doi][:doi],
                      conceptrecid: @resp[:conceptrecid])
 
+        # make sure the dataset has the relationships for these things synchronized to zenodo
+        StashDatacite::RelatedIdentifier.set_latest_zenodo_relations(resource: @resource)
+
         return publish_dataset if @copy.copy_type.end_with?('_publish')
 
         return metadata_only_update unless files_changed?

--- a/stash/stash_engine/lib/stash/zenodo_software/copier.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/copier.rb
@@ -86,6 +86,10 @@ module Stash
         error_if_out_of_order
         error_if_any_previous_unfinished
         error_if_more_than_one_replication_for_resource
+
+        # make sure the dataset has the relationships for these things synchronized to zenodo
+        StashDatacite::RelatedIdentifier.set_latest_zenodo_relations(resource: @resource)
+
         return if nothing_to_submit?
 
         @copy.update(state: 'replicating')
@@ -101,9 +105,6 @@ module Stash
         # update the database with current information on this dataset from Zenodo
         @copy.update(deposition_id: @resp[:id], software_doi: @resp[:metadata][:prereserve_doi][:doi],
                      conceptrecid: @resp[:conceptrecid])
-
-        # make sure the dataset has the relationships for these things sent to zenodo
-        StashDatacite::RelatedIdentifier.set_latest_zenodo_relations(resource: @resource)
 
         return publish_dataset if @copy.copy_type.end_with?('_publish')
 


### PR DESCRIPTION
Even if it doesn't notice changes in the files going to zenodo, update anyway.

(Add 1st synchronization of related works much earlier in the process, with a couple of synchronizations later just to be sure.)