### PR TITLE
Fixes for ckeditor and also associating labels with fields on metadata page

### DIFF
--- a/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
@@ -1,6 +1,7 @@
+<% my_suffix = field_suffix(author) %>
 <%= form.fields_for :affiliation, author.affiliation do |affil_fields| %>
-    <%= affil_fields.label :long_name, "Institutional Affiliation", class: 'c-input__label required' %>
-    <%= affil_fields.text_field(:long_name, class: 'c-input__text js-affiliation') %>
+		<label class="c-input__label required" for="instit_affil_<%= my_suffix %>">Institutional Affiliation</label>
+    <%= affil_fields.text_field(:long_name, id: "instit_affil_#{my_suffix}", class: 'c-input__text js-affiliation') %>
     <%= affil_fields.hidden_field :id %>
     <%= affil_fields.hidden_field :ror_id, class: 'js-affiliation_id' %>
 <% end %>

--- a/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
@@ -1,4 +1,5 @@
 <% my_suffix = field_suffix(author) %>
+
 <%= form.fields_for :affiliation, author.affiliation do |affil_fields| %>
 		<label class="c-input__label required" for="instit_affil_<%= my_suffix %>">Institutional Affiliation</label>
     <%= affil_fields.text_field(:long_name, id: "instit_affil_#{my_suffix}", class: 'c-input__text js-affiliation') %>

--- a/stash/stash_datacite/app/views/stash_datacite/authors/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/_form.html.erb
@@ -16,8 +16,8 @@
     <%= render partial: 'stash_datacite/authors/affiliation', locals: { author: author, form: f, form_id: form_id } %>
   </div>
   <div class="c-input">
-  <%= f.label "author_email", "Author Email", class: 'c-input__label js-author_label' %>
-  <%= f.email_field :author_email, class: 'c-input__text js-author_email', placeholder: 'email@example.com' %>
+  <%= f.label "email_#{my_suffix}", "Author Email", class: 'c-input__label js-author_label' %>
+  <%= f.email_field :author_email, id: "author_email_#{my_suffix}",  class: 'c-input__text js-author_email', placeholder: 'email@example.com' %>
   <p id="invalid_email" class="c-input__error-message">Please enter a valid email address.</p>
   </div>
   <%= link_to 'remove', stash_datacite.authors_delete_path(author.id || 'new'), method: :delete, remote: true, data: {confirm: 'Are you sure you want to remove this author?'}, class: 't-describe__remove-button o-button__remove remove_record' %>

--- a/stash/stash_datacite/app/views/stash_datacite/descriptions/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/descriptions/_form.html.erb
@@ -2,11 +2,21 @@
 <%= form_with(model: description, url: stash_datacite.descriptions_update_path, remote: true, authenticity_token: true,
              id: "description_form_#{description_type}", class: 'c-input') do |f| %>
   <%#= render "datacite/shared/error_messages", :target => @description %>
-  <%# f.text_area :description, class: "c-input__textarea js-description", id: "description_#{description_type}" %>
-  <%= f.cktext_area :description, class: "c-input__textarea js-description", id: "description_#{description_type}" %>
+  <%# f.text_area :description, class: "c-input__textarea js-description",id: "description_#{description_type}" %>
+  <%= f.cktext_area :description, name: description_type, class: "c-input__textarea js-description", id: "description_#{description_type}",
+      "aria-describedby" => "ckeditor_#{description_type}" %>
   <%= f.hidden_field :description_type, value: description_type %>
   <%= f.hidden_field :resource_id %>
   <%= f.hidden_field :id %>
   <%# f.submit %>
-  <br/>
+  <div id="ckeditor_<%= description_type %>">
+    Press Alt 0  or Option 0 for help using the rich text editor with keyboard only.
+  </div>
 <% end %>
+
+<script>
+  setTimeout(
+      function (){
+        $('#cke_description_<%= description_type %>_arialbl').html("Rich text editor for <%= description_name %>. Press Alt 0 or Option 0 for help using with keyboard only.");
+      }, 2000);
+</script>

