### PR TITLE
Improve logic for curator assignment

### DIFF
--- a/documentation/reports.md
+++ b/documentation/reports.md
@@ -36,7 +36,7 @@ cd /apps/dryad/apps/ui/current
 RAILS_ENV=production bundle exec rake identifiers:shopping_cart_report YEAR_MONTH=2020-11
 exit # go back to personal account
 cp /apps/dryad/apps/ui/current/shopping* ~/journal-payments/shoppingcart/
-cd ~/tools/journal-payments/shoppingcart
+cd ~/journal-payments/shoppingcart
 git pull
 git add <new-file>
 git commit -a -m "add reports for 2019-11"

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -753,7 +753,7 @@ module StashEngine
       # This will usually have the side effect of sending out notification emails to the author/journal
       curation_activities << StashEngine::CurationActivity.create(user_id: attribution, status: target_status)
 
-      return if prior_version.blank? || prior_version.current_curation_status.blank?
+      return if prior_version.blank? || prior_version.current_curation_status.blank? || prior_version.current_editor_id.blank?
       return if %w[in_progress submitted].include?(prior_version.current_curation_status)
 
       # If we get here, the previous status was *not* controlled by the submitter,

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -764,7 +764,7 @@ module StashEngine
 
       target_curator = StashEngine::User.find(prior_version.current_editor_id)
       if target_curator.nil? || !target_curator.curator?
-        # if the previous curator does not exist,
+        # if the previous curator does not exist, or is no longer a curator,
         # set it to the most experienced current curator (lowest ID number), but not a superuser
         target_curator = StashEngine::User.where(role: 'curator').first
       end


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1472

- Allow auto-assignment of curators in more situations, so all resubmissions are assigned to a curator
- When a curator is no longer with Dryad, choose an appropriate backup curator.