### PR TITLE
Add ISSN to API requests that only contain journal title

### DIFF
--- a/stash/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser.rb
@@ -93,6 +93,10 @@ module StashApi
     end
 
     def parse_internal_data
+      if @hash['publicationName'].present? && @hash['publicationISSN'].blank?
+        @hash['publicationISSN'] = StashEngine::Journal.where(title: @hash['publicationName'])&.first&.issn
+      end
+
       INTERNAL_DATA_FIELDS.each do |int_field|
         StashEngine::InternalDatum.create(data_type: int_field, stash_identifier: @resource.identifier, value: @hash[int_field]) if @hash[int_field]
       end


### PR DESCRIPTION
When API users only send journal title, locate the ISSN if it is available.