### PR TITLE
Add "at a glance" stats to curation stats

### DIFF
--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller/stats.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller/stats.rb
@@ -15,9 +15,10 @@ module StashEngine
       SQL
 
       # leave tenant_id blank if you want stats for all
-      def initialize(tenant_id: nil, since: START_OF_AD_TIME)
+      def initialize(tenant_id: nil, since: START_OF_AD_TIME, untouched_since: Time.now)
         @tenant_id = tenant_id
         @since = since
+        @untouched_since = untouched_since
       end
 
       # it seems like ActiveRecord caches queries so, not sure I need to cache this
@@ -56,7 +57,7 @@ module StashEngine
       end
 
       def datasets_with_curation_status_count(status:)
-        query = "#{STATUS_QUERY_BASE} WHERE ser.updated_at > '#{@since}' AND seca.status = '#{status}'"
+        query = "#{STATUS_QUERY_BASE} WHERE ser.updated_at < '#{@untouched_since}' AND ser.created_at > '#{@since}' AND seca.status = '#{status}'"
         ApplicationRecord.connection.execute(query)&.first&.first
       end
 

--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller/stats.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller/stats.rb
@@ -5,6 +5,15 @@ module StashEngine
 
       START_OF_AD_TIME = Time.new(0, 1, 1).utc
 
+      STATUS_QUERY_BASE = <<-SQL.freeze
+           SELECT count(*)
+           FROM stash_engine_resources ser
+             INNER JOIN stash_engine_identifiers sei ON ser.identifier_id = sei.id
+             INNER JOIN (SELECT MAX(r2.id) r_id FROM stash_engine_resources r2 GROUP BY r2.identifier_id) j1 ON j1.r_id = ser.id
+             LEFT OUTER JOIN (SELECT ca2.resource_id, MAX(ca2.id) latest_curation_activity_id FROM stash_engine_curation_activities ca2 GROUP BY ca2.resource_id) j3 ON j3.resource_id = ser.id
+             LEFT OUTER JOIN stash_engine_curation_activities seca ON seca.id = j3.latest_curation_activity_id
+      SQL
+
       # leave tenant_id blank if you want stats for all
       def initialize(tenant_id: nil, since: START_OF_AD_TIME)
         @tenant_id = tenant_id
@@ -25,20 +34,30 @@ module StashEngine
       end
 
       def datasets_started_count
-        datasets_with_status_count(status: 'in_progress')
+        datasets_with_resource_state_count(state: 'in_progress')
       end
 
       def datasets_submitted_count
-        datasets_with_status_count(status: 'submitted')
+        datasets_with_resource_state_count(state: 'submitted')
+      end
+
+      def datasets_available_for_curation
+        datasets_with_curation_status_count(status: 'submitted') +
+          datasets_with_curation_status_count(status: 'curation')
       end
 
       private
 
-      def datasets_with_status_count(status:)
+      def datasets_with_resource_state_count(state:)
         ident_query = Identifier.where(['stash_engine_identifiers.created_at > ?', @since]).joins(latest_resource: :current_resource_state)
         ident_query = ident_query.where(['stash_engine_resources.tenant_id = ?', @tenant_id]) if @tenant_id
-        ident_query = ident_query.where(['stash_engine_resource_states.resource_state = ?', status])
+        ident_query = ident_query.where(['stash_engine_resource_states.resource_state = ?', state])
         ident_query.count
+      end
+
+      def datasets_with_curation_status_count(status:)
+        query = "#{STATUS_QUERY_BASE} WHERE ser.updated_at > '#{@since}' AND seca.status = '#{status}'"
+        ApplicationRecord.connection.execute(query)&.first&.first
       end
 
     end

--- a/stash/stash_engine/app/controllers/stash_engine/curation_stats_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/curation_stats_controller.rb
@@ -14,7 +14,7 @@ module StashEngine
       @current_stats = CurationStats.where(date: 1.month.ago..Date.today).order('date DESC')
 
       @admin_stats = StashEngine::AdminDatasetsController::Stats.new
-      @admin_stats_2day = StashEngine::AdminDatasetsController::Stats.new(since: Time.now - 2.days)
+      @admin_stats_2day = StashEngine::AdminDatasetsController::Stats.new(untouched_since: Time.now - 2.days)
 
       respond_to do |format|
         format.html

--- a/stash/stash_engine/app/controllers/stash_engine/curation_stats_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/curation_stats_controller.rb
@@ -11,7 +11,10 @@ module StashEngine
       params.permit(:format)
 
       @all_stats = CurationStats.all
-      @stats = CurationStats.where(date: 1.month.ago..Date.today).order('date DESC')
+      @current_stats = CurationStats.where(date: 1.month.ago..Date.today).order('date DESC')
+
+      @admin_stats = StashEngine::AdminDatasetsController::Stats.new
+      @admin_stats_2day = StashEngine::AdminDatasetsController::Stats.new(since: Time.now - 2.days)
 
       respond_to do |format|
         format.html

--- a/stash/stash_engine/app/views/stash_engine/curation_stats/index.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/curation_stats/index.html.erb
@@ -1,12 +1,15 @@
 <% @page_title = "Curation Stats" %>
 <h1 class="o-heading__level1">Curation Stats</h1>
 
-<p>
-Datasets currently available for curation: <%= @admin_stats.datasets_available_for_curation %></br>
-Datasets available for curation and not touched recently: <%= @admin_stats_2day.datasets_available_for_curation %>
-</p>
+<div class="o-admin-container">
+    <div class="o-admin-left-head">
+	<div class="o-heading__level3">At a glance</div>
+	<%= @admin_stats.datasets_available_for_curation %> datasets currently available for curation<br/>
+	<%= @admin_stats_2day.datasets_available_for_curation %> datasets available for curation and not touched in 48 hours 
+    </div>
+</div>
 
-<p>Curation statistics are available in the table below (mouseover any table heading for a more complete description), or the complete stats history can be downloaded as a CSV.</p>
+<p>Recent statistics are available in the table below (mouseover any table heading for a more complete description), or the complete stats history can be downloaded as a CSV.</p>
 
   <div>
     <%= link_to 'Get full stats as CSV', curation_stats_path(format: :csv) %>

--- a/stash/stash_engine/app/views/stash_engine/curation_stats/index.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/curation_stats/index.html.erb
@@ -1,6 +1,11 @@
 <% @page_title = "Curation Stats" %>
 <h1 class="o-heading__level1">Curation Stats</h1>
 
+<p>
+Datasets currently available for curation: <%= @admin_stats.datasets_available_for_curation %></br>
+Datasets available for curation and not touched recently: <%= @admin_stats_2day.datasets_available_for_curation %>
+</p>
+
 <p>Curation statistics are available in the table below (mouseover any table heading for a more complete description), or the complete stats history can be downloaded as a CSV.</p>
 
   <div>
@@ -31,7 +36,7 @@
       <th title="The number resubmitted that day (were 'published' or 'embargoed' before, and change status to 'submitted')"
 	  class="c-admin-table">Author Versioned</th>
   </tr>
-  <% @stats.each do |stat| %>
+  <% @current_stats.each do |stat| %>
   <tr class="c-lined-table__row" id="js-dataset-row-id-<%= stat.id %>">
       <td><%= formatted_date(stat.date) %></td>
       <td><%= stat.datasets_curated %></td>


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1384

To accomplish this, I adapted and simplified the mega query from the Admin Dashboard. Given this duplication, I'm starting to contemplate pulling all of the admin queries out into a separate module that just builds queries for various purposes. But that's a larger task that I don't want to tackle just yet...