### PR TITLE
Adding a bunch of role="button" for accessibility

### DIFF
--- a/stash/stash_datacite/app/views/stash_datacite/authors/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/_form.html.erb
@@ -20,7 +20,7 @@
   <%= f.email_field :author_email, class: 'c-input__text js-author_email', placeholder: 'email@example.com' %>
   <p id="invalid_email" class="c-input__error-message">Please enter a valid email address.</p>
   </div>
-  <%= link_to 'remove', stash_datacite.authors_delete_path(author.id || 'new'), method: :delete, remote: true, data: {confirm: 'Are you sure you want to remove this author?'}, class: 't-describe__remove-button o-button__remove remove_record' %>
+  <%= link_to 'remove', stash_datacite.authors_delete_path(author.id || 'new'), role: 'button', method: :delete, remote: true, data: {confirm: 'Are you sure you want to remove this author?'}, class: 't-describe__remove-button o-button__remove remove_record' %>
   <%= f.hidden_field :resource_id %>
   <%= f.hidden_field :id %>
   <%= hidden_field_tag(:form_id, form_id) %>

--- a/stash/stash_datacite/app/views/stash_datacite/contributors/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/contributors/_form.html.erb
@@ -12,7 +12,7 @@
 		<%= f.label "award_number_#{my_suffix}", "Award Number", class: 'c-input__label' %>
 		<%= f.text_field :award_number, id: "contributor_award_number_#{my_suffix}", class: "js-award_number c-input__text" %>
 	</div>
-	<%= link_to 'remove', stash_datacite.contributors_delete_path(contributor.id || 'new'), method: :delete, remote: true,
+	<%= link_to 'remove', stash_datacite.contributors_delete_path(contributor.id || 'new'), method: :delete, remote: true, role: 'button',
 							data: { confirm: 'Are you sure you want to remove this funder?' }, class: 'remove_record t-describe__remove-button o-button__remove' %>
 	<%= f.hidden_field :contributor_type, value: :funder %>
 	<%= f.hidden_field :resource_id %>

--- a/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
@@ -25,7 +25,7 @@
           <%= render partial: "stash_datacite/authors/form", locals: { author: @metadata_entry.new_author, path: stash_datacite.authors_create_path } %>
       <% end %>
     </div>
-    <%= link_to "Add Author", stash_datacite.authors_new_path( resource_id: @resource.id ), remote: :true, class: 't-describe__add-button o-button__add' %>
+    <%= link_to "Add Author", stash_datacite.authors_new_path( resource_id: @resource.id ), role: 'button', remote: :true, class: 't-describe__add-button o-button__add' %>
   </fieldset>
 
   <%= render partial: "stash_datacite/fos_subjects/form", locals: { resource: @resource} %><br/>
@@ -41,7 +41,7 @@
         <%= render partial: "stash_datacite/contributors/form", locals: { contributor: @metadata_entry.new_contributor, path: stash_datacite.contributors_create_path } %>
       <% end %>
     </div>
-    <%= link_to "add another funder", stash_datacite.contributors_new_path( resource_id: @resource.id ), remote: :true, class: 't-describe__add-funder-button o-button__add' %>
+    <%= link_to "add another funder", stash_datacite.contributors_new_path( resource_id: @resource.id ), role: 'button', remote: :true, class: 't-describe__add-funder-button o-button__add' %>
   </fieldset>
 
 

--- a/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_form.html.erb
@@ -14,7 +14,7 @@
       <%= f.text_field :related_identifier, size: 40, id: "related_identifier_#{my_suffix}", class: "js-related_identifier c-input__text",
         placeholder: 'example: https://doi.org/10.1594/PANGAEA.726855' %>
     </div>
-    <%= link_to 'remove', stash_datacite.related_identifiers_delete_path(related_identifier.id || 'new'), method: :delete, remote: true, data: { confirm: 'Are you sure you want to remove this related work?' }, class: 'remove_record t-describe__remove-button o-button__remove' %>
+    <%= link_to 'remove', stash_datacite.related_identifiers_delete_path(related_identifier.id || 'new'), role: 'button', method: :delete, remote: true, data: { confirm: 'Are you sure you want to remove this related work?' }, class: 'remove_record t-describe__remove-button o-button__remove' %>
       <%= f.hidden_field :resource_id %>
       <%= f.hidden_field :id, class: 'js-related_identifier_id' %>
       <%= hidden_field_tag(:form_id, form_id) %>

--- a/stash/stash_datacite/app/views/stash_datacite/subjects/_keywords_list.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/subjects/_keywords_list.html.erb
@@ -2,7 +2,9 @@
 <div id="js-keywords__container" class="c-keywords__container">
   <% subjects.each do |subject| %>
     <span class="c-keywords__keyword">
-      <%= subject.subject %><span class="delete_keyword"><%=link_to '', stash_datacite.subjects_delete_path(subject.id, resource_id: resource_id), method: :delete, remote: true, class: 'c-keywords__keyword-remove' %></span>
+      <%= subject.subject %><span class="delete_keyword"><%=link_to '',
+                stash_datacite.subjects_delete_path(subject.id, resource_id: resource_id), 'aria-label' => 'Remove this keyword',
+                role: 'button', method: :delete, remote: true, class: 'c-keywords__keyword-remove' %></span>
     </span>
   <% end %>
   <%= text_field_tag('subject' , nil, { id: 'keyword', class: 'js-keywords__input c-keywords__input' }) %>

--- a/stash/stash_engine/app/views/stash_engine/landing/_files.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/landing/_files.html.erb
@@ -26,7 +26,7 @@
     <!-- list individual files -->
     <% resources.each do |res| %>
       <details class="c-file-group" role="group">
-        <summary class="o-showhide__summary c-file-group__summary">
+        <summary role="button" class="o-showhide__summary c-file-group__summary">
           <%= formatted_date(res.publication_date.present? && res.publication_date < Time.new ?
                                  res.publication_date : res.updated_at) %>
           <%= ( res_id.positive? && res.id > res_id ? '*' : '' ) -%>


### PR DESCRIPTION
where ticket indicated button functionality and they were links. It would involve much larger layout changes to make these into actual buttons since they'd have to be moved outside of forms and also would take significantly more room in the layout and change the visual look which was designed for us.

We think this addresses the accessibility problems without a huge rework, but we can evaluate at the aria review.