### PR TITLE
Uncouple "primary" article DOI from other related works

### DIFF
--- a/documentation/local_testing_setup.md
+++ b/documentation/local_testing_setup.md
@@ -141,8 +141,8 @@ use commands like:
 - page.find_by_id('author_affiliation_long_name').value
 - page.document
 - page.current_url
-- page.execute_script("$('#internal_datum_doi').val('true')") #suppresses return value
-- page.evaluate_script("$('#internal_datum_doi')").first.value
+- page.execute_script("$('#doi').val('true')") #suppresses return value
+- page.evaluate_script("$('#doi')").first.value
   
 
 ## Notes about Rubocop, .ruby-version, Bundler and Rake

--- a/lib/tasks/publication_updater.rake
+++ b/lib/tasks/publication_updater.rake
@@ -8,7 +8,7 @@ namespace :publication_updater do
     FROM stash_engine_resources ser
       INNER JOIN stash_engine_identifiers sei ON ser.identifier_id = sei.id
       LEFT OUTER JOIN dcs_related_identifiers dri ON ser.id = dri.resource_id
-        AND dri.relation_type = 'cites' AND dri.related_identifier_type = 'doi'
+        AND dri.work_type = 'primary_article' AND dri.related_identifier_type = 'doi'
       INNER JOIN (SELECT MAX(r2.id) r_id FROM stash_engine_resources r2 GROUP BY r2.identifier_id) j1 ON j1.r_id = ser.id
       LEFT OUTER JOIN (SELECT ca2.resource_id, MAX(ca2.id) latest_curation_activity_id FROM stash_engine_curation_activities ca2 GROUP BY ca2.resource_id) j3 ON j3.resource_id = ser.id
       LEFT OUTER JOIN stash_engine_curation_activities seca ON seca.id = j3.latest_curation_activity_id

--- a/spec/features/stash_datacite/manuscript_populate_metadata_spec.rb
+++ b/spec/features/stash_datacite/manuscript_populate_metadata_spec.rb
@@ -108,7 +108,7 @@ RSpec.feature 'Populate manuscript metadata from outside source', type: :feature
       # Tell the form that we're really doing the import and not just an ajax autocomplete.
       # For normal use, this is set by javascript, but within rspec, it wasn't working properly,
       # so we force it here.
-      page.execute_script("$('#internal_datum_do_import').val('true')")
+      page.execute_script("$('#do_import').val('true')")
 
       click_button 'Import Article Metadata'
     end

--- a/spec/lib/stash_datacite/indexing_resource_spec.rb
+++ b/spec/lib/stash_datacite/indexing_resource_spec.rb
@@ -55,7 +55,7 @@ module Stash
         @resource_state = create(:resource_state, resource_id: @resource.id)
         @resource.update(current_resource_state_id: @resource_state.id)
         create(:related_identifier, resource_id: @resource.id, related_identifier_type: 'doi', relation_type: 'cites',
-                                    related_identifier: 'doi123')
+                                    related_identifier: 'doi123', work_type: 'primary_article')
         @version = create(:version, resource_id: @resource.id)
         @affil1 = create(:affiliation, long_name: 'Lafayette Tech', ror_id: 'https://ror.example.org/16xx22bs')
         @affil2 = create(:affiliation, long_name: 'Orinda Tech', ror_id: 'https://ror.example.org/18dl67sn1')

--- a/spec/models/stash_engine/identifier_spec.rb
+++ b/spec/models/stash_engine/identifier_spec.rb
@@ -430,7 +430,8 @@ module StashEngine
         @fake_article_doi = 'http://doi.org/10.1234/bogus-doi'
         allow_any_instance_of(Resource).to receive(:related_identifiers).and_return([OpenStruct.new(related_identifier: @fake_article_doi,
                                                                                                     related_identifier_type: 'doi',
-                                                                                                    relation_type: 'cites')])
+                                                                                                    relation_type: 'cites',
+                                                                                                    work_type: 'primary_article')])
         expect(@identifier.publication_article_doi).to eql(@fake_article_doi)
       end
     end

--- a/spec/support/helpers/dataset_helper.rb
+++ b/spec/support/helpers/dataset_helper.rb
@@ -73,16 +73,16 @@ module DatasetHelper
 
   def fill_manuscript_info(name:, issn:, msid:)
     choose('choose_manuscript')
