### PR TITLE
Explicit destroy of the frictionless reports before removing the file

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -169,8 +169,8 @@ defaults: &DEFAULTS
     zenodo_size: 50_000_000_000
     files: 1000
   frictionless:
-    # 25 MB and below
-    size_limit: 25_000_000
+    # 5 MB and below
+    size_limit: 5_000_000
   rate_limit:
     # number of requests allowed per minute
     all_requests: 120

--- a/stash/stash_engine/app/models/stash_engine/generic_file.rb
+++ b/stash/stash_engine/app/models/stash_engine/generic_file.rb
@@ -102,7 +102,7 @@ module StashEngine
         update(file_state: 'deleted')
       else
         # remove all of this filename for this resource from the database
-        FrictionlessReport.where(generic_file_id: self.id).destroy_all
+        FrictionlessReport.where(generic_file_id: id).destroy_all
         self.class.where(resource_id: resource_id, upload_file_name: upload_file_name).destroy_all
       end
 

--- a/stash/stash_engine/app/models/stash_engine/generic_file.rb
+++ b/stash/stash_engine/app/models/stash_engine/generic_file.rb
@@ -102,6 +102,7 @@ module StashEngine
         update(file_state: 'deleted')
       else
         # remove all of this filename for this resource from the database
+        FrictionlessReport.where(generic_file_id: self.id).destroy_all
         self.class.where(resource_id: resource_id, upload_file_name: upload_file_name).destroy_all
       end
 


### PR DESCRIPTION
A user couldn't delete because there were two copies of frictionless reports for a CSV.  The destroy_all failed because of constraints.  IDK how they got two reports, but, added an explicit destroy of frictionless reports before destroying a file to prevent this issue.

Also put in the change we've been running with for a while anyway to limit size for CSV checking to 5MB since some of the larger ones with very odd formats cause frictionless to take minutes to process.