### PR TITLE
Allow journal links to work

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,7 +113,8 @@ Rails.application.routes.draw do
   get '/themes/Dryad/images/:image', to: redirect('/images/%{image}')
   get '/themes/Dryad/images/dryadLogo.png', to: redirect('/images/logo_dryad.png')
   get '/themes/Mirage/docs/:doc', to: redirect('/docs/%{doc}.%{format}')
-
+  get '/submit', to: redirect("/stash/resources/new")
+  
   # Routing to redirect old Dryad landing pages to the correct location
   # Regex based on https://www.crossref.org/blog/dois-and-matching-regular-expressions/ but a little more restrictive specific to old dryad
   # Dataset:            https://datadryad.org/resource/doi:10.5061/dryad.kq201


### PR DESCRIPTION
Many journals direct their authors to submit data using a link like:
http://datadryad.org/submit?journalID=ECE3&manu=ECE-2021-04-12345.R1

We previously had a redirect in Apache to handle these URLs, but the redirect didn't carry over to the new servers. I'm adding it to Rails so we have direct control over it for the future.