### PR TITLE
 Funder dashboard

### DIFF
--- a/documentation/technical_notes/permissions.md
+++ b/documentation/technical_notes/permissions.md
@@ -18,8 +18,10 @@ Dryad has several levels of permissions. Some permissions are defined by the
 Other permissions are orthogonal to the `User.role`:
 - *journal_admin* -- Has view and edit access to all datasets associated with an
    article in the appropriate journal. Journal administrators are defined by
-  `User.journal_role`, so they may overlap or overried permissions defined by
-  `User.role`. 
+  `User.journal_role`.
+- *funder_admin* -- Has view and edit access to all datasets associated with a
+   given funder. Funder administrators are defined by
+  `FunderRole`
 - *API access* -- All users are able to use the public API without authentication. However,
   some portions of the API require authication. Once a user is
   authenticated through the API, their other permissions take

--- a/spec/factories/stash_engine/funder_roles.rb
+++ b/spec/factories/stash_engine/funder_roles.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+
+  factory :funder_role, class: StashEngine::FunderRole do
+
+    user
+    funder_id { "#{Faker::Name.initials(number: 4)}-#{Faker::Number.number(digits: 4)}" }
+    funder_name { Faker::Company.name }
+    role { 'admin' }
+
+  end
+
+end

--- a/spec/models/stash_engine/funder_role_spec.rb
+++ b/spec/models/stash_engine/funder_role_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+module StashEngine
+
+  RSpec.describe FunderRole, type: :model do
+
+    before(:each) do
+      @user = create(:user)
+      @funder_role1 = create(:funder_role, user: @user)
+      @funder_role2 = create(:funder_role, user: @user)
+      @res = create(:resource)
+    end
+
+    describe 'users as funder admins' do
+      it 'returns funders that the user administers' do
+        expect(@user.funders_as_admin.size).to eql(2)
+        expect(@user.funders_as_admin.map(&:funder_id)).to include(@funder_role1.funder_id)
+        expect(@user.funders_as_admin.map(&:funder_id)).to include(@funder_role2.funder_id)
+
+      end
+
+      it 'disallows editing a resource that has no funder' do
+        expect(@res.admin_for_this_item?(user: @user)).to be_falsey
+      end
+
+      it 'allows editing a resource that has the same funder' do
+        @res.contributors << create(:contributor, resource: @res, name_identifier_id: @funder_role1.funder_id)
+        expect(@res.admin_for_this_item?(user: @user)).to be_truthy
+      end
+
+      it 'disallows editing a resource that has a different funder' do
+        @res.contributors << create(:contributor, resource: @res, name_identifier_id: 'non-matching funder ID')
+        expect(@res.admin_for_this_item?(user: @user)).to be_falsey
+        #### TODO
+      end
+
+    end
+
+  end
+
+end

--- a/spec/models/stash_engine/funder_role_spec.rb
+++ b/spec/models/stash_engine/funder_role_spec.rb
@@ -19,16 +19,16 @@ module StashEngine
 
       end
 
-      it 'disallows editing a resource that has no funder' do
+      it 'disallows admin when resource has no funder' do
         expect(@res.admin_for_this_item?(user: @user)).to be_falsey
       end
 
-      it 'allows editing a resource that has the same funder' do
+      it 'allows admin when resource has the same funder' do
         @res.contributors << create(:contributor, resource: @res, name_identifier_id: @funder_role1.funder_id)
         expect(@res.admin_for_this_item?(user: @user)).to be_truthy
       end
 
-      it 'disallows editing a resource that has a different funder' do
+      it 'disallows admin when resource has a different funder' do
         @res.contributors << create(:contributor, resource: @res, name_identifier_id: 'non-matching funder ID')
         expect(@res.admin_for_this_item?(user: @user)).to be_falsey
         #### TODO

--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -22,12 +22,18 @@ module StashEngine
                           current_user.journals_as_admin.present?
                          current_user.journals_as_admin.map(&:title)
                        end)
+      funder_limit = (if current_user.role != 'superuser' &&
+                         current_user.role != 'curator' &&
+                         current_user.funders_as_admin.present?
+                        current_user.funders_as_admin.map(&:funder_id)
+                      end)
 
       @all_stats = Stats.new
       @seven_day_stats = Stats.new(tenant_id: my_tenant_id, since: (Time.new.utc - 7.days))
       @datasets = StashEngine::AdminDatasets::CurationTableRow.where(params: helpers.sortable_table_params,
                                                                      tenant: tenant_limit,
-                                                                     journals: journal_limit)
+                                                                     journals: journal_limit,
+                                                                     funders: funder_limit)
       @publications = @datasets.collect(&:publication_name).compact.uniq.sort { |a, b| a <=> b }
       @pub_name = params[:publication_name] || nil
 

--- a/stash/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
@@ -62,7 +62,8 @@ module StashEngine
 
     def require_admin
       return if current_user && (%w[admin superuser curator tenant_curator].include?(current_user.role) ||
-                                 current_user.journals_as_admin.present?)
+                                 current_user.journals_as_admin.present? ||
+                                 current_user.funders_as_admin.present?)
 
       flash[:alert] = 'You must be an administrator to view this information.'
       redirect_to stash_engine.dashboard_path

--- a/stash/stash_engine/app/models/stash_engine/funder_role.rb
+++ b/stash/stash_engine/app/models/stash_engine/funder_role.rb
@@ -1,0 +1,7 @@
+module StashEngine
+  class FunderRole < ApplicationRecord
+    belongs_to :user
+
+    scope :admins, -> { where(role: 'admin') }
+  end
+end

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -23,7 +23,7 @@ module StashEngine
     # See https://medium.com/rubyinside/active-records-queries-tricks-2546181a98dd for some good tricks
     # returns the identifiers that have resources with that *latest* curation state you specify (for any of the resources)
     scope :with_visibility, ->(states:, journal_issns: nil, user_id: nil, tenant_id: nil) do
-      where(id: Resource.with_visibility(states: states, journal_issns: journal_issns, user_id: user_id, tenant_id: tenant_id)
+      where(id: Resource.with_visibility(states: states, journal_issns: journal_issns, funder_ids: funder_ids, user_id: user_id, tenant_id: tenant_id)
                         .select('identifier_id').distinct.map(&:identifier_id))
     end
 
@@ -41,6 +41,7 @@ module StashEngine
         with_visibility(states: %w[published embargoed],
                         tenant_id: tenant_admin,
                         journal_issns: user.journals_as_admin.map(&:issn),
+                        funder_ids: user.funders_as_admin.map(&:funder_id),
                         user_id: user.id)
       end
     end

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -22,7 +22,7 @@ module StashEngine
 
     # See https://medium.com/rubyinside/active-records-queries-tricks-2546181a98dd for some good tricks
     # returns the identifiers that have resources with that *latest* curation state you specify (for any of the resources)
-    scope :with_visibility, ->(states:, journal_issns: nil, user_id: nil, tenant_id: nil) do
+    scope :with_visibility, ->(states:, journal_issns: nil, funder_ids: nil, user_id: nil, tenant_id: nil) do
       where(id: Resource.with_visibility(states: states, journal_issns: journal_issns, funder_ids: funder_ids, user_id: user_id, tenant_id: tenant_id)
                         .select('identifier_id').distinct.map(&:identifier_id))
     end

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -570,12 +570,12 @@ module StashEngine
         user_id == user.id ||
         (user.tenant_id == tenant_id && user.role == 'tenant_curator') ||
         (user.tenant_id == tenant_id && user.role == 'admin') ||
-        funders_match? ||
+        funders_match?(user: user) ||
         user.journals_as_admin.include?(identifier&.journal) ||
         (user.journals_as_admin.present? && identifier&.journal.blank?)
     end
 
-    def funders_match?
+    def funders_match?(user:)
       user_funders = user.funders_as_admin
       resource_funders = contributors
       return unless user_funders.present? && resource_funders.present?

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -192,13 +192,16 @@ module StashEngine
                              'LEFT OUTER JOIN stash_engine_internal_data ' \
                              'ON stash_engine_internal_data.identifier_id = stash_engine_identifiers.id'.freeze
 
+    JOIN_FOR_CONTRIBUTORS = 'LEFT OUTER JOIN dcs_contributors ON stash_engine_resources.id = dcs_contributors.resource_id'.freeze
+
     # returns the resources that are currently in a curation state you specify (not looking at obsolete states),
     # ie last state for each resource.  Also returns resources (regardless of curation state) that the user can
     # see due to special privileges:
     #  - resources owned by this user_id
     #  - if tenant is specified, resources associated with the tenant
     #  - if one or more journal_issns are specified, resources associated with the journal(s)
-    scope :with_visibility, ->(states:, journal_issns: nil, user_id: nil, tenant_id: nil) do
+    #  - if one or more funder_ids are specified, resources associated with the funder(s)
+    scope :with_visibility, ->(states:, journal_issns: nil, funder_ids: nil, user_id: nil, tenant_id: nil) do
       my_states = (states.is_a?(String) || states.is_a?(Symbol) ? [states] : states)
       str = 'stash_engine_curation_activities.status IN (?)'
       arr = [my_states]
@@ -214,7 +217,11 @@ module StashEngine
         str += " OR (stash_engine_internal_data.data_type = 'publicationISSN' AND stash_engine_internal_data.value IN (?))"
         arr.push(journal_issns)
       end
-      joins(JOIN_FOR_LATEST_CURATION).joins(JOIN_FOR_INTERNAL_DATA).distinct.where(str, *arr)
+      if funder_ids.present?
+        str += " OR (dcs_contributors.contributor_type = 'funder' AND dcs_contributors.name_identifier_id IN (?))"
+        arr.push(funder_ids)
+      end
+      joins(JOIN_FOR_LATEST_CURATION).joins(JOIN_FOR_INTERNAL_DATA).joins(JOIN_FOR_CONTRIBUTORS).distinct.where(str, *arr)
     end
 
     scope :visible_to_user, ->(user:) do
@@ -226,6 +233,7 @@ module StashEngine
         tenant_admin = (user.tenant_id if user.role == 'admin')
         with_visibility(states: %w[published embargoed],
                         tenant_id: tenant_admin,
+                        funder_ids: user.funders_as_admin.map(&:funder_id),
                         journal_issns: user.journals_as_admin.map(&:issn),
                         user_id: user.id)
       end
@@ -562,8 +570,19 @@ module StashEngine
         user_id == user.id ||
         (user.tenant_id == tenant_id && user.role == 'tenant_curator') ||
         (user.tenant_id == tenant_id && user.role == 'admin') ||
+        funders_match? ||
         user.journals_as_admin.include?(identifier&.journal) ||
         (user.journals_as_admin.present? && identifier&.journal.blank?)
+    end
+
+    def funders_match?
+      user_funders = user.funders_as_admin
+      resource_funders = contributors
+      return unless user_funders.present? && resource_funders.present?
+
+      user_funder_ids = user_funders.map(&:funder_id).reject(&:empty?)
+      resource_funder_ids = resource_funders.map(&:name_identifier_id).reject(&:empty?)
+      user_funder_ids.&(resource_funder_ids).present?
     end
 
     # have the permission to edit

--- a/stash/stash_engine/app/models/stash_engine/user.rb
+++ b/stash/stash_engine/app/models/stash_engine/user.rb
@@ -49,6 +49,10 @@ module StashEngine
       admin_journals + admin_org_journals
     end
 
+    def funders_as_admin
+      StashEngine::FunderRole.where(user_id: id, role: 'admin')
+    end
+    
     NO_MIGRATE_STRING = 'xxxxxx'.freeze
 
     def migration_complete?

--- a/stash/stash_engine/app/models/stash_engine/user.rb
+++ b/stash/stash_engine/app/models/stash_engine/user.rb
@@ -52,7 +52,7 @@ module StashEngine
     def funders_as_admin
       StashEngine::FunderRole.where(user_id: id, role: 'admin')
     end
-    
+
     NO_MIGRATE_STRING = 'xxxxxx'.freeze
 
     def migration_complete?

--- a/stash/stash_engine/app/views/stash_engine/pages/_nav.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/pages/_nav.html.erb
@@ -29,7 +29,8 @@
           </details>
         </div>
       </div>
-    <% elsif current_user && (current_user.role == 'admin' || current_user.role == 'tenant_curator' || current_user.journals_as_admin.present? )%>
+    <% elsif current_user && (current_user.role == 'admin' || current_user.role == 'tenant_curator' ||
+			      current_user.journals_as_admin.present? || current_user.funders_as_admin.present?)%>
       <%= link_to 'Admin', stash_url_helpers.url_for(controller: 'stash_engine/admin_datasets', action: 'index', only_path: true), class: 'c-header__nav-item' %>
     <% end %>
     <%# link_to 'Home', stash_url_helpers.root_path, class: 'c-header__nav-item' %>

--- a/stash/stash_engine/db/migrate/20210813195352_create_funder_roles.rb
+++ b/stash/stash_engine/db/migrate/20210813195352_create_funder_roles.rb
@@ -1,0 +1,11 @@
+class CreateFunderRoles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :stash_engine_funder_roles do |t|
+      t.belongs_to :user
+      t.string :funder_id
+      t.string :funder_name
+      t.string :role
+      t.timestamps  
+    end
+  end
+end


### PR DESCRIPTION
For: https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1402

Allow users to be assigned a role as administrator of a funder. Users with this assignment may view the Admin Dashboard, and see datasets there that are associated with the funder.

This does not add an explicit model object for funders. Instead, the relationships are tracked using FundRef IDs. The IDs are stored in `dcs_contributors` for the resources, and `stash_engine_funder_roles` for the users.

To test:
- identify a user that has only basic "user" permissions
- create a FunderRole associated with the user, like `fr = StashEngine::FunderRole.new(user: u, funder_id: 'http://dx.doi.org/10.13039/100000001', funder_name: 'NSF', role: 'admin')`
- login as this user
- view the Admin Dashboard, and verify that all of the visible datasets are associated with the funder