### PR TITLE
Sets content-type of 'application/json' when that's what we return

### DIFF
--- a/spec/requests/stash_api/datasets_controller_spec.rb
+++ b/spec/requests/stash_api/datasets_controller_spec.rb
@@ -596,7 +596,7 @@ module StashApi
 
       it 'shows the dataset with the correct json type, even if not set explicitly in accept headers' do
         get "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}", headers: { 'ACCEPT' => '*/*' }
-        expect(response.headers['Content-type']).to eq('application/json')
+        expect(response.headers['Content-type']).to eq('application/json; charset=utf-8')
       end
 
       it 'shows the private record for superuser' do

--- a/spec/requests/stash_api/datasets_controller_spec.rb
+++ b/spec/requests/stash_api/datasets_controller_spec.rb
@@ -594,6 +594,11 @@ module StashApi
         expect(hsh['editLink']).to eq(nil)
       end
 
+      it 'shows the dataset with the correct json type, even if not set explicitly in accept headers' do
+        get "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}", headers: { 'ACCEPT' => '*/*' }
+        expect(response.headers['Content-type']).to eq('application/json')
+      end
+
       it 'shows the private record for superuser' do
         @identifier.edit_code = Faker::Number.number(digits: 6)
         @identifier.save

--- a/stash/stash_api/app/controllers/stash_api/application_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/application_controller.rb
@@ -118,7 +118,7 @@ module StashApi
     end
 
     def force_json_content_type
-      response.headers['Content-Type'] = 'application/json'
+      response.headers['Content-Type'] = 'application/json; charset=utf-8'
     end
   end
 end

--- a/stash/stash_api/app/controllers/stash_api/application_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/application_controller.rb
@@ -117,5 +117,8 @@ module StashApi
       end
     end
 
+    def force_json_content_type
+      response.headers['Content-Type'] = 'application/json'
+    end
   end
 end

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -13,6 +13,7 @@ module StashApi
     include StashApi::Concerns::Downloadable
 
     before_action :require_json_headers, only: %i[show create index update]
+    before_action :force_json_content_type
     before_action -> { require_stash_identifier(doi: params[:id]) }, only: %i[show download]
     before_action :setup_identifier_and_resource_for_put, only: %i[update em_submission_metadata set_internal_datum add_internal_datum]
     before_action :doorkeeper_authorize!, only: %i[create update]

--- a/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -13,7 +13,7 @@ module StashApi
     include StashApi::Concerns::Downloadable
 
     before_action :require_json_headers, only: %i[show create index update]
-    before_action :force_json_content_type
+    before_action :force_json_content_type, except: :download
     before_action -> { require_stash_identifier(doi: params[:id]) }, only: %i[show download]
     before_action :setup_identifier_and_resource_for_put, only: %i[update em_submission_metadata set_internal_datum add_internal_datum]
     before_action :doorkeeper_authorize!, only: %i[create update]

--- a/stash/stash_api/app/controllers/stash_api/files_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/files_controller.rb
@@ -11,6 +11,7 @@ module StashApi
   class FilesController < ApplicationController
 
     before_action :require_json_headers, only: %i[show index destroy]
+    before_action :force_json_content_type, except: :download
     before_action -> { require_resource_id(resource_id: params[:version_id]) }, only: [:index]
     before_action -> { require_file_id(file_id: params[:id]) }, only: %i[show destroy download]
     before_action -> { require_stash_identifier(doi: params[:id]) }, only: %i[update]

--- a/stash/stash_api/app/controllers/stash_api/general_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/general_controller.rb
@@ -6,6 +6,7 @@ module StashApi
   class GeneralController < ApplicationController
 
     before_action :require_json_headers
+    before_action :force_json_content_type
     before_action :doorkeeper_authorize!, only: :test
     before_action :require_api_user, only: :test
 

--- a/stash/stash_api/app/controllers/stash_api/submission_queue_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/submission_queue_controller.rb
@@ -4,6 +4,7 @@ require_dependency 'stash_api/datasets_controller'
 module StashApi
   class SubmissionQueueController < ApplicationController
     before_action :require_json_headers
+    before_action :force_json_content_type
     before_action :doorkeeper_authorize!
     before_action :require_api_user
     before_action :require_superuser

--- a/stash/stash_api/app/controllers/stash_api/urls_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/urls_controller.rb
@@ -5,6 +5,7 @@ module StashApi
   class UrlsController < ApplicationController
 
     before_action :require_json_headers
+    before_action :force_json_content_type
     before_action -> { require_stash_identifier(doi: params[:dataset_id]) }, only: %i[create]
     before_action :doorkeeper_authorize!, only: :create
     before_action :require_api_user, only: :create

--- a/stash/stash_api/app/controllers/stash_api/users_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/users_controller.rb
@@ -4,6 +4,7 @@ module StashApi
   class UsersController < ApplicationController
 
     before_action :require_json_headers
+    before_action :force_json_content_type
     before_action :doorkeeper_authorize!, only: %i[show index]
     before_action :require_api_user, only: %i[show index]
     before_action :require_admin, only: %i[show index]

