### PR TITLE
Allow page size selection in all API calls

### DIFF
--- a/spec/requests/stash_api/datasets_controller_spec.rb
+++ b/spec/requests/stash_api/datasets_controller_spec.rb
@@ -422,6 +422,17 @@ module StashApi
           # this would be private based on curation status, but the journal admin should be able to see it
           expect(dois).to include(@identifiers[1].to_s)
         end
+
+        it 'correctly pages index results' do
+          # There are 8 results total
+          get '/api/v2/datasets?page=2&per_page=2', headers: default_authenticated_headers
+          output = response_body_hash
+          expect(output['_links']['last']['href']).to include('page=4')
+
+          get '/api/v2/datasets?page=2&per_page=3', headers: default_authenticated_headers
+          output = response_body_hash
+          expect(output['_links']['last']['href']).to include('page=3')
+        end
       end
 
       describe 'shows appropriate latest resource metadata under identifier based on user' do
@@ -504,7 +515,7 @@ module StashApi
         expect(result['curationStatus']).to eq('Published')
       end
 
-      it 'correctly pages results' do
+      it 'correctly pages search results' do
         # the mocked solr response reports that there are 110 total results, but only
         # includes 5 of those results
         get '/api/v2/search?q=data&page=2&per_page=6', headers: default_authenticated_headers

--- a/stash/stash_api/app/controllers/stash_api/application_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/application_controller.rb
@@ -18,8 +18,12 @@ module StashApi
       @page ||= (params[:page].to_i.positive? ? params[:page].to_i : 1)
     end
 
-    def paging_hash(result_count:, page_size: DEFAULT_PAGE_SIZE)
-      up = UrlPager.new(current_url: request.original_url, result_count: result_count, current_page: page, page_size: page_size)
+    def per_page
+      [params['per_page']&.to_i || DEFAULT_PAGE_SIZE, 100].min
+    end
+
+    def paging_hash(result_count:)
+      up = UrlPager.new(current_url: request.original_url, result_count: result_count, current_page: page, page_size: per_page)
       up.paging_hash
     end
 

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -298,7 +298,7 @@ module StashApi
         ds_query = ds_query.with_visibility(states: params['curationStatus']) # this finds identifiers with a version with this state, acceptable?
       end
 
-      datasets = paged_datasets(datasets: ds_query)
+      datasets = paged_datasets(datasets: ds_query, page_size: per_page)
       render json: datasets
     end
 
@@ -306,7 +306,6 @@ module StashApi
     def search
       # datasets in SOLR are always public, so there is no need to limit the query based on the API user
       page = params['page'] || 1
-      per_page = [params['per_page']&.to_i || DEFAULT_PAGE_SIZE, 100].min
       query = params['q']
 
       begin
@@ -437,6 +436,10 @@ module StashApi
     end
 
     private
+
+    def per_page
+      [params['per_page']&.to_i || DEFAULT_PAGE_SIZE, 100].min
+    end
 
     def setup_identifier_and_resource_for_put
       @stash_identifier = get_stash_identifier(params[:id]) || get_stash_identifier(params[:deposit_id])

--- a/stash/stash_api/app/controllers/stash_api/files_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/files_controller.rb
@@ -178,7 +178,7 @@ module StashApi
 
       visible = resource.data_files.present_files
       all_count = visible.count
-      data_files = visible.limit(DEFAULT_PAGE_SIZE).offset(DEFAULT_PAGE_SIZE * (page - 1))
+      data_files = visible.limit(per_page).offset(per_page * (page - 1))
       results = data_files.map { |i| StashApi::File.new(file_id: i.id).metadata }
       files_output(all_count, results)
     end

--- a/stash/stash_api/app/controllers/stash_api/users_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/users_controller.rb
@@ -38,7 +38,7 @@ module StashApi
 
     def paged_users(results)
       all_count = results.count
-      results = results.limit(page_size).offset(page_size * (page - 1))
+      results = results.limit(per_page).offset(per_page * (page - 1))
       results = results.map { |user| User.new(user_id: user.id).metadata }
       paging_hash_results(all_count, results)
     end

--- a/stash/stash_api/app/controllers/stash_api/versions_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/versions_controller.rb
@@ -46,7 +46,7 @@ module StashApi
       id = StashEngine::Identifier.find_with_id(params[:dataset_id])
       limited_resources = id.resources.visible_to_user(user: @user)
       all_count = limited_resources.count
-      results = limited_resources.limit(DEFAULT_PAGE_SIZE).offset(DEFAULT_PAGE_SIZE * (page - 1))
+      results = limited_resources.limit(per_page).offset(per_page * (page - 1))
       results = results.map { |i| Version.new(resource_id: i.id).metadata_with_links }
       page_output(all_count, results)
     end

--- a/stash/stash_api/public/openapi.yml
+++ b/stash/stash_api/public/openapi.yml
@@ -195,6 +195,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/doi'
         - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/per_page'
       responses:
         '200':
           description: A list of a dataset's versions
@@ -231,6 +232,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/version_id'
         - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/per_page'
       responses:
         '200':
           description: A list of the files in the version
@@ -909,7 +911,7 @@ components:
         type: integer
       description:
         Number of results to return on each page. Defaults
-        to 10. Maximum allowed is 100.
+        to 20. Maximum allowed is 100.
 
     publicationISSN:
       in: query


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1101

- Fixes the `/datasets` call so the `page_size` is actually applied as the documentation specifies.
- Adds `page_size` to calls for `files` and `versions`