### PR TITLE
first part of logging cleanup log --> logger

### DIFF
--- a/spec/models/stash-sword/log_spec.rb
+++ b/spec/models/stash-sword/log_spec.rb
@@ -12,7 +12,7 @@ module Stash
       before(:each) do
         @log_io = StringIO.new
         @log_utils = Class.new { include LogUtils }.new
-        @log_utils.instance_variable_set(:@log, LogUtils.create_default_logger(@log_io, log_utils.level))
+        @log_utils.instance_variable_set(:@logger, LogUtils.create_default_logger(@log_io, log_utils.level))
       end
 
       def log_str

--- a/spec/models/stash/repo/file_builder_spec.rb
+++ b/spec/models/stash/repo/file_builder_spec.rb
@@ -26,7 +26,7 @@ module Stash
           logger = instance_double(Logger)
           allow(Rails).to receive(:logger).and_return(logger)
           builder = FileBuilder.new
-          expect(builder.log).to be(logger)
+          expect(builder.logger).to be(logger)
         end
       end
 

--- a/spec/models/stash/repo/submission_job_spec.rb
+++ b/spec/models/stash/repo/submission_job_spec.rb
@@ -52,7 +52,7 @@ module Stash
 
       describe :log do
         it 'returns the Rails logger' do
-          expect(job.log).to be(logger)
+          expect(job.logger).to be(logger)
         end
       end
     end

--- a/stash/stash-merritt/lib/stash/merritt/submission_job.rb
+++ b/stash/stash-merritt/lib/stash/merritt/submission_job.rb
@@ -75,7 +75,7 @@ module Stash
 
       def submit(package)
         log_info("submitting resource #{resource_id} (#{resource.identifier_str})")
-        sword_helper = SwordHelper.new(package: package, logger: log)
+        sword_helper = SwordHelper.new(package: package, logger: logger)
         sword_helper.submit!
       end
 

--- a/stash/stash-merritt/lib/stash/merritt/submission_job.rb
+++ b/stash/stash-merritt/lib/stash/merritt/submission_job.rb
@@ -17,7 +17,7 @@ module Stash
 
       # this is where it actually starts running the real submission whenever it activates from the promise
       def submit!
-        log.info("#{Time.now.xmlschema} #{description}")
+        logger.info("#{Time.now.xmlschema} #{description}")
         previously_submitted = StashEngine::RepoQueueState.where(resource_id: @resource_id, state: 'processing').count.positive?
         if Stash::Repo::Repository.hold_submissions?
           # to mark that it needs to be re-enqueued and processed later
@@ -40,7 +40,7 @@ module Stash
           resource = StashEngine::Resource.find(resource_id)
           description_for(resource)
                          rescue StandardError => e
-                           log.error("Can't find resource #{resource_id}: #{e}\n#{e.backtrace.join("\n")}")
+                           logger.error("Can't find resource #{resource_id}: #{e}\n#{e.backtrace.join("\n")}")
                            "#{self.class} for missing resource #{resource_id}"
         end
       end
@@ -90,7 +90,7 @@ module Stash
       end
 
       def log_info(message)
-        log.info("#{Time.now.xmlschema} #{self.class}: #{message}")
+        logger.info("#{Time.now.xmlschema} #{self.class}: #{message}")
       end
     end
   end

--- a/stash/stash-sword/lib/stash/sword/log_utils.rb
+++ b/stash/stash-sword/lib/stash/sword/log_utils.rb
@@ -2,12 +2,12 @@ module Stash
   module Sword
     module LogUtils
 
-      def log
-        @log ||= default_logger
+      def logger
+        @logger ||= default_logger
       end
 
       def log_error(e)
-        log.error(to_log_msg(e))
+        logger.error(to_log_msg(e))
       end
 
       def to_log_msg(e)
@@ -20,7 +20,7 @@ module Stash
 
       def log_hash(hash)
         msg = hash_to_log_msg(hash)
-        log.debug(msg)
+        logger.debug(msg)
       end
 
       def hash_to_log_msg(hash)

--- a/stash/stash_engine/lib/stash/repo/file_builder.rb
+++ b/stash/stash_engine/lib/stash/repo/file_builder.rb
@@ -5,7 +5,7 @@ require 'stash/aws/s3'
 module Stash
   module Repo
     class FileBuilder
-      def log
+      def logger
         Rails.logger
       end
 

--- a/stash/stash_engine/lib/stash/repo/repository.rb
+++ b/stash/stash_engine/lib/stash/repo/repository.rb
@@ -57,7 +57,7 @@ module Stash
 
       # Returns a logger
       # @return [Logger] a logger
-      def log
+      def logger
         Rails.logger
       end
 
@@ -105,7 +105,7 @@ module Stash
       rescue StandardError => e
         msg = "An unexpected error occurred when cleaning up files for resource #{resource.id}: "
         msg << to_msg(e)
-        log.warn(msg)
+        logger.warn(msg)
       end
 
       def self.update_repo_queue_state(resource_id:, state:)
@@ -155,7 +155,7 @@ module Stash
       # rubcop:enable Metrics/MethodLength
 
       def log_error(error)
-        log.error(to_msg(error))
+        logger.error(to_msg(error))
       end
 
       def remove_if_exists(file)

--- a/stash/stash_engine/lib/stash/repo/repository.rb
+++ b/stash/stash_engine/lib/stash/repo/repository.rb
@@ -132,7 +132,7 @@ module Stash
       end
 
       def handle_success(result)
-        result.log_to(log)
+        result.log_to(logger)
         update_submission_log(result)
         self.class.update_repo_queue_state(resource_id: result.resource_id, state: 'completed')
       rescue StandardError => e
@@ -142,7 +142,7 @@ module Stash
 
       # rubcop:disable Metrics/MethodLength
       def handle_failure(result)
-        result.log_to(log)
+        result.log_to(logger)
         update_submission_log(result)
         self.class.update_repo_queue_state(resource_id: result.resource_id, state: 'errored')
         resource = StashEngine::Resource.find(result.resource_id)

--- a/stash/stash_engine/lib/stash/repo/submission_job.rb
+++ b/stash/stash_engine/lib/stash/repo/submission_job.rb
@@ -41,7 +41,7 @@ module Stash
         Concurrent::Promise.new(executor: executor) { ActiveRecord::Base.connection_pool.with_connection { submit! } }.execute
       end
 
-      def log
+      def logger
         Rails.logger
       end
     end

--- a/stash/stash_engine/lib/stash/repo/validating_xml_builder.rb
+++ b/stash/stash_engine/lib/stash/repo/validating_xml_builder.rb
@@ -26,7 +26,7 @@ module Stash
         errors = schema.validate(doc)
         return xml if errors.empty?
 
-        log.error(errors.join("\n"))
+        logger.error(errors.join("\n"))
         raise errors[0]
       end
 


### PR DESCRIPTION
In some gems, log method instead of the rails standard logger method was used.  This was put into that ticket for cleanup.

I'm doing some smaller PRs since my tests are now running extremely slow and easier to see on github actions.