--- a/stash/stash_datacite/app/views/stash_datacite/descriptions/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/descriptions/_form.html.erb
@@ -3,7 +3,7 @@
              id: "description_form_#{description_type}", class: 'c-input') do |f| %>
   <%#= render "datacite/shared/error_messages", :target => @description %>
   <%# f.text_area :description, class: "c-input__textarea js-description",id: "description_#{description_type}" %>
-  <%= f.cktext_area :description, name: description_type, class: "c-input__textarea js-description", id: "description_#{description_type}",
+  <%= f.cktext_area :description, class: "c-input__textarea js-description", id: "description_#{description_type}",
       "aria-describedby" => "ckeditor_#{description_type}" %>
   <%= f.hidden_field :description_type, value: description_type %>
   <%= f.hidden_field :resource_id %>

--- a/stash/stash_datacite/app/views/stash_datacite/fos_subjects/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/fos_subjects/_form.html.erb
@@ -3,7 +3,7 @@
 <%= form_with(url: fos_subjects_update_path, method: :patch, remote: true, authenticity_token: true, id: form_id,
               class: 'c-input' ) do |f| %>
   <% my_suffix = field_suffix(resource) %>
-  <strong><%= label_tag "#{my_suffix}", "Research Domain", class: 'c-input__label' %></strong><br/>
+  <strong><%= label_tag "fos_subject_#{my_suffix}", "Research Domain", class: 'c-input__label' %></strong><br/>
   <%= text_field_tag :fos_subjects, resource&.subjects&.permissive_fos&.first&.subject, id: "fos_subjects_#{my_suffix}",
                      list: "fos_subject_#{my_suffix}", class: 'title c-input__text', size: 70 %>
   <%= hidden_field_tag :id, resource.id %>

--- a/stash/stash_datacite/app/views/stash_datacite/fos_subjects/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/fos_subjects/_form.html.erb
@@ -1,5 +1,5 @@
 <%# the local variable 'resource' should be passed in to this partial %>
-<% form_id = "dc_fos_subject_#{resource.id}" %>
+<% form_id = "dc_fos_subjects_#{resource.id}" %>
 <%= form_with(url: fos_subjects_update_path, method: :patch, remote: true, authenticity_token: true, id: form_id,
               class: 'c-input' ) do |f| %>
   <% my_suffix = field_suffix(resource) %>
@@ -9,7 +9,7 @@
   <%= hidden_field_tag :id, resource.id %>
   <%= hidden_field_tag(:form_id, form_id) %>
 
-  <datalist id="<%= "fos_subjects_#{my_suffix}" %>">
+  <datalist id="<%= "fos_subject_#{my_suffix}" %>">
     <%= options_for_select(StashDatacite::Subject.fos.pluck(:subject).uniq.sort, resource&.subjects&.fos&.first&.subject) %>
   </datalist>
 <% end %>

--- a/stash/stash_datacite/app/views/stash_datacite/fos_subjects/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/fos_subjects/_form.html.erb
@@ -1,15 +1,15 @@
 <%# the local variable 'resource' should be passed in to this partial %>
-<% form_id = "dc_fos_subjects_#{resource.id}" %>
+<% form_id = "dc_fos_subject_#{resource.id}" %>
 <%= form_with(url: fos_subjects_update_path, method: :patch, remote: true, authenticity_token: true, id: form_id,
               class: 'c-input' ) do |f| %>
   <% my_suffix = field_suffix(resource) %>
-  <strong><%= label_tag "fos_subject_#{my_suffix}", "Research Domain", class: 'c-input__label' %></strong><br/>
+  <strong><%= label_tag "fos_subjects_#{my_suffix}", "Research Domain", class: 'c-input__label' %></strong><br/>
   <%= text_field_tag :fos_subjects, resource&.subjects&.permissive_fos&.first&.subject, id: "fos_subjects_#{my_suffix}",
                      list: "fos_subject_#{my_suffix}", class: 'title c-input__text', size: 70 %>
   <%= hidden_field_tag :id, resource.id %>
   <%= hidden_field_tag(:form_id, form_id) %>
 
