### PR TITLE
Ignore rack attack limits for presigning chunk uploads for files

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -39,8 +39,9 @@ end
 
 # Baseline throttle all requests by IP
 # But don't return anything for /assets, which are just part of each page and should not be tracked.
+# Also, don't throttle AWS presign requests for upload chunks that will be sent to S3 for files
 Rack::Attack.throttle('all_requests_by_IP', limit: APP_CONFIG[:rate_limit][:all_requests], period: 1.minute) do |req|
-  req.ip unless req.path.start_with?('/assets')
+  req.ip unless req.path.start_with?('/assets') || req.path.match(%r{^/stash/[a-z]+_file/presign_upload/\d+})
 end
 
 # Zip downloads have a much lower limit than other requests,


### PR DESCRIPTION
Otherwise, dropping a large number of files at once makes some stall and not upload.

This is an easy change to rack::attack.

I tested on my dev machine with the huge group of files I used to find problem on production.

I can retag our release with this incorporated and test on dev/stage and redeploy to production.