### PR TITLE
How to unpublish, instructions

### DIFF
--- a/documentation/server_maintenance/troubleshooting.md
+++ b/documentation/server_maintenance/troubleshooting.md
@@ -167,11 +167,11 @@ update stash_engine_curation_activities set status='submitted' where id=;
 update stash_engine_resources set file_view=false, meta_view=false where identifier_id=;
 update stash_engine_resources set publication_date=NULL where id=;
 update stash_engine_identifiers set pub_state='unpublished' where id=;
-select deposition_id from stash_engine_zenodo_copies WHERE copy_type="data" and resource_id=;
+select deposition_id from stash_engine_zenodo_copies WHERE resource_id=;
 ```
 
 It's pretty impossible to remove from Zenodo without contacting them and waiting a while, so an embargo for a century
-or two might serve the purpose.
+or two might serve the purpose.  Do this for each of the unique deposition_ids listed in the query above. 
 ````
 # the parameters are 1) resource_id, 2) deposition_id (see last sql above), 3) date far in the future
 RAILS_ENV=production bundle exec rake dev_ops:embargo_zenodo <resource-id> <deposition-id> 2200-12-31


### PR DESCRIPTION
I added specific instructions for "unpublishing" since this is coming up semi-regularly recently.

There is really no easy way to completely take back a publication and then re-publish it again later with all the external services involved and permanent identifiers that get set up.

This should mostly do the job, I think, but it seems like we may need some way to prevent this from happening so often since it affects external systems like Zenodo and DataCite that expect publishing to be a pretty permanent step that isn't easily recalled.

It probably should re-confirm or make people go through an extra step that the other states don't have so that it doesn't happen on accident so often.