--- a/stash/stash_api/app/controllers/stash_api/versions_controller.rb
+++ b/stash/stash_api/app/controllers/stash_api/versions_controller.rb
@@ -7,6 +7,7 @@ module StashApi
     include StashApi::Concerns::Downloadable
 
     before_action :require_json_headers, only: %i[show index]
+    before_action :force_json_content_type, except: :download
     before_action -> { require_stash_identifier(doi: params[:dataset_id]) }, only: [:index]
     before_action -> { require_resource_id(resource_id: params[:id]) }, only: %i[show download]
     before_action :optional_api_user


### PR DESCRIPTION
I ran across this problem when playing with the API for curator downloads.  If you forget to set your `accept` type specifically (probably '*/*')  then all the blocks that use the `format.any` return the data as 'text/html'. That then causes HTTP clients that have automatic parsing capabilities (like HTTParty or HTTP) to barf when you try to parse something that is expected to be 'application/json' but is incorrectly set as content type 'text/html'.

also added a test to the response tests.

You can test on the current production api to see the problem, like:

```
> irb
irb(main):001:0> require 'http'
=> true
irb(main):002:0> resp = HTTP.get('https://datadryad.org/api/v2/datasets/doi%3A10.5061%2Fdryad.r8d4q')
=> #<HTTP::Response/1.1 200 OK {"Date"=>"Thu, 30 Sep 2021 23:00:21 GMT", "Content-Type"=>"text/html; charset=utf-8", "Transfer-Encoding"=>"chunked", "Connect...
irb(main):003:0> resp.parse
Traceback (most recent call last):
	21: from /Users/sfisher/.rbenv/versions/2.6.6/bin/irb:23:in `<main>'
	20: from /Users/sfisher/.rbenv/versions/2.6.6/bin/irb:23:in `load'
	19: from /Users/sfisher/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.3.7/exe/irb:11:in `<top (required)>'
	 2: from (irb):3:in `<main>'
	 1: from /Users/sfisher/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/http-5.0.2/lib/http/response.rb:161:in `parse'
/Users/sfisher/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/http-5.0.2/lib/http/mime_type.rb:38:in `[]': Unknown MIME type: text/html (HTTP::Error)
irb(main):004:0> resp.headers["Content-Type"]
=> "text/html; charset=utf-8"
```

vs with correct content-type response header set

```
$ irb
irb(main):001:0> require 'http'
=> true
irb(main):002:0> resp = HTTP.get('http://localhost:3000/api/v2/datasets/doi%3A10.5072%2Fdryad.0zpc8670')
=> #<HTTP::Response/1.1 200 OK {"X-Frame-Options"=>"SAMEORIGIN", "X-XSS-Protection"=>"1; mode=block", "X-Content-Type-Options"=>"nosniff", "X-Download-Option...
irb(main):003:0> resp.headers["Content-Type"]
=> "application/json"
irb(main):004:0> resp.parse
=>
{"_links"=>
  {"self"=>{"href"=>"/api/v2/datasets/doi%3A10.5072%2Fdryad.0zpc8670"},
   "stash:versions"=>{"href"=>"/api/v2/datasets/doi%3A10.5072%2Fdryad.0zpc8670/versions"},
   "stash:version"=>{"href"=>"/api/v2/versions/15"},
   "stash:download"=>{"href"=>"/api/v2/datasets/doi%3A10.5072%2Fdryad.0zpc8670/download"},
   "curies"=>[{"name"=>"stash", "href"=>"https://github.com/CDL-Dryad/stash/blob/main/stash_api/link-relations.md\#{rel}", "templated"=>"true"}]},
 "identifier"=>"doi:10.5072/dryad.0zpc8670",
 "id"=>13,
 "storageSize"=>3225887,
 "relatedPublicationISSN"=>"2044-3706",
 "title"=>"My maxofacial abnormality project",
 "authors"=>[{"firstName"=>"Brian", "lastName"=>"Riley", "email"=>"brian.riley@ucop.edu", "affiliation"=>"UCOP", "orcid"=>"0000-0001-7781-6508"}],
 "abstract"=>"<p>ekljgleagert</p>\r\n\r\n<p>gar</p>\r\n\r\n<p>thsr</p>\r\n\r\n<p>hrth wjnljghlk ejgklejlt jeltjqerltjlt</p>\r\n",
 "locations"=>[{"point"=>{"latitude"=>37.748711, "longitude"=>-122.167969}}],
 "relatedWorks"=>[{"relationship"=>"undefined", "identifierType"=>"DOI", "identifier"=>"57t3yt93th3og"}],
 "versionNumber"=>2,
 "versionStatus"=>"in_progress",
 "curationStatus"=>"Published",
 "publicationDate"=>"2019-04-02",
 "lastModificationDate"=>"2019-08-06",
 "visibility"=>"public",
 "sharingLink"=>"https://localhost:3000/stash/share/ESJzuG7vPvz_6yDXG2peaj96567k8wSuuejfVdLZyMY",
 "userId"=>22,
 "license"=>"https://creativecommons.org/publicdomain/zero/1.0/"}
```