### PR TITLE
Lower timeout for requests to Merritt

### DIFF
--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -362,6 +362,8 @@ module StashApi
         when 202
           render status: 202, plain: 'The version of the dataset is being assembled. ' \
           "Check back in around #{time_ago_in_words(res.download_token.available + 30.seconds)} and it should be ready to download."
+        when 408
+          render status: 503, plain: 'Download Service Unavailable for this request'
         else
           render status: 404, plain: 'Not found'
         end

--- a/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/downloads_controller.rb
@@ -82,7 +82,7 @@ module StashEngine
       logger.warn("Timeout in downloads_controller#assembly_status for #{@resource&.id}") if @status_hash[:status] == 408
       render json: @status_hash
     rescue HTTP::TimeoutError
-      logger.warn("Timeout in downloads_controller#assembly_status for #{@resource&.id}")
+      logger.warn("HTTP Timeout from Merritt in downloads_controller#assembly_status for Resource #{@resource&.id}")
       render json: { status: 408 }
     end
 
@@ -193,7 +193,7 @@ module StashEngine
     end
 
     def notify_download_timeout
-      msg = "Timeout in downloads_controller#download_resource for #{@resource&.id} for IP #{request.remote_ip}"
+      msg = "Timeout in downloads_controller#download_resource for resource #{@resource&.id} for IP #{request.remote_ip}"
       logger.warn(msg)
       ExceptionNotifier.notify_exception(Stash::Download::MerrittException.new(msg))
     end

--- a/stash/stash_engine/app/models/stash_engine/data_file.rb
+++ b/stash/stash_engine/app/models/stash_engine/data_file.rb
@@ -36,7 +36,7 @@ module StashEngine
       raise Stash::Download::MerrittError, "Tenant not defined for resource_id: #{resource&.id}" if resource&.tenant.blank?
 
       http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
-        .timeout(connect: 30, read: 30).timeout(60).follow(max_hops: 2)
+        .timeout(connect: 5, read: 5).timeout(5).follow(max_hops: 2)
         .basic_auth(user: resource.tenant.repository.username, pass: resource.tenant.repository.password)
 
       r = http.get(merritt_presign_info_url)

--- a/stash/stash_engine/lib/stash/download/file_presigned.rb
+++ b/stash/stash_engine/lib/stash/download/file_presigned.rb
@@ -17,7 +17,7 @@ module Stash
         @cc = controller_context
       end
 
-      # file is file_upload from ActiveRecord
+      # file is file from ActiveRecord object
       def download(file:)
         tenant = file&.resource&.tenant
         if file.blank? || tenant.blank?

--- a/stash/stash_engine/lib/stash/download/version_presigned.rb
+++ b/stash/stash_engine/lib/stash/download/version_presigned.rb
@@ -21,7 +21,7 @@ module Stash
         @domain = @tenant&.repository&.domain
 
         @http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
-          .timeout(connect: 30, read: 30).timeout(30.seconds.to_i).follow(max_hops: 3)
+          .timeout(connect: 5, read: 5).timeout(5.seconds.to_i).follow(max_hops: 3)
           .basic_auth(user: @tenant&.repository&.username, pass: @tenant&.repository&.password)
       end
 


### PR DESCRIPTION
for creating presigned downloads or packaging requests

This will make it less likely that our request queue for passenger gets > 100 which knocks our service out since we're not waiting 30 seconds or 60 seconds for Merritt to respond with info about a download.  Terry said 5 seconds was enough time for these requests to be fulfilled normally unless something bad is going on.