-  <datalist id="<%= "fos_subject_#{my_suffix}" %>">
+  <datalist id="<%= "fos_subjects_#{my_suffix}" %>">
     <%= options_for_select(StashDatacite::Subject.fos.pluck(:subject).uniq.sort, resource&.subjects&.fos&.first&.subject) %>
   </datalist>
 <% end %>

--- a/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
@@ -46,7 +46,8 @@
 
 
     <%= label_tag :description, "Abstract", class: 'c-input__label required', for: 'description_abstract' %>
-    <%= render partial: "stash_datacite/descriptions/form", locals: { description: @metadata_entry.abstract, description_type: :abstract }  %>
+    <%= render partial: "stash_datacite/descriptions/form", locals: {
+        description: @metadata_entry.abstract, description_type: :abstract, description_name: "abstract" }  %>
 
   <p class="c-input__required-note">required fields</p>
 
@@ -59,10 +60,12 @@
     <% end %>
 
     <%= label_tag :description, "Methods:", class: 'c-input__label', for: 'description_methods' %>&nbsp;&nbsp;How was this dataset collected? How has it been processed?
-    <%= render partial: "stash_datacite/descriptions/form", locals: { description: @metadata_entry.methods, description_type: :methods } %>
+    <%= render partial: "stash_datacite/descriptions/form", locals: {
+        description: @metadata_entry.methods, description_type: :methods, description_name: "methods" } %>
 
     <%= label_tag :description, "Usage Notes:", class: 'c-input__label', for: 'description_other' %>&nbsp;&nbsp;What else would someone need to know to use this dataset? Are there any missing values? Please upload any files necessary for re-use (i.e. ReadMe files) and note them.
-    <%= render partial: "stash_datacite/descriptions/form", locals: { description: @metadata_entry.other, description_type: :other } %>
+    <%= render partial: "stash_datacite/descriptions/form", locals: {
+        description: @metadata_entry.other, description_type: :other, description_name: 'usage notes' } %>
 
 
     <h2 class="o-heading__page-span">Related Works</h2>

--- a/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
@@ -6,7 +6,7 @@
 </div>
 
 <h2 class="o-heading__page-span">Preliminary Information</h2>
-  <div class="js-contributors_form">
+  <div class="js-contributors_form_top">
     <%= render partial: "stash_datacite/metadata_entry_pages/publication", locals: { publication: @publication, resource: @resource } %>
   </div>
 

--- a/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
@@ -45,7 +45,7 @@
   </fieldset>
 
 
-    <%= label_tag :description, "Abstract", class: 'c-input__label required', for: 'description_abstract' %>
+    <%= label_tag :description, "Abstract", class: 'c-input__label required', for: 'cke_description_abstract' %>
     <%= render partial: "stash_datacite/descriptions/form", locals: {
         description: @metadata_entry.abstract, description_type: :abstract, description_name: "abstract" }  %>
 
@@ -59,11 +59,11 @@
     <%= render partial: "stash_datacite/subjects/form", locals: { resource_id: @resource.id } %>
     <% end %>
 
-    <%= label_tag :description, "Methods:", class: 'c-input__label', for: 'description_methods' %>&nbsp;&nbsp;How was this dataset collected? How has it been processed?
+    <%= label_tag :description, "Methods:", class: 'c-input__label', for: 'cke_description_methods' %>&nbsp;&nbsp;How was this dataset collected? How has it been processed?
     <%= render partial: "stash_datacite/descriptions/form", locals: {
         description: @metadata_entry.methods, description_type: :methods, description_name: "methods" } %>
 
