### PR TITLE
Fix api version downloads

### DIFF
--- a/spec/requests/stash_api/versions_controller_spec.rb
+++ b/spec/requests/stash_api/versions_controller_spec.rb
@@ -247,7 +247,7 @@ module StashApi
       describe 'permissions' do
         before(:each) do
           allow_any_instance_of(Stash::Download::VersionPresigned).to receive(:download)
-                                                                        .and_return({ status: 200, url: 'http://example.com/fun' }.with_indifferent_access)
+            .and_return({ status: 200, url: 'http://example.com/fun' }.with_indifferent_access)
         end
 
         it 'downloads a public version' do
@@ -311,7 +311,7 @@ module StashApi
 
         it 'handles 202 from Merritt presigned library' do
           allow_any_instance_of(Stash::Download::VersionPresigned).to receive(:download)
-                                                                        .and_return({ status: 202, url: 'http://example.com/fun' }.with_indifferent_access)
+            .and_return({ status: 202, url: 'http://example.com/fun' }.with_indifferent_access)
           # some horrific callback or something that is untraceable keeps resetting file_view to false
           @resources[0].update(file_view: true)
 
@@ -325,7 +325,7 @@ module StashApi
 
         it 'handles 408 from Merritt presigned library' do
           allow_any_instance_of(Stash::Download::VersionPresigned).to receive(:download)
-                                                                        .and_return({ status: 408 }.with_indifferent_access)
+            .and_return({ status: 408 }.with_indifferent_access)
           # some horrific callback or something that is untraceable keeps resetting file_view to false
           @resources[0].update(file_view: true)
 
@@ -338,7 +338,7 @@ module StashApi
 
         it 'handles other random code from Merritt presigned library' do
           allow_any_instance_of(Stash::Download::VersionPresigned).to receive(:download)
-                                                                        .and_return({ status: 417 }.with_indifferent_access)
+            .and_return({ status: 417 }.with_indifferent_access)
           # some horrific callback or something that is untraceable keeps resetting file_view to false
           @resources[0].update(file_view: true)
 

--- a/spec/requests/stash_api/versions_controller_spec.rb
+++ b/spec/requests/stash_api/versions_controller_spec.rb
@@ -50,7 +50,7 @@ module StashApi
 
       # we get some crazy failures and it refused to update the resource because of ridiculous curation failures if user zero doesn't exist
       # Took me hours to figure out and really annoying.
-      @sys_user = create(:user, id: 0, tenant_id: @tenant_ids.first, role: 'user', first_name: "system user")
+      @sys_user = create(:user, id: 0, tenant_id: @tenant_ids.first, role: 'user', first_name: 'system user')
 
       # be sure versions are set correctly, because creating them manually like this doesn't ensure it
       @resources[0].stash_version.update(version: 1)
@@ -241,10 +241,10 @@ module StashApi
 
         @resources[1].current_state = 'submitted' # has to show submitted to merritt in order to download
 
-        allow_any_instance_of(Stash::Download::VersionPresigned).to receive("valid_resource?").and_return(true)
+        allow_any_instance_of(Stash::Download::VersionPresigned).to receive('valid_resource?').and_return(true)
 
         allow_any_instance_of(Stash::Download::VersionPresigned).to receive(:download)
-          .and_return({status: 200, url: 'http://example.com/fun'}.with_indifferent_access)
+          .and_return({ status: 200, url: 'http://example.com/fun' }.with_indifferent_access)
       end
 
       it 'downloads a public version' do

--- a/stash/stash_api/app/controllers/stash_api/concerns/downloadable.rb
+++ b/stash/stash_api/app/controllers/stash_api/concerns/downloadable.rb
@@ -1,0 +1,34 @@
+require 'stash/download/version_presigned'
+
+module StashApi
+  module Concerns
+    module Downloadable
+      extend ActiveSupport::Concern
+      include ActionView::Helpers::DateHelper
+
+      private
+
+      # this really requires resource passed in and @user to be set (if there is one)
+      def download_version(resource:)
+        @version_presigned = Stash::Download::VersionPresigned.new(resource: resource)
+        if resource&.may_download?(ui_user: @user) && @version_presigned.valid_resource?
+          @status_hash = @version_presigned.download
+          case @status_hash[:status]
+          when 200
+            StashEngine::CounterLogger.version_download_hit(request: request, resource: resource)
+            redirect_to @status_hash[:url]
+          when 202
+            render status: 202, plain: 'The version of the dataset is being assembled. ' \
+              "Check back in around #{time_ago_in_words(resource.download_token.available + 30.seconds)} and it should be ready to download."
+          when 408
+            render status: 503, plain: 'Download Service Unavailable for this request'
+          else
+            render status: 404, plain: 'Not found'
+          end
+        else
+          render plain: 'download for this version of the dataset is unavailable', status: 404
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Makes the code for download dataset and download version common
- Fixes tests that were there for security checks and download
- Adds tests for redirect statuses and info

This turned into a huge pain for tests because of some hidden callbacks and validations on the curation activities that interfere with the resource class saving and operating independently. (User 0 didn't exist in the database so updates to resource didn't work because curation activities were being added when they weren't useful and validation failed because of missing user which canceled updates on resources without warning.)

I'm starting to be of the opinion that these kinds of side-effect callbacks on related things are something of an anti-pattern unless they really need to be applied every single time something happens and in a deep way across all models all the time.  It took forever to trace and figure out and the deep side effects weren't showing why things failed on unrelated models until I dug for a while.