### PR TITLE
Also link salesforce cases where leading zeroes were omitted

### DIFF
--- a/stash/stash_engine/lib/stash/salesforce.rb
+++ b/stash/stash_engine/lib/stash/salesforce.rb
@@ -16,7 +16,8 @@ module Stash
     def self.case_id(case_num:)
       return unless case_num
 
-      result = db_query("SELECT Id FROM Case Where CaseNumber = '#{case_num}'")
+      result = db_query("SELECT Id FROM Case Where CaseNumber = '#{case_num}' " \
+                        "or CaseNumber like '%00#{case_num}'")
       return unless result && result.size > 0
 
       result.first['Id']


### PR DESCRIPTION
When I originally checked the curation activities to see the formats being used for Salesforce tickets, I thought all of the references used the full case number. However, in some recent datasets, I see the leading zeroes omitted. This will allow them to display as links.