### PR TITLE
Fixes Datacite metadata generation for funder ids

### DIFF
--- a/stash/stash-merritt/lib/datacite/mapping/datacite_xml_factory.rb
+++ b/stash/stash-merritt/lib/datacite/mapping/datacite_xml_factory.rb
@@ -191,8 +191,17 @@ module Datacite
 
       def add_funding_references(dcs_resource)
         dcs_resource.funding_references = sd_funder_contribs.map do |c|
+          dmfi =
+            if c.contributor_type == 'funder' && c.name_identifier_id.present?
+              # all our funders that have ids come from crossref
+              FunderIdentifier.new(type: FunderIdentifierType::CROSSREF_FUNDER_ID, value: c.name_identifier_id)
+            else
+              nil
+            end
+
           FundingReference.new(
             name: c.contributor_name,
+            identifier: dmfi,
             award_number: c.award_number
           )
         end


### PR DESCRIPTION
Generate funder ids for fundref if they are set in our database for a contributor of type funder with an id.