-    page.execute_script("$('#internal_datum_publication').val('#{name}')")
-    page.execute_script("$('#internal_datum_publication_issn').val('#{issn}')") # must do to fill hidden field for issn
-    page.execute_script("$('#internal_datum_publication_name').val('#{name}')") # must do to fill hidden field for issn
-    fill_in 'internal_datum[msid]', with: msid
+    page.execute_script("$('#publication').val('#{name}')")
+    page.execute_script("$('#publication_issn').val('#{issn}')") # must do to fill hidden field for issn
+    page.execute_script("$('#publication_name').val('#{name}')") # must do to fill hidden field for issn
+    fill_in 'msid', with: msid
   end
 
   def fill_crossref_info(name:, doi:)
     choose('choose_published')
-    fill_in 'internal_datum[publication]', with: name
-    fill_in 'internal_datum[doi]', with: doi
+    fill_in 'publication', with: name
+    fill_in 'primary_article_doi', with: doi
   end
 
   def fill_in_author

--- a/stash/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
+++ b/stash/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
@@ -21,29 +21,29 @@ function loadPublications() {
             })
             .autocomplete({
 		// when page is loaded, IF the dataset has been filled in already,
-		// internal_datum_publication will have an ISSN (for a controlled value),
-		// or internal_datum_publication_name will have a text value, so use one of 
+		// publication will have an ISSN (for a controlled value),
+		// or publication_name will have a text value, so use one of 
 		// these values to fill in the journal title
 		create: function(a) {
-		    if($("#internal_datum_publication_issn").val()){
+		    if($("#publication_issn").val()){
 			$.ajax({
-                            url: "/stash_datacite/publications/issn/"+ $("#internal_datum_publication_issn").val(),
+                            url: "/stash_datacite/publications/issn/" + $("#publication_issn").val(),
                             dataType: "json",
                             success: function( data ) {
-				$("#internal_datum_publication").val("")
+				$("#publication").val("")
 				if (data.title != null) {
-				    $("#internal_datum_publication").val(data.title);
+				    $("#publication").val(data.title);
 				}
 			    }
 			});
-		    } else if($("#internal_datum_publication_name").val()){
-			$("#internal_datum_publication").val($("#internal_datum_publication_name").val())
+		    } else if($("#publication_name").val()){
+			$("#publication").val($("#publication_name").val())
 		    }
 		},
                 source: function (request, response) {
 		    // save the user's typed request in the database with an asterisk, in case they don't click on an autocomplete result
-		    $("#internal_datum_publication_name").val(request.term + "*");
-		    $("#internal_datum_publication_issn").val(''); // clear any ISSN that was saved previously
+		    $("#publication_name").val(request.term + "*");
+		    $("#publication_issn").val(''); // clear any ISSN that was saved previously
 		    var form = $(this.form);
                     $(form).trigger('submit.rails');
 		    $.ajax({
@@ -70,8 +70,8 @@ function loadPublications() {
                 select: function( event, ui ) {
                     new_value = ui.item.value;
                     new_label = ui.item.label;
-                    $("#internal_datum_publication_issn").val(new_value);
-                    $("#internal_datum_publication_name").val(new_label);
+                    $("#publication_issn").val(new_value);
+                    $("#publication_name").val(new_label);
                     ui.item.value = ui.item.label;
                     var form = $(this.form);
                     $(form).trigger('submit.rails');
@@ -106,7 +106,7 @@ function loadPublications() {
     // trap the submit button, change hidden 'do_import' = 'true' and then submit when this button is clicked
     $('.js-populate-submit').click(function(e){
         e.preventDefault();
-        $('#internal_datum_do_import').val('true');
+        $('#do_import').val('true');
         $(this).closest("form").submit();
     });
 

--- a/stash/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
@@ -8,7 +8,6 @@ module StashDatacite
       @metadata_entry = Resource::MetadataEntry.new(@resource, current_tenant)
       @metadata_entry.resource_type
       se_id = StashEngine::Identifier.find(@resource.identifier_id)
-      puts "se_id #{se_id}"
       @publication_issn = StashEngine::InternalDatum.find_or_initialize_by(stash_identifier: se_id, data_type: 'publicationISSN')
       @publication_name = StashEngine::InternalDatum.find_or_initialize_by(stash_identifier: se_id, data_type: 'publicationName')
       @msid = StashEngine::InternalDatum.find_or_initialize_by(stash_identifier: se_id, data_type: 'manuscriptNumber')

--- a/stash/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
@@ -8,6 +8,7 @@ module StashDatacite
       @metadata_entry = Resource::MetadataEntry.new(@resource, current_tenant)
       @metadata_entry.resource_type
       se_id = StashEngine::Identifier.find(@resource.identifier_id)
+      puts "se_id #{se_id}"
       @publication_issn = StashEngine::InternalDatum.find_or_initialize_by(stash_identifier: se_id, data_type: 'publicationISSN')
       @publication_name = StashEngine::InternalDatum.find_or_initialize_by(stash_identifier: se_id, data_type: 'publicationName')
       @msid = StashEngine::InternalDatum.find_or_initialize_by(stash_identifier: se_id, data_type: 'manuscriptNumber')

--- a/stash/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
@@ -12,7 +12,7 @@ module StashDatacite
       @publication_name = StashEngine::InternalDatum.find_or_initialize_by(stash_identifier: se_id, data_type: 'publicationName')
       @msid = StashEngine::InternalDatum.find_or_initialize_by(stash_identifier: se_id, data_type: 'manuscriptNumber')
       @doi = StashDatacite::RelatedIdentifier.find_or_initialize_by(resource_id: @resource.id, related_identifier_type: 'doi',
-                                                                    relation_type: 'cites')
+                                                                    work_type: 'primary_article')
       @resource.update(updated_at: Time.current)
       respond_to do |format|
         format.js

--- a/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -78,8 +78,8 @@ module StashDatacite
 
         standard_doi = RelatedIdentifier.standardize_doi(bare_form_doi)
 
-        # user is expanding on a DOI that we already have; update it in the DB
-        rd.update(related_identifier: standard_doi, work_type: 'article', hidden: false)
+        # user is expanding on a DOI that we already have; update it in the DB (and change the work_type if needed)
+        rd.update(related_identifier: standard_doi, work_type: 'primary_article', hidden: false)
         rd.update(verified: rd.live_url_valid?) # do this separately since we need the doi in standard format in object to check
         return nil
       end
@@ -90,7 +90,7 @@ module StashDatacite
                                     related_identifier: standard_doi,
                                     related_identifier_type: 'doi',
                                     relation_type: 'cites', # based on what Daniella defined for auto-added articles from elsewhere
-                                    work_type: 'article',
+                                    work_type: 'primary_article',
                                     hidden: false)
       ri.update(verified: ri.live_url_valid?) # do this separately since we need the doi in standard format in object to check
       @resource.reload

--- a/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -8,15 +8,16 @@ require 'cgi'
 module StashDatacite
   class PublicationsController < ApplicationController
     def update
-      @se_id = StashEngine::Identifier.find(params[:internal_datum][:identifier_id])
-      @resource = StashEngine::Resource.find(params[:internal_datum][:resource_id])
+      puts "XXXX #{params}"
+      @se_id = StashEngine::Identifier.find(params[:identifier_id])
+      @resource = StashEngine::Resource.find(params[:resource_id])
       save_form_to_internal_data
       respond_to do |format|
         format.js do
-          if params[:internal_datum][:do_import] == 'true'
-            @error = 'Please fill in the form completely' if params[:internal_datum][:msid].blank? && params[:internal_datum][:doi].blank?
+          if params[:do_import] == 'true'
+            @error = 'Please fill in the form completely' if params[:msid].blank? && params[:primary_article_doi].blank?
             update_manuscript_metadata if params[:import_type] == 'manuscript'
-            update_doi_metadata if params[:internal_datum][:doi].present? && params[:import_type] == 'published'
+            update_doi_metadata if params[:primary_article_doi].present? && params[:import_type] == 'published'
             manage_pubmed_datum(identifier: @se_id, doi: @doi.related_identifier) if !@doi&.related_identifier.blank? &&
               params[:import_type] == 'published'
             params[:import_type] == 'published'
@@ -53,19 +54,19 @@ module StashDatacite
     end
 
     def save_form_to_internal_data
-      @pub_name = params[:internal_datum][:publication_name]
-      @pub_issn = params[:internal_datum][:publication_issn]
+      @pub_name = params[:publication_name]
+      @pub_issn = params[:publication_issn]
       fix_removable_asterisk
       @pub_name = manage_internal_datum(identifier: @se_id, data_type: 'publicationName', value: @pub_name)
       @pub_issn = manage_internal_datum(identifier: @se_id, data_type: 'publicationISSN', value: @pub_issn)
 
-      parsed_msid = parse_msid(issn: params[:internal_datum][:publication_issn], msid: params[:internal_datum][:msid])
+      parsed_msid = parse_msid(issn: params[:publication_issn], msid: params[:msid])
       @msid = manage_internal_datum(identifier: @se_id, data_type: 'manuscriptNumber', value: parsed_msid)
       save_doi
     end
 
     def save_doi
-      form_doi = params[:internal_datum][:doi]
+      form_doi = params[:primary_article_doi]
       return if form_doi.blank?
 
       bare_form_doi = Stash::Import::Crossref.bare_doi(doi_string: form_doi)
@@ -115,11 +116,11 @@ module StashDatacite
     end
 
     def update_manuscript_metadata
-      if !params[:internal_datum][:publication].blank? && params[:internal_datum][:publication_issn].blank?
+      if !params[:publication].blank? && params[:publication_issn].blank?
         @error = 'Please select your journal from the autocomplete drop-down list'
         return
       end
-      return if params[:internal_datum][:publication].blank? # keeps the default fill-in message
+      return if params[:publication].blank? # keeps the default fill-in message
       return if @pub_issn&.value.blank?
       return if @msid&.value.blank?
 
@@ -142,13 +143,13 @@ module StashDatacite
     end
 
     def update_doi_metadata
-      unless params[:internal_datum][:doi].present?
+      unless params[:primary_article_doi].present?
         @error = 'Please enter a DOI to import metadata'
         return
       end
-      cr = Stash::Import::Crossref.query_by_doi(resource: @resource, doi: params[:internal_datum][:doi])
+      cr = Stash::Import::Crossref.query_by_doi(resource: @resource, doi: params[:primary_article_doi])
       unless cr.present?
-        @error = "We couldn't obtain information from CrossRef about this DOI: #{params[:internal_datum][:doi]}"
+        @error = "We couldn't obtain information from CrossRef about this DOI: #{params[:primary_article_doi]}"
         return
       end
 

--- a/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -8,7 +8,6 @@ require 'cgi'
 module StashDatacite
   class PublicationsController < ApplicationController
     def update
-      puts "XXXX #{params}"
       @se_id = StashEngine::Identifier.find(params[:identifier_id])
       @resource = StashEngine::Resource.find(params[:resource_id])
       save_form_to_internal_data

--- a/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
@@ -34,7 +34,7 @@ module StashDatacite
                              'is identical to': 'isidenticalto', 'is derived from': 'isderivedfrom',
                              'is source of': 'issourceof' }.freeze
 
-    enum work_type: %i[undefined article dataset preprint software supplemental_information]
+    enum work_type: %i[undefined article dataset preprint software supplemental_information primary_article]
 
     enum added_by: { default: 0, zenodo: 1 }
 
@@ -46,7 +46,7 @@ module StashDatacite
                                  supplemental_information: 'Supplemental Information' }.with_indifferent_access
 
     WORK_TYPES_TO_RELATION_TYPE = { article: 'cites', dataset: 'issupplementto', preprint: 'cites', software: 'isderivedfrom',
-                                    supplemental_information: 'ispartof' }.with_indifferent_access
+                                    supplemental_information: 'ispartof', primary_article: 'cites' }.with_indifferent_access
 
     # these keys will be case-insensitive matches
     ACCESSION_TYPES = {

--- a/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/related_identifier.rb
@@ -104,11 +104,11 @@ module StashDatacite
     end
 
     def work_type_friendly
-      WORK_TYPE_CHOICES[work_type] || work_type.capitalize
+      WORK_TYPE_CHOICES[work_type] || work_type.humanize
     end
 
     def work_type_friendly_plural
-      WORK_TYPE_CHOICES_PLURAL[work_type] || work_type.capitalize.pluralize
+      WORK_TYPE_CHOICES_PLURAL[work_type] || work_type.humanize.pluralize
     end
 
     def self.related_identifier_type_mapping_obj(str)

--- a/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
@@ -1,5 +1,6 @@
 <p id="import-choices-label">My data is related to:</p>
-<%= form_with(model: @publication_issn, url: publications_update_path, method: :patch, remote: true,
+<% form_id = "resource_publication_#{resource.id}" %> 
+<%= form_with(id: form_id, url: publications_update_path, method: :patch, remote: true,
 							authenticity_token: true) do |f| %>
 	<div class="c-import__choicesbox js-import-choice" role="group" aria-labelledby="import-choices-label">
 		<div class="c-import__choicebox">
@@ -33,13 +34,13 @@
 
 		<div class="c-input__inline">
 			<div class="c-input">
-				<%= f.label "publication", 'Journal Name', class: 'c-input__label required' %>
-			        <%= f.text_field :publication, value: @publication_name.value, class: "js-publications c-input__text" %>
-				<%= f.hidden_field :identifier_id, value: @resource.identifier_id %>
-				<%= f.hidden_field :resource_id, value: @resource.id %>
-				<%= f.hidden_field :publication_issn, value: @publication_issn.value %>
-				<%= f.hidden_field :publication_name, value: @publication_name.value %>
-				<%= f.hidden_field :do_import, value: 'false' %>
+			    <%= f.label "publication", 'Journal Name', class: 'c-input__label required' %>
+			    <%= f.text_field :publication, value: @publication_name.value, class: "js-publications c-input__text" %>
+			    <%= f.hidden_field :identifier_id, value: @resource.identifier_id %>
+			    <%= f.hidden_field :resource_id, value: @resource.id %>
+			    <%= f.hidden_field :publication_issn, value: @publication_issn.value %>
+			    <%= f.hidden_field :publication_name, value: @publication_name.value %>
+			    <%= f.hidden_field :do_import, value: 'false' %>
 			</div>
 			<div class="c-input js-ms-section">
 				<%= f.label "msid", 'Manuscript Number', class: 'c-input__label required' %>
@@ -47,7 +48,7 @@
 			</div>
 			<div class="c-input js-doi-section">
 				<%= f.label "doi", 'DOI', class: 'c-input__label required' %>
-				<%= f.text_field :doi, value: @doi.related_identifier, class: "js-doi c-input__text", placeholder: '5702.125/qlm.1266rr' %>
+				<%= f.text_field :primary_article_doi, value: @doi.related_identifier, class: "js-doi c-input__text", placeholder: '5702.125/qlm.1266rr' %>
 			</div>
 		</div>
 		<div>

--- a/stash/stash_datacite/app/views/stash_datacite/publications/update.js.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/publications/update.js.erb
@@ -1,11 +1,9 @@
-// switch do_import hidden value back to false in case form needs to be played with some more
-//$('#internal_datum_do_import').val('false');
 
 <% if defined?(@error) && !@error.blank? %>
 // populate and display warning
   $( '#population-warnings' ).html("<%= escape_javascript(@error) %>");
   $( "#population-warnings" ).show();
-  $('#internal_datum_do_import').val('false');  // reset the import to false again, to be changed back by js with submit button click event
+  $('#do_import').val('false');  // reset the import to false again, to be changed back by js with submit button click event
 <% else %>
   // get data into DB somehow and reload the page to show the pretty new data, which also resets this form to defaults
   location.reload(true);

--- a/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_landing_related_works.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_landing_related_works.html.erb
@@ -1,5 +1,5 @@
 
-<!-- Article IDs -->
+<% # Article IDs %>
 
 <% article_ids = @resource.related_identifiers.where(work_type: [:article, :primary_article]).where(hidden: false).order(work_type: :desc) %>
 <% if article_ids.present? %>
@@ -21,7 +21,7 @@
     </ul>
 <% end %>
 
-<!-- All other related IDs -->
+<% # All other related IDs %>
 
 <% other_relations = @resource.related_identifiers.select(:work_type).where(hidden: false).where.not(work_type: [:article, :primary_article]).distinct.order(:work_type) %>
 <% other_relations.each do |orel| %>

--- a/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_landing_related_works.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_landing_related_works.html.erb
@@ -1,20 +1,46 @@
-<% @resource.related_identifiers.select(:work_type).where(hidden: false).distinct.order(:work_type).each do |wt| %>
-  <% my_ids = @resource.related_identifiers.where(work_type: wt.work_type).where(hidden: false) %>
-  <h3 class="o-heading__level3-related-works"><%= (my_ids.count > 1 ? wt.work_type_friendly_plural : wt.work_type_friendly) %></h3>
-  <ul class="o-list-related">
-    <% my_ids.each do |r| %>
-      <% bad_asterisk = ( (current_user&.curator? && !r.verified?) ? ' *' : '') %>
-      <li>
-        <% if r.work_type == 'undefined' %>
-          This dataset <%= r.relation_name_english %>
-          <%= display_id(type: r.related_identifier_type,
-                     my_id: r.related_identifier) %> <%= bad_asterisk %>
-        <% else %>
-          <%= link_to r.related_identifier.ellipsisize(40), r.related_identifier, class: 'o-link__primary', title: r.related_identifier %>
-          <%= bad_asterisk %>
-        <% end %>
-      </li>
-    <% end %>
-  </ul>
+
+<!-- Article IDs -->
+
+<% article_ids = @resource.related_identifiers.where(work_type: [:article, :primary_article]).where(hidden: false).order(work_type: :desc) %>
+<% if article_ids.present? %>
+    <h3 class="o-heading__level3-related-works"><%= (article_ids.count > 1 ? "Articles" : "Article") %></h3>
+    <ul class="o-list-related">
+	<% article_ids.each do |r| %>
+	    <% bad_asterisk = ( (current_user&.curator? && !r.verified?) ? ' *' : '') %>
+	    <li>
+		<% if r.work_type == 'undefined' %>
+		    This dataset <%= r.relation_name_english %>
+		    <%= display_id(type: r.related_identifier_type,
+				   my_id: r.related_identifier) %> <%= bad_asterisk %>
+		<% else %>
+		    <%= link_to r.related_identifier.ellipsisize(40), r.related_identifier, class: 'o-link__primary', title: r.related_identifier %>
+		    <%= bad_asterisk %>
+		<% end %>
+	    </li>
+	<% end %>
+    </ul>
+<% end %>
+
+<!-- All other related IDs -->
+
+<% other_relations = @resource.related_identifiers.select(:work_type).where(hidden: false).where.not(work_type: [:article, :primary_article]).distinct.order(:work_type) %>
+<% other_relations.each do |orel| %>
+    <h3 class="o-heading__level3-related-works"><%= orel.work_type_friendly %></h3>
+    <% other_ids = @resource.related_identifiers.where(work_type: orel.work_type).where(hidden: false) %>
+    <ul class="o-list-related">
+	<% other_ids.each do |r| %>
+	    <% bad_asterisk = ( (current_user&.curator? && !r.verified?) ? ' *' : '') %>
+	    <li>
+		<% if r.work_type == 'undefined' %>
+		    This dataset <%= r.relation_name_english %>
+		    <%= display_id(type: r.related_identifier_type,
+				   my_id: r.related_identifier) %> <%= bad_asterisk %>
+		<% else %>
+		    <%= link_to r.related_identifier.ellipsisize(40), r.related_identifier, class: 'o-link__primary', title: r.related_identifier %>
+		    <%= bad_asterisk %>
+		<% end %>
+	    </li>
+	<% end %>
+    </ul>
 <% end %>
 

--- a/stash/stash_datacite/db/migrate/20210803125801_update_related_identifier_types.rb
+++ b/stash/stash_datacite/db/migrate/20210803125801_update_related_identifier_types.rb
@@ -1,0 +1,7 @@
+class UpdateRelatedIdentifierTypes < ActiveRecord::Migration[5.2]
+  def change
+    StashDatacite::RelatedIdentifier.where(work_type: :article).group_by(&:resource_id).each do |_resource_id, ri|
+      ri.first.update(work_type: :primary_article)
+    end
+  end
+end

--- a/stash/stash_datacite/lib/stash/import/crossref.rb
+++ b/stash/stash_datacite/lib/stash/import/crossref.rb
@@ -224,7 +224,7 @@ module Stash
       end
 
       def related_identifier_will_change?(proposed_change:)
-        related_identifier = @resource.related_identifiers.where(related_identifier_type: 'doi', work_type: 'primary_article').first
+        related_identifier = @resource.related_identifiers.where(related_identifier_type: 'doi', work_type: 'primary_article').last
         proposed_change.publication_doi != related_identifier&.related_identifier
       end
 

--- a/stash/stash_datacite/lib/stash/import/crossref.rb
+++ b/stash/stash_datacite/lib/stash/import/crossref.rb
@@ -310,6 +310,12 @@ module Stash
       def populate_publication_issn
         return unless @sm['ISSN'].present? && @sm['ISSN'].first.present?
 
+        # We only want to save the ISSN if we receive one that we already know about. Otherwise,
+        # it is likely an alternative ISSN for a journal where we have a different primary ISSN
+        # (most journals have separate ISSNs for print, online, linking)
+        # In that case, we will save the journal name, and look up the correct ISSN from the name.
+        return unless StashEngine::Journal.where(issn: @sm['ISSN'].first).present?
+
         datum = StashEngine::InternalDatum.find_or_initialize_by(identifier_id: @resource.identifier.id,
                                                                  data_type: 'publicationISSN')
         datum.update(value: @sm['ISSN'].first)
@@ -321,6 +327,14 @@ module Stash
         datum = StashEngine::InternalDatum.find_or_initialize_by(identifier_id: @resource.identifier.id,
                                                                  data_type: 'publicationName')
         datum.update(value: publisher)
+
+        journal = StashEngine::Journal.where(title: publisher)
+        return unless journal.present?
+
+        # If the publication name matches an existing journal, populate/update the ISSN
+        datum = StashEngine::InternalDatum.find_or_initialize_by(identifier_id: @resource.identifier.id,
+                                                                 data_type: 'publicationISSN')
+        datum.update(value: journal.first.issn)
       end
 
       def populate_title

--- a/stash/stash_datacite/lib/stash/import/crossref.rb
+++ b/stash/stash_datacite/lib/stash/import/crossref.rb
@@ -224,7 +224,7 @@ module Stash
       end
 
       def related_identifier_will_change?(proposed_change:)
-        related_identifier = @resource.related_identifiers.where(related_identifier_type: 'doi', relation_type: 'cites').first
+        related_identifier = @resource.related_identifiers.where(related_identifier_type: 'doi', work_type: 'primary_article').first
         proposed_change.publication_doi != related_identifier&.related_identifier
       end
 
@@ -278,7 +278,7 @@ module Stash
                                     related_identifier: StashDatacite::RelatedIdentifier.standardize_doi(my_related),
                                     related_identifier_type: 'doi',
                                     relation_type: 'cites', # based on what Daniella defined for auto-added articles from elsewhere
-                                    work_type: 'article',
+                                    work_type: 'primary_article',
                                     verified: true,
                                     hidden: false
                                   })

--- a/stash/stash_datacite/lib/stash/indexer/indexing_resource.rb
+++ b/stash/stash_datacite/lib/stash/indexer/indexing_resource.rb
@@ -225,7 +225,7 @@ module Stash
 
       def related_publication_id
         ids = @resource.identifier.internal_data.where(data_type: %w[manuscriptNumber pubmedID])&.map(&:value)&.join(' ')
-        pub_doi = @resource.related_identifiers.where(related_identifier_type: 'doi', relation_type: 'cites').first
+        pub_doi = @resource.related_identifiers.where(related_identifier_type: 'doi', work_type: 'primary_article').first
         (pub_doi.present? ? "#{ids} #{pub_doi.related_identifier}" : ids)
       end
 

--- a/stash/stash_datacite/lib/stash/indexer/indexing_resource.rb
+++ b/stash/stash_datacite/lib/stash/indexer/indexing_resource.rb
@@ -225,7 +225,7 @@ module Stash
 
       def related_publication_id
         ids = @resource.identifier.internal_data.where(data_type: %w[manuscriptNumber pubmedID])&.map(&:value)&.join(' ')
-        pub_doi = @resource.related_identifiers.where(related_identifier_type: 'doi', work_type: 'primary_article').first
+        pub_doi = @resource.related_identifiers.where(related_identifier_type: 'doi', work_type: 'primary_article').last
         (pub_doi.present? ? "#{ids} #{pub_doi.related_identifier}" : ids)
       end
 

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -292,7 +292,7 @@ module StashEngine
       doi = nil
       resources.each do |res|
         dois = res.related_identifiers&.select { |id| id.related_identifier_type == 'doi' && id.work_type == 'primary_article' }
-        doi = dois&.first&.related_identifier
+        doi = dois&.last&.related_identifier
         break unless doi.nil?
       end
       doi

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -291,7 +291,7 @@ module StashEngine
     def publication_article_doi
       doi = nil
       resources.each do |res|
-        dois = res.related_identifiers&.select { |id| id.related_identifier_type == 'doi' && id.relation_type == 'cites' }
+        dois = res.related_identifiers&.select { |id| id.related_identifier_type == 'doi' && id.work_type == 'primary_article' }
         doi = dois&.first&.related_identifier
         break unless doi.nil?
       end

--- a/stash/stash_engine/lib/tasks/link_out.rake
+++ b/stash/stash_engine/lib/tasks/link_out.rake
@@ -69,7 +69,7 @@ namespace :link_out do
     existing_pmids = StashEngine::Identifier.cited_by_pubmed.pluck(:id)
     resource_ids = StashEngine::Resource.latest_per_dataset.where.not(identifier_id: existing_pmids).pluck(:id)
     related_identifiers = StashDatacite::RelatedIdentifier.where(resource_id: resource_ids, related_identifier_type: 'doi',
-                                                                 relation_type: 'cites').order(created_at: :desc)
+                                                                 work_type: 'primary_article').order(created_at: :desc)
     related_identifiers.each do |data|
       p "  looking for pmid for #{data.related_identifier}"
       pmid = pubmed_service.lookup_pubmed_id(data.related_identifier.gsub('doi:', ''))

--- a/stash/stash_engine/ui-library/includes/import_metadata.html
+++ b/stash/stash_engine/ui-library/includes/import_metadata.html
@@ -32,19 +32,19 @@
   <p>Please provide the following information. You may either enter the information and leave it or choose to autofill
     your dataset based on you supply below.</p>
 
-  <form class="edit_internal_datum" id="edit_internal_datum_157"><input name="utf8" type="hidden" value="✓">
+  <form class="edit_157" id="edit_157"><input name="utf8" type="hidden" value="✓">
     <div class="c-input__inline">
       <div class="c-input">
-        <label class="c-input__label" for="internal_datum_publication_name">Journal Name</label>
-        <input value="" class="js-publications c-input__text ui-autocomplete-input" type="text" name="internal_datum[publication_name]" id="internal_datum_publication_name">
+        <label class="c-input__label" for="publication_name">Journal Name</label>
+        <input value="" class="js-publications c-input__text ui-autocomplete-input" type="text" name="publication_name" id="publication_name">
       </div>
       <div class="c-input js-ms-section">
-        <label class="c-input__label" for="internal_datum_msid">Manuscript Number</label>
-        <input class="js-msid c-input__text" type="text" name="internal_datum[msid]" id="internal_datum_msid">
+        <label class="c-input__label" for="msid">Manuscript Number</label>
+        <input class="js-msid c-input__text" type="text" name="msid" id="msid">
       </div>
       <div class="c-input js-doi-section">
-        <label class="c-input__label" for="internal_datum_doi">DOI</label>
-        <input class="js-doi c-input__text" type="text" name="internal_datum[doi]" id="internal_datum_doi">
+        <label class="c-input__label" for="primary_article_doi">DOI</label>
+        <input class="js-doi c-input__text" type="text" name="primary_article_doi" id="primary_article_doi">
       </div>
     </div>
     <div>


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1382

- Adds a new type of dcs_relation, the `primary_article`.
- Separates handling for two types of DOI fields: the `primary_article` at the top of the submission from, and other `article` relationships in the Related Works section.
- Simplifies field names in the top of the submission page. Instead of a field that incorrectly implies the DOI is stored as an internal_datum, use the name `primary_article_doi`.
- Removes the assumption throughout the code that the dataset is tightly tied to the first `article`. Instead, we use the most recent `primary_article`.
- Fixes an issue with importing metadata from CrossRef, where an incorrect ISSN could be saved.
- On landing pages, combines the display of `primary_article` and `article` relationships into a single "Article" section, with the `primary_article` values displayed first.