### PR TITLE
Allow curators to be unassigned from a dataset

### DIFF
--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -146,6 +146,25 @@ RSpec.feature 'Admin', type: :feature do
 
       end
 
+      it 'allows un-assigning a curator', js: true do
+        @curator = create(:user, role: 'superuser', tenant_id: 'dryad')
+
+        visit root_path
+        find('.o-sites__summary', text: 'Admin').click
+        find('.o-sites__group-item', text: 'Dataset Curation').click
+
+        expect(page).to have_text('Admin Dashboard')
+        expect(page).to have_css('button[title="Update curator"]')
+        find('button[title="Update curator"]').click
+        find("#resource_current_editor_id option[value='#{@curator.id}']").select_option
+        click_button('Submit')
+
+        within(:css, '.c-lined-table__row', wait: 10) do
+          expect(page).not_to have_text(@curator.name.to_s)
+        end
+
+      end
+
       # Skipping this test that fails intermittently, for a feature we're not actually using
       xit 'allows changing user role as a superuser', js: true do
         visit stash_url_helpers.admin_path

--- a/stash/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -211,7 +211,7 @@ module StashEngine
         StashEngine::UserMailer.status_change(resource, status).deliver_now
         StashEngine::UserMailer.journal_review_notice(resource, status).deliver_now
       when 'submitted'
-        return if previously_submitted? # Don't sent multiple emails for the same resource
+        return if previously_submitted? # Don't send multiple emails for the same resource
 
         StashEngine::UserMailer.status_change(resource, status).deliver_now
       end

--- a/stash/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -211,6 +211,8 @@ module StashEngine
         StashEngine::UserMailer.status_change(resource, status).deliver_now
         StashEngine::UserMailer.journal_review_notice(resource, status).deliver_now
       when 'submitted'
+        return if previously_submitted?
+
         StashEngine::UserMailer.status_change(resource, status).deliver_now
       end
     end
@@ -227,6 +229,18 @@ module StashEngine
         end
       end
       prev_pub
+    end
+
+    def previously_submitted?
+      # ignoring the current CA, is there a submitted status at any point for this resource?
+      prev_sub = false
+      resource.curation_activities&.each do |ca|
+        if (ca.id != id) && ca.submitted?
+          prev_sub = true
+          break
+        end
+      end
+      prev_sub
     end
 
     # Triggered on a status of :published

--- a/stash/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -211,7 +211,7 @@ module StashEngine
         StashEngine::UserMailer.status_change(resource, status).deliver_now
         StashEngine::UserMailer.journal_review_notice(resource, status).deliver_now
       when 'submitted'
-        return if previously_submitted?
+        return if previously_submitted? # Don't sent multiple emails for the same resource
 
         StashEngine::UserMailer.status_change(resource, status).deliver_now
       end

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_current_editor_form.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_current_editor_form.html.erb
@@ -11,7 +11,7 @@
       <%= f.fields_for :current_editor, resource do |r| %>
         <div class="c-input">
             <label class="c-input__label">Curator</label>
-          <%= r.select :id, options_for_select(editor_select), include_blank: true %>
+          <%= r.select :id, options_for_select([['(unassign)', '0']] + editor_select), include_blank: true %>
         </div>
       <% end %>
     <% end %>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/_current_editor_form.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/_current_editor_form.html.erb
@@ -11,7 +11,7 @@
       <%= f.fields_for :current_editor, resource do |r| %>
         <div class="c-input">
             <label class="c-input__label">Curator</label>
-          <%= r.select :id, options_for_select([['(unassign)', '0']] + editor_select), include_blank: true %>
+          <%= r.select :id, options_for_select([['(unassign)', '0']] + editor_select), include_blank: false %>
         </div>
       <% end %>
     <% end %>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/current_editor_change.js.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/current_editor_change.js.erb
@@ -1,4 +1,4 @@
-<% # redrawing full row rather than trying to fix each item.  Will I need to reattach all button events after?  So far doesn't seem like it. %>
+<% # redrawing full row rather than trying to fix each item. %>
 
 $("#js-dataset-row-id-<%= @resource.identifier.id %>").replaceWith("<%= escape_javascript(render partial: 'stash_engine/admin_datasets/datasets_row', locals: { dataset: @curation_row }) %>")
 


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1404

On the Admin Dashboard, the pencil next to a dataset's curator may now be used to unassign the curator. When a curator is unassigned, the dataset is forced into curation status 'submitted', so other curators will see it and can take it over.