### PR TITLE
Force irb to be part of the environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ require File.join(File.dirname(__FILE__), 'lib', 'bundler_help.rb')
 # ############################################################
 # Rails
 
-gem 'irb', '~> 1.3.7' 
+gem 'irb', '~> 1.3.7'
 gem 'mysql2', '~> 0.5.3'
 gem 'rails', '~> 5.2'
 gem 'react-rails', '~> 2.6.1'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ require File.join(File.dirname(__FILE__), 'lib', 'bundler_help.rb')
 # ############################################################
 # Rails
 
+gem 'irb', '~> 1.3.7' 
 gem 'mysql2', '~> 0.5.3'
 gem 'rails', '~> 5.2'
 gem 'react-rails', '~> 2.6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -481,6 +481,9 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    io-console (0.5.9)
+    irb (1.3.7)
+      reline (>= 0.2.7)
     iso8601 (0.9.1)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
@@ -718,6 +721,8 @@ GEM
     redcarpet (3.5.1)
     ref (2.0.0)
     regexp_parser (2.1.1)
+    reline (0.2.7)
+      io-console (~> 0.5)
     representable (3.1.1)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -959,6 +964,7 @@ DEPENDENCIES
   guard-rspec
   http
   httparty
+  irb (~> 1.3.7)
   jbuilder (~> 2.0)
   jquery-rails
   listen


### PR DESCRIPTION
irb exists in most Rails environments, but we need to explicitly include it due to the setup of the new servers that Dryad uses.

With this change, you should be able to enter a Rails console using a command like:
```
cd /apps/dryad/apps/ui/current/
RAILS_ENV=development bundle exec rails console
```