### PR TITLE
Adding source for pyenv for counter script so that pyenv loads for cron

### DIFF
--- a/cron/weekly.sh
+++ b/cron/weekly.sh
@@ -17,6 +17,7 @@ bundle exec rails counter:populate_citations >> /apps/dryad/apps/ui/shared/cron/
 # the MDC/counter processor only runs in the production environment to send stats to the datacite hub, no need to run in other environments
 if [ "$RAILS_ENV" == "production" ] || [ "$RAILS_ENV" == "stage" ]
 then
+    source ~/.profile.d/pyenv
     cd /apps/dryad/apps/ui/current/cron
     ./counter.sh >> /apps/dryad/apps/ui/shared/cron/logs/counter.log 2>&1
 fi


### PR DESCRIPTION
Pyenv wasn't loading correctly under cron environment and was using the wrong version of python when it ran weekly.

I tested this manually according to the info at https://stackoverflow.com/questions/2135478/how-to-simulate-the-environment-cron-executes-a-script-with   .  I tried getting the environment and going into a shell with it and then sourcing `~/.profile.d/pyenv`.  It then shows the correct version of python (3.7.9) rather than python 2.