### PR TITLE
Improve robustness of Frictionless

### DIFF
--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -65,8 +65,8 @@ module StashEngine
         end
 
         # I think there was something weird about Amoeba that required this approach
-        resources = new_resource.generic_files.select { |ar_record| ar_record.file_state == 'deleted' }
-        resources.each(&:delete)
+        deleted_files = new_resource.generic_files.select { |ar_record| ar_record.file_state == 'deleted' }
+        deleted_files.each(&:destroy)
       end)
     end
 


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1424

Cleanup of some issues related to frictionless:
- When versioning a resource, the file entries must be removed with `destroy` instead of `delete`, so the dependent frictionless reports are also deleted.
- Improve parsing of the JSON that is output by frictionless