### PR TITLE
Prevent multiple copy records for the same resource

### DIFF
--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -1485,6 +1485,12 @@ module StashEngine
         @resource.send_to_zenodo
       end
 
+      it "doesn't call perform_later if non-finished copy exists and not enqueued" do
+        expect(ZenodoCopyJob).to_not receive(:perform_later).with(@resource.id)
+        ZenodoCopy.create(state: 'replicating', identifier_id: @resource.identifier.id, resource_id: @resource.id, copy_type: 'data', note: 'this one stalls')
+        @resource.send_to_zenodo
+      end
+
     end
 
     describe '#previous_resource' do

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -1487,7 +1487,7 @@ module StashEngine
 
       it "doesn't call perform_later if non-finished copy exists and not enqueued" do
         expect(ZenodoCopyJob).to_not receive(:perform_later).with(@resource.id)
-        ZenodoCopy.create(state: 'replicating', identifier_id: @resource.identifier.id, resource_id: @resource.id, copy_type: 'data', note: 'this one stalls')
+        ZenodoCopy.create(state: 'replicating', identifier_id: @resource.identifier.id, resource_id: @resource.id, copy_type: 'data', note: '')
         @resource.send_to_zenodo
       end
 

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -722,8 +722,12 @@ module StashEngine
     def send_to_zenodo(note: nil)
       return if data_files.empty? # no files? Then don't send to Zenodo for duplication.
 
-      ZenodoCopy.create(state: 'enqueued', identifier_id: identifier_id, resource_id: id, copy_type: 'data', note: note) if zenodo_copies.data.empty?
-      ZenodoCopyJob.perform_later(id)
+      existing_copy = zenodo_copies.data.first
+      if existing_copy.nil?
+        existing_copy = ZenodoCopy.create(state: 'enqueued', identifier_id: identifier_id, resource_id: id, copy_type: 'data', note: note)
+      end
+
+      ZenodoCopyJob.perform_later(id) if existing_copy.state == 'enqueued'
     end
 
     # if publish: true then it just publishes, which is a separate operation than updating files


### PR DESCRIPTION
We had a couple of weird, rare failures where we had more than one copy record for replicating data to zenodo for the same resource.

This prevents another entry from being created if one exists and also prevents starting replication if it's anything other than enqueued state or it just created the record (as enqueued).

I thought maybe there was something in submitting that allowed multiple submissions for the same resource, but I think this happens from curators publishing, so probably it happened when curators somehow clicked multiple times in rapid succession to publish an item somehow.  I guess we should probably have the publishing step block them with a spinner to only allow clicking once until a response to the request is received.