### PR TITLE
Improve logic for emails in Salesforce cases

### DIFF
--- a/stash/stash_engine/lib/stash/salesforce.rb
+++ b/stash/stash_engine/lib/stash/salesforce.rb
@@ -87,13 +87,15 @@ module Stash
     def self.create_case(identifier:, owner:)
       return unless identifier && owner
 
+      case_user = identifier.latest_resource&.authors&.first || identifier.latest_resource&.user
+
       case_id = sf_client.create('Case',
                                  Subject: "Your Dryad data submission - DOI:#{identifier.identifier}",
                                  DOI__c: identifier.identifier,
                                  Dataset_Title__c: identifier.latest_resource&.title,
                                  Origin: 'Web',
-                                 SuppliedName: identifier.latest_resource&.user&.name,
-                                 SuppliedEmail: identifier.latest_resource&.user&.email,
+                                 SuppliedName: user_name(case_user),
+                                 SuppliedEmail: user_email(case_user),
                                  Journal__c: find_account_by_name(identifier.journal&.title),
                                  Institutional_Affiliation__c: find_account_by_name(identifier.latest_resource&.user&.tenant&.long_name))
 
@@ -120,6 +122,16 @@ module Stash
         @sf_client.authenticate!
         @sf_client
       end
+
+      # rubocop:disable Style/NestedTernaryOperator
+      def user_email(user)
+        user.present? ? (user.respond_to?(:author_email) ? user.author_email : user.email) : nil
+      end
+
+      def user_name(user)
+        user.present? ? (user.respond_to?(:author_standard_name) ? user.author_standard_name : user.name) : nil
+      end
+      # rubocop:enable Style/NestedTernaryOperator
 
     end
   end


### PR DESCRIPTION
Curators complained about email addresses not being included in the salesforce tickets. This is due to the submitter (resource.user) not having an email address present.

This change updates the logic in the Salesforce module to be parallel to the logic used in UserMailer, so it will use the first author's information if that is available. It is a slight duplication of code, but I didn't think it was enough to warrant moving everything into a separate helper class.