### PR TITLE
Don't allow "reverting" datasets never submitted

### DIFF
--- a/stash/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
@@ -80,7 +80,7 @@ module StashEngine
     # only someone who has created the dataset in progress can edit it.  Other users can't until they're finished
     def require_in_progress_editor
       return if valid_edit_code? ||
-                resource.dataset_in_progress_editor.id == current_user.id ||
+                resource&.dataset_in_progress_editor&.id == current_user.id ||
                 current_user.curator?
 
       display_authorization_failure

--- a/stash/stash_engine/app/views/stash_engine/shared/_dataset_non_user_editor.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/shared/_dataset_non_user_editor.html.erb
@@ -1,13 +1,19 @@
 <% # takes resource as local %>
 <% unless current_user&.id == resource.user_id %>
+  <% revertible = resource.identifier.resources.count > 1 %>
   <div class="c-admin-editing-banner">
     <div class="o-div__placeholder"></div>
     <div class="o-div__editing_msg">
       You are editing <%= resource.user.name %>'s dataset.
+      <% unless revertible %>
+        <p>This dataset has never been submitted, so no checkpoints have been created.  Any changes you make are permanent.</p>
+      <% end %>
     </div>
     <div>
-      <%= button_to 'Cancel and Discard Changes', stash_url_helpers.resource_path(resource), method: :delete, data: { confirm: 'Are you sure?' },
-          form_class: 'o-button__inline-form', class: 'o-button__cancel-edit' %>
+      <% if revertible %>
+        <%= button_to 'Cancel and Discard Changes', stash_url_helpers.resource_path(resource), method: :delete, data: { confirm: 'Are you sure?' },
+            form_class: 'o-button__inline-form', class: 'o-button__cancel-edit' %>
+      <% end %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
I believe removing the dataset staging version under editing should be disallowed under circumstances where no version of it was ever submitted.

We may want to give curators a way to return control back to the user instead (aside from submitting their changes, which does that), but at least for now we can prevent them from destroying completely unsubmitted data with dangerous actions.