-    <%= label_tag :description, "Usage Notes:", class: 'c-input__label', for: 'description_other' %>&nbsp;&nbsp;What else would someone need to know to use this dataset? Are there any missing values? Please upload any files necessary for re-use (i.e. ReadMe files) and note them.
+    <%= label_tag :description, "Usage Notes:", class: 'c-input__label', for: 'cke_description_other' %>&nbsp;&nbsp;What else would someone need to know to use this dataset? Are there any missing values? Please upload any files necessary for re-use (i.e. ReadMe files) and note them.
     <%= render partial: "stash_datacite/descriptions/form", locals: {
         description: @metadata_entry.other, description_type: :other, description_name: 'usage notes' } %>
 

--- a/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
@@ -47,7 +47,7 @@
 			        <%= f.text_field :msid, value: @msid.value, class: "js-msid c-input__text", placeholder: 'APPS-D-17-00113' %>
 			</div>
 			<div class="c-input js-doi-section">
-				<%= f.label "doi", 'DOI', class: 'c-input__label required' %>
+				<%= f.label "primary_article_doi", 'DOI', class: 'c-input__label required' %>
 				<%= f.text_field :primary_article_doi, value: @doi.related_identifier, class: "js-doi c-input__text", placeholder: '5702.125/qlm.1266rr' %>
 			</div>
 		</div>

--- a/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/related_identifiers/_form.html.erb
@@ -7,10 +7,15 @@
     <%#= render "datacite/shared/error_messages", :target => @related_identifier %>
 
     <div class="c-input">
+      <label class="c-input__label" for="work_type_<%= my_suffix %>">Work Type</label>
+      <%# The following adds the model to the label in rails, but doesn't add it to the select, so doing it manually above
+        f.label "work_type_#{my_suffix}", "Work Type", class: 'c-input__label' %>
       <%= f.select(:work_type, StashDatacite::RelatedIdentifier::WORK_TYPE_CHOICES.invert.to_a, {},
                    {id: "work_type_#{my_suffix}", class: "js-work_type c-input__select"}) %>
     </div>
     <div class="c-input">
+      <label class="c-input__label" for="related_identifier_<%= my_suffix %>">Identifier or external url</label>
+      <%# f.label "related_identifier_#{my_suffix}", "Identifier", class: 'c-input__label' %>
       <%= f.text_field :related_identifier, size: 40, id: "related_identifier_#{my_suffix}", class: "js-related_identifier c-input__text",
         placeholder: 'example: https://doi.org/10.1594/PANGAEA.726855' %>
     </div>

--- a/stash/stash_datacite/app/views/stash_datacite/titles/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/titles/_form.html.erb
@@ -2,7 +2,7 @@
 <% form_id = "resource_title_#{resource.id}" %>
 <%= form_with(url: titles_update_path, method: :patch, remote: true, authenticity_token: true, id: form_id, class: 'c-input' ) do %>
   <% my_suffix = field_suffix(resource) %>
-  <strong><%= label_tag "#{my_suffix}", "Dataset Title", class: 'required c-input__label' %></strong><br/>
+  <strong><%= label_tag "title_#{my_suffix}", "Dataset Title", class: 'required c-input__label' %></strong><br/>
   <%= text_field_tag :title, resource.title, id: "title_#{my_suffix}", class: 'title c-input__text', size: 130 %>
   <%= hidden_field_tag :id, resource.id %>
   <%= hidden_field_tag(:form_id, form_id) %>


### PR DESCRIPTION
https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1324

If you look at CKEditor, then adding note below all the places it's used to note people can press ALT-0 for help screen.  Also modifies the text that is associated with the editor and screen readers to have correct name of field and to repeat they can press ALT-0 for help with controls.  Had to do this with trickery since it's inside external libraries (javascript changes it after loading).

Fixing and adding labels.  You can test most labels to see if they're correctly associated by clicking on the label and it automatically goes to the form element.

There were some wonky things in there that got fixed around the top form for choosing manuscript and some other areas not associated correctly on multiple elements (first ones worked but labels were not specific to multiple copies of the forms).