### PR TITLE
Automatically close page for EM API

### DIFF
--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -256,7 +256,8 @@ module StashApi
     # Reformat a `metadata` response object, putting it in the format that Editorial Manager prefers
     def em_reformat_response(metadata:, deposit_request:)
       sharing_link = @stash_identifier.shares&.first&.sharing_link
-      edit_url = (request.protocol + request.host_with_port + metadata[:editLink] if metadata[:editLink])
+      return_link = "?returnURL=#{StashEngine::Engine.routes.url_helpers.close_page_path}"
+      edit_url = (request.protocol + request.host_with_port + metadata[:editLink] + return_link if metadata[:editLink])
       {
         deposit_id: @stash_identifier.identifier,
         deposit_doi: @stash_identifier.identifier,

--- a/stash/stash_engine/app/controllers/stash_engine/pages_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/pages_controller.rb
@@ -8,6 +8,9 @@ module StashEngine
       @hostname = request.host
     end
 
+    # Utility page that closes itself
+    def close_page; end
+
     def best_practices; end
 
     def jounral_integration; end

--- a/stash/stash_engine/app/views/stash_engine/pages/close_page.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/pages/close_page.html.erb
@@ -1,0 +1,7 @@
+<% @page_title = 'Close page' %>
+
+<body onload="window.open('', '_self', ''); window.close();">
+    <h1>Operation Complete</h1>
+    <p>Please close this page and return to your previous page.</p>
+</body>
+

--- a/stash/stash_engine/config/routes.rb
+++ b/stash/stash_engine/config/routes.rb
@@ -91,6 +91,7 @@ StashEngine::Engine.routes.draw do
   post 'sessions/no_partner', to: 'sessions#no_partner', as: 'no_partner'
   post 'sessions/sso', to: 'sessions#sso', as: 'sso'
 
+  get 'close_page', to: 'pages#close_page'
   get 'faq', to: 'pages#faq'
   get 'best_practices', to: 'pages#best_practices'
   get 'our_community', to: 'pages#our_membership'


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1440

When users make a deposit through the Editorial Manager API, they are redirected to an `edit_url`. This PR adds a parameter to the `edit_url` so the page will close at the end of the submission process.

Unfortunately, the JavaScript for closing a page does not work consistently in all browsers. For browsers where it does not work, the page text simply instructs the user to close the page themselves.