### PR TITLE
3 smaller fixes

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -14,7 +14,7 @@ defaults: &DEFAULTS
     host: ezid.cdlib.org
     port: 443
   google_maps_api_key: <%= Rails.application.credentials[Rails.env.to_sym][:google_maps_api_key] %>
-  contact_us_uri: mailto:help@datadryad.org
+  contact_us_uri: help@datadryad.org
   # sandbox orcid credentials
   orcid:
     site: https://sandbox.orcid.org/

--- a/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
@@ -102,16 +102,10 @@ $(document).ready(function(){
         $('.js-submission').attr('disabled', true); //disable input
     }
   });
+});
 
-	$('#zenodo_license').selectize({
-		sortField: 'text'
-	});
-
-	// write this into the form that gets sent on submission of dataset
-	$('#zenodo_license').change(function (){
-		var selected = $(this).children("option:selected").val();
-		$("#software_license").val(selected);
-	});
+$('#zenodo_license').on('change', function(e){
+	$('#software_license').val($("#zenodo_license option:selected").val());
 });
 </script>
 

--- a/stash/stash_datacite/app/views/stash_datacite/licenses/_software_license.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/licenses/_software_license.html.erb
@@ -2,7 +2,8 @@
     <p>Please select a license from the dropdown list below for your Zenodo software. For guidance,
     check <a href="https://choosealicense.com/" target="_blank">choosealicense.org</a>.</p>
   <div>
-    <label for="zenodo_license" class="required">Select license for software files (type to search within list)</label>
+    <label for="zenodo_license" class="required">Select license for software files</label>
+    <br/>
     <%= select_tag 'zenodo_license',
                    options_from_collection_for_select(StashEngine::SoftwareLicense.all, 'identifier', 'name',
                                                       @resource&.identifier&.software_license&.identifier || 'MIT') %>

--- a/stash/stash_datacite/app/views/stash_datacite/peer_review/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/peer_review/_review.html.erb
@@ -2,7 +2,7 @@
   <p>By choosing this option, your dataset will be private during your related article's peer review period. You will
     have access to a private dataset download URL to be shared with collaborators or the journal. Your dataset will not
     enter curation or be published. Because we may not have the status of your related article, the default for this
-    period is six months. Please email <a href="mail_to:<%= @help_email %>"><%= @help_email %></a> or uncheck this box
+    period is six months. Please <%= mail_to APP_CONFIG[:contact_us_uri], 'email us'  %> or uncheck this box
     at any point if your dataset is ready to enter curation.</p>
 
   <div>

--- a/stash/stash_datacite/app/views/stash_datacite/resources/_in_progress_line.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/resources/_in_progress_line.html.erb
@@ -19,7 +19,7 @@
   <td>
     <% if line.resource&.dataset_in_progress_editor&.id == current_user&.id %>
       <% if line.status == 'error' %>
-        Please <%= link_to 'contact us', StashEngine.app.contact_us_uri %> to fix this submission error.
+        Please <%= mail_to StashEngine.app.contact_us_uri, 'contact us' %> to fix this submission error.
       <% else %>
         <%= button_to 'Resume', stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: line.resource.id), form_class: 'o-button__inline-form', class: 'o-button__plain-text6' %>
         <%= button_to 'Delete', stash_url_helpers.resource_path(line.resource), method: :delete, data: { confirm: 'Are you sure you want to remove this dataset?' }, form_class: 'o-button__inline-form', class: 'o-button__plain-text7' %>

--- a/stash/stash_engine/app/views/stash_engine/shared/_footer.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/shared/_footer.html.erb
@@ -10,8 +10,8 @@
       <% end %>
     </div>
     <div class="c-footer__social-group">
-      <a href="https://twitter.com/datadryad" class="js-nav-out"><i class="fa fa-twitter-square fa-2x"></i> Follow us on Twitter</a>
-      <a href="https://blog.datadryad.org/" class="js-nav-out"><i class="fa fa-rss-square fa-2x"></i> Check out our Blog</a>
+      <a href="https://twitter.com/datadryad" class="js-nav-out"><em class="fa fa-twitter-square fa-2x"></em> Follow us on Twitter</a>
+      <a href="https://blog.datadryad.org/" class="js-nav-out"><em class="fa fa-rss-square fa-2x"></em> Check out our Blog</a>
     </div>
   </div>
   <p>Copyright (c) <%= Time.new.year %> Dryad</p>


### PR DESCRIPTION
1. Fixing email address so it shows up correctly for contact in the "Keep my dataset private" area of review page.
2. Changing `<i></i>` to `<em></em>` if that makes someone happy.  Really no effect since it's just something for bootstrap icons and doesn't show or have any effect, anyway.  That's how bootstrap rolls.
3. Futzing with the software license and just making it a standard select list for now since apparently the other one isn't accessible.  Tried with the html 5 datalist which gets recommended by others, but their use case is different since no easy way to lock to only the options in the list with the datalist and people say to just use the standard select list.
  - We can revisit later and spend a bunch of time in javascript to make the datalist lock to only values in the list, but not going to to it now since I don't have time.