### PR TITLE
Update some gem versions for security issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'httparty'
 gem 'jbuilder', '~> 2.0'
 gem 'net-sftp'
 gem 'rb-readline', '~> 0.5.5', require: false
-gem 'restforce', '~> 2.5.3'
+gem 'restforce', '~> 3.0'
 gem 'stripe'
 gem 'wicked_pdf'
 gem 'wkhtmltopdf-binary'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -731,7 +731,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    restforce (2.5.4)
+    restforce (3.2.0)
       faraday (>= 0.9.0, <= 1.0)
       faraday_middleware (>= 0.8.8, <= 1.0)
       hashie (>= 1.2.0, < 4.0)
@@ -974,7 +974,7 @@ DEPENDENCIES
   rails (~> 5.2)
   rb-readline (~> 0.5.5)
   react-rails (~> 2.6.1)
-  restforce (~> 2.5.3)
+  restforce (~> 3.0)
   rspec-collection_matchers
   rspec-github
   rspec-html
@@ -1007,4 +1007,4 @@ DEPENDENCIES
   yui-compressor
 
 BUNDLED WITH
-   2.2.17
+   2.2.24

--- a/stash/stash_api/Gemfile.lock
+++ b/stash/stash_api/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     amatch (0.4.0)
       mize

--- a/stash/stash_datacite/Gemfile.lock
+++ b/stash/stash_datacite/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     amatch (0.4.0)
       mize

--- a/stash/stash_engine/Gemfile.lock
+++ b/stash/stash_engine/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     amazing_print (1.3.0)
     amoeba (3.0.0)


### PR DESCRIPTION
These were suggested by dependabot. There are still others that it recommends, but these didn't require much testing.