### PR TITLE
Add datacite contributor identifier_type

### DIFF
--- a/documentation/apis/sample_dataset.json
+++ b/documentation/apis/sample_dataset.json
@@ -24,8 +24,10 @@
     } ],
     "funders": [ 
 	{
-	    "organization": "Savannah River Operations Office, U.S. Department of Energy",
-	    "awardNumber": "12345" },
+		"organization": "Savannah River Operations Office, U.S. Department of Energy",
+		"identifierType": "crossref_funder_id",
+		"identifier": "http://dx.doi.org/10.13039/100008972",
+		"awardNumber": "12345" },
 	{
 	    "organization": "The Cat Chronicles",
 	    "awardNumber": "cat383"

--- a/spec/factories/stash_datacite/contributors.rb
+++ b/spec/factories/stash_datacite/contributors.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
 
     contributor_name    { Faker::Company.name }
     contributor_type    { 'funder' }
+    identifier_type     { 'crossref_funder_id' }
     name_identifier_id  { Faker::Pid.doi }
     award_number        { Faker::Alphanumeric.alphanumeric(number: 8, min_alpha: 2, min_numeric: 4) }
   end

--- a/spec/fixtures/stash_api/metadata.rb
+++ b/spec/fixtures/stash_api/metadata.rb
@@ -147,7 +147,7 @@ module Fixtures
             "organization": Faker::Company.name,
             "awardNumber": Faker::Number.number(digits: 4),
             "identifier": "http://dx.doi.org/10.13039/fakedoi.#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}",
-            "identifier_type": "crossref_funder_id"
+            "identifierType": 'crossref_funder_id'
           }
         )
       end

--- a/spec/fixtures/stash_api/metadata.rb
+++ b/spec/fixtures/stash_api/metadata.rb
@@ -140,6 +140,18 @@ module Fixtures
         }
       end
 
+      def add_funder
+        create_key_and_array(key: :funders)
+        @metadata[:funders].push(
+          {
+            "organization": Faker::Company.name,
+            "awardNumber": Faker::Number.number(digits: 4),
+            "identifier": "http://dx.doi.org/10.13039/fakedoi.#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}",
+            "identifier_type": "crossref_funder_id"
+          }
+        )
+      end
+
     end
   end
 end

--- a/spec/models/stash_datacite/contributor_spec.rb
+++ b/spec/models/stash_datacite/contributor_spec.rb
@@ -70,6 +70,28 @@ module StashDatacite
       end
     end
 
+    describe 'identifier_type_mapping_obj' do
+      it 'returns the Datacite::Mapping enum instance' do
+        expect(@contrib.identifier_type_mapping_obj).to be(Datacite::Mapping::FunderIdentifierType::CROSSREF_FUNDER_ID)
+      end
+
+      it 'maps nil to nil' do
+        @contrib.update(identifier_type: nil)
+        expect(@contrib.identifier_type_mapping_obj).to be_nil
+      end
+    end
+
+    describe 'identifier_type_friendly' do
+      it 'returns nil if null type' do
+        @contrib.update(identifier_type: nil)
+        expect(@contrib.identifier_type_friendly).to be_nil
+      end
+
+      it 'returns a readable name (correct capitalization)' do
+        expect(@contrib.identifier_type_friendly).to eq('Crossref Funder ID')
+      end
+    end
+
     describe 'affiliations' do
       attr_reader :affiliations
       before(:each) do

--- a/spec/requests/stash_api/datasets_controller_spec.rb
+++ b/spec/requests/stash_api/datasets_controller_spec.rb
@@ -56,6 +56,21 @@ module StashApi
         expect(out_author[:affiliation]).to eq(in_author[:affiliation])
       end
 
+      it 'creates a new dataset from minimal metadata with funder' do
+        # the following works for post with headers
+        funder = @meta.add_funder
+        response_code = post '/api/v2/datasets', params: @meta.json, headers: default_authenticated_headers
+        output = response_body_hash
+        expect(response_code).to eq(201)
+        expect(/doi:10./).to match(output[:identifier])
+        hsh = @meta.hash
+        funder = funder.first
+        ret_fund = hsh[:funders].first
+        expect(ret_fund[:organization]).to eq(funder[:organization])
+        expect(ret_fund[:awardNumber]).to eq(funder[:awardNumber])
+        expect(ret_fund[:identifier]).to eq(funder[:identifier])
+        expect(ret_fund[:identifier_type]).to eq(funder[:identifier_type])
+      end
       it 'creates a new dataset with a userId explicitly set by superuser)' do
         test_user = StashEngine::User.create(first_name: Faker::Name.first_name,
                                              last_name: Faker::Name.last_name,

--- a/spec/requests/stash_api/datasets_controller_spec.rb
+++ b/spec/requests/stash_api/datasets_controller_spec.rb
@@ -69,7 +69,7 @@ module StashApi
         expect(ret_fund[:organization]).to eq(funder[:organization])
         expect(ret_fund[:awardNumber]).to eq(funder[:awardNumber])
         expect(ret_fund[:identifier]).to eq(funder[:identifier])
-        expect(ret_fund[:identifier_type]).to eq(funder[:identifier_type])
+        expect(ret_fund[:identifierType]).to eq(funder[:identifierType])
       end
       it 'creates a new dataset with a userId explicitly set by superuser)' do
         test_user = StashEngine::User.create(first_name: Faker::Name.first_name,

--- a/spec/requests/stash_datacite/contributors_controller_spec.rb
+++ b/spec/requests/stash_datacite/contributors_controller_spec.rb
@@ -42,6 +42,7 @@ module StashDatacite
           { 'contributor_name' => 'Sorbonne Université',
             'name_identifier_id' => '', 'award_number' => '',
             'contributor_type' => 'funder',
+            'identifier_type' => 'crossref_funder_id',
             'resource_id' => @resource.id, 'id' => '' } }
       end
 
@@ -49,6 +50,7 @@ module StashDatacite
         post '/stash_datacite/contributors/create', params: @params_hash, xhr: true
         contrib = StashDatacite::Contributor.where(resource_id: @resource.id).first
         expect(contrib.contributor_name).to eq('Sorbonne Université')
+        expect(contrib.identifier_type).to eq('crossref_funder_id')
         expect(contrib.name_identifier_id).to eq('http://dx.doi.org/10.13039/501100019125')
       end
 

--- a/stash/stash-merritt/lib/datacite/mapping/datacite_xml_factory.rb
+++ b/stash/stash-merritt/lib/datacite/mapping/datacite_xml_factory.rb
@@ -191,11 +191,7 @@ module Datacite
 
       def add_funding_references(dcs_resource)
         dcs_resource.funding_references = sd_funder_contribs.map do |c|
-          dmfi =
-            if c.contributor_type == 'funder' && c.name_identifier_id.present?
-              # all our funders that have ids come from crossref
-              FunderIdentifier.new(type: FunderIdentifierType::CROSSREF_FUNDER_ID, value: c.name_identifier_id)
-            end
+          dmfi = (FunderIdentifier.new(type: c.identifier_type_mapping_obj, value: c.name_identifier_id) if c.name_identifier_id.present?)
 
           FundingReference.new(
             name: c.contributor_name,

--- a/stash/stash_api/app/models/stash_api/dataset_parser/example.json
+++ b/stash/stash_api/app/models/stash_api/dataset_parser/example.json
@@ -20,6 +20,8 @@
   "funders": [
     {
       "organization": "Savannah River Operations Office, U.S. Department of Energy",
+      "identifier_type": "crossref_funder_id",
+      "identifier": "http://dx.doi.org/10.13039/100008972",
       "awardNumber": "12345"
     }
   ],

--- a/stash/stash_api/app/models/stash_api/dataset_parser/example.json
+++ b/stash/stash_api/app/models/stash_api/dataset_parser/example.json
@@ -20,7 +20,7 @@
   "funders": [
     {
       "organization": "Savannah River Operations Office, U.S. Department of Energy",
-      "identifier_type": "crossref_funder_id",
+      "identifierType": "crossref_funder_id",
       "identifier": "http://dx.doi.org/10.13039/100008972",
       "awardNumber": "12345"
     }

--- a/stash/stash_api/app/models/stash_api/dataset_parser/funders.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser/funders.rb
@@ -7,6 +7,8 @@ module StashApi
       #   {
       #     "organization": "Savannah River Operations Office, U.S. Department of Energy",
       #     "awardNumber": "12345"
+      #     "identifierType": "crossref_funder_id",
+      #     "identifier": "http://dx.doi.org/387867/3798789"
       #   }
       # ]
 
@@ -18,7 +20,7 @@ module StashApi
           @resource.contributors << StashDatacite::Contributor.create(
             contributor_name: funder['organization'],
             contributor_type: 'funder',
-            identifier_type: funder['identifier_type'],
+            identifier_type: funder['identifierType'],
             name_identifier_id: funder['identifier'],
             award_number: funder['awardNumber']
           )

--- a/stash/stash_api/app/models/stash_api/dataset_parser/funders.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser/funders.rb
@@ -15,8 +15,13 @@ module StashApi
         return if @hash['funders'].nil?
 
         @hash['funders'].each do |funder|
-          @resource.contributors << StashDatacite::Contributor.create(contributor_name: funder['organization'],
-                                                                      contributor_type: 'funder', award_number: funder['awardNumber'])
+          @resource.contributors << StashDatacite::Contributor.create(
+            contributor_name: funder['organization'],
+            contributor_type: 'funder',
+            identifier_type: funder['identifier_type'],
+            name_identifier_id: funder['identifier'],
+            award_number: funder['awardNumber']
+          )
         end
       end
 

--- a/stash/stash_api/app/models/stash_api/version/metadata/funders.rb
+++ b/stash/stash_api/app/models/stash_api/version/metadata/funders.rb
@@ -11,7 +11,7 @@ module StashApi
           @resource.contributors.where(contributor_type: 'funder').map do |funder|
             {
               organization: funder.contributor_name,
-              identifier_type: funder.identifierType,
+              identifierType: funder.identifier_type,
               identifier: funder.name_identifier_id,
               awardNumber: funder.award_number
             }

--- a/stash/stash_api/app/models/stash_api/version/metadata/funders.rb
+++ b/stash/stash_api/app/models/stash_api/version/metadata/funders.rb
@@ -11,7 +11,7 @@ module StashApi
           @resource.contributors.where(contributor_type: 'funder').map do |funder|
             {
               organization: funder.contributor_name,
-              identifier_type: funder.identifier_type,
+              identifier_type: funder.identifierType,
               identifier: funder.name_identifier_id,
               awardNumber: funder.award_number
             }

--- a/stash/stash_api/app/models/stash_api/version/metadata/funders.rb
+++ b/stash/stash_api/app/models/stash_api/version/metadata/funders.rb
@@ -11,6 +11,8 @@ module StashApi
           @resource.contributors.where(contributor_type: 'funder').map do |funder|
             {
               organization: funder.contributor_name,
+              identifier_type: funder.identifier_type,
+              identifier: funder.name_identifier_id,
               awardNumber: funder.award_number
             }
           end

--- a/stash/stash_api/public/api/v2/docs/examples/dataset.json
+++ b/stash/stash_api/public/api/v2/docs/examples/dataset.json
@@ -43,7 +43,7 @@
   "funders": [
     {
       "organization": "Savannah River Operations Office, U.S. Department of Energy",
-      "identifier_type": "crossref_funder_id",
+      "identifierType": "crossref_funder_id",
       "identifier": "http://dx.doi.org/10.13039/100008972",
       "awardNumber": "12345"
     }

--- a/stash/stash_api/public/api/v2/docs/examples/dataset.json
+++ b/stash/stash_api/public/api/v2/docs/examples/dataset.json
@@ -43,6 +43,8 @@
   "funders": [
     {
       "organization": "Savannah River Operations Office, U.S. Department of Energy",
+      "identifier_type": "crossref_funder_id",
+      "identifier": "http://dx.doi.org/10.13039/100008972",
       "awardNumber": "12345"
     }
   ],

--- a/stash/stash_api/public/api/v2/docs/examples/dataset_post_request.json
+++ b/stash/stash_api/public/api/v2/docs/examples/dataset_post_request.json
@@ -18,6 +18,8 @@
   "funders": [
     {
       "organization": "Savannah River Operations Office, U.S. Department of Energy",
+      "identifier_type": "crossref_funder_id",
+      "identifier": "http://dx.doi.org/10.13039/100008972",
       "awardNumber": "12345"
     }
   ],

--- a/stash/stash_api/public/api/v2/docs/examples/dataset_post_request.json
+++ b/stash/stash_api/public/api/v2/docs/examples/dataset_post_request.json
@@ -18,7 +18,7 @@
   "funders": [
     {
       "organization": "Savannah River Operations Office, U.S. Department of Energy",
-      "identifier_type": "crossref_funder_id",
+      "identifierType": "crossref_funder_id",
       "identifier": "http://dx.doi.org/10.13039/100008972",
       "awardNumber": "12345"
     }

--- a/stash/stash_api/public/api/v2/docs/examples/datasets.json
+++ b/stash/stash_api/public/api/v2/docs/examples/datasets.json
@@ -96,7 +96,9 @@
         "funders": [
           {
             "organization": "Albani Fonden",
-            "awardNumber": "FondAlb28"
+            "awardNumber": "FondAlb28",
+            "identifier": "http://dx.doi.org/10.13039/501100008201",
+            "identifier_type": "crossref_funder_id"
           }
         ],
         "keywords": [

--- a/stash/stash_api/public/api/v2/docs/examples/datasets.json
+++ b/stash/stash_api/public/api/v2/docs/examples/datasets.json
@@ -98,7 +98,7 @@
             "organization": "Albani Fonden",
             "awardNumber": "FondAlb28",
             "identifier": "http://dx.doi.org/10.13039/501100008201",
-            "identifier_type": "crossref_funder_id"
+            "identifierType": "crossref_funder_id"
           }
         ],
         "keywords": [

--- a/stash/stash_api/public/api/v2/docs/examples/version.json
+++ b/stash/stash_api/public/api/v2/docs/examples/version.json
@@ -41,7 +41,7 @@
   "funders": [
     {
       "organization": "Savannah River Operations Office, U.S. Department of Energy",
-      "identifier_type": "crossref_funder_id",
+      "identifierType": "crossref_funder_id",
       "identifier": "http://dx.doi.org/10.13039/100008972",
       "awardNumber": "12345"
     }

--- a/stash/stash_api/public/api/v2/docs/examples/version.json
+++ b/stash/stash_api/public/api/v2/docs/examples/version.json
@@ -41,6 +41,8 @@
   "funders": [
     {
       "organization": "Savannah River Operations Office, U.S. Department of Energy",
+      "identifier_type": "crossref_funder_id",
+      "identifier": "http://dx.doi.org/10.13039/100008972",
       "awardNumber": "12345"
     }
   ],

--- a/stash/stash_api/public/openapi.yml
+++ b/stash/stash_api/public/openapi.yml
@@ -773,6 +773,11 @@ components:
           type: string
         awardNumber:
           type: string
+        identifier:
+          type: string
+        identifierType:
+          description: type of identifier -- null, isni, grid, crossref_funder_id or other
+          type: string
     relatedWork:
       properties:
         relationship:

--- a/stash/stash_datacite/app/controllers/stash_datacite/contributors_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/contributors_controller.rb
@@ -158,7 +158,7 @@ module StashDatacite
 
     # Only allow a trusted parameter "white list" through.
     def contributor_params
-      params.require(:contributor).permit(:id, :contributor_name, :contributor_type, :name_identifier_id,
+      params.require(:contributor).permit(:id, :contributor_name, :contributor_type, :identifier_type, :name_identifier_id,
                                           :affiliation_id, :award_number, :resource_id)
     end
 

--- a/stash/stash_datacite/app/models/stash_datacite/contributor.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/contributor.rb
@@ -16,10 +16,10 @@ module StashDatacite
     ContributorTypesStrToFull = ContributorTypes.map { |i| [i.downcase, i] }.to_h
 
     # maps DB value to the DataciteMapping class of fun from that gem
-    IdentifierTypesToMapping = Datacite::Mapping::FunderIdentifierType.map{ |i| [i.value.downcase.gsub(' ', '_'), i ] }.to_h
+    IdentifierTypesToMapping = Datacite::Mapping::FunderIdentifierType.map { |i| [i.value.downcase.gsub(' ', '_'), i] }.to_h
 
     # maps from enum to the special full name/abbreviation like Crossref Funder ID or ROR
-    IdentifierTypesStrToFull = Datacite::Mapping::FunderIdentifierType.map{ |i| [i.value.downcase.gsub(' ', '_'), i.value ] }.to_h
+    IdentifierTypesStrToFull = Datacite::Mapping::FunderIdentifierType.map { |i| [i.value.downcase.gsub(' ', '_'), i.value] }.to_h
 
     enum contributor_type: ContributorTypesEnum
 

--- a/stash/stash_datacite/app/models/stash_datacite/contributor.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/contributor.rb
@@ -15,6 +15,12 @@ module StashDatacite
     ContributorTypesEnum = ContributorTypes.map { |i| [i.downcase.to_sym, i.downcase] }.to_h
     ContributorTypesStrToFull = ContributorTypes.map { |i| [i.downcase, i] }.to_h
 
+    # maps DB value to the DataciteMapping class of fun from that gem
+    IdentifierTypesToMapping = Datacite::Mapping::FunderIdentifierType.map{ |i| [i.value.downcase.gsub(' ', '_'), i ] }.to_h
+
+    # maps from enum to the special full name/abbreviation like Crossref Funder ID or ROR
+    IdentifierTypesStrToFull = Datacite::Mapping::FunderIdentifierType.map{ |i| [i.value.downcase.gsub(' ', '_'), i.value ] }.to_h
+
     enum contributor_type: ContributorTypesEnum
 
     before_save :strip_whitespace
@@ -54,6 +60,20 @@ module StashDatacite
       else
         contributor_name
       end
+    end
+
+    # gives the mapping object used to submit through Datacite mapping gem
+    def identifier_type_mapping_obj
+      return nil if identifier_type.blank?
+
+      IdentifierTypesToMapping[identifier_type]
+    end
+
+    # gives a printable name
+    def identifier_type_friendly
+      return nil if identifier_type.blank?
+
+      IdentifierTypesStrToFull[identifier_type]
     end
 
     # this is to simulate the bad old structure where a user can only have one affiliation

--- a/stash/stash_datacite/app/views/stash_datacite/contributors/_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/contributors/_form.html.erb
@@ -6,6 +6,7 @@
 	<div class="c-input">
 	    <%= f.label "name_#{my_suffix}", "Granting Organization", class: 'c-input__label' %>
 	    <%= f.text_field :contributor_name, id: "contributor_name_#{my_suffix}", class: "js-funders c-input__text" %>
+			<%= f.hidden_field :identifier_type, value: 'crossref_funder_id' %>
 	    <%= f.hidden_field :name_identifier_id, id: "contributor_name_identifier_id", class: "js-funder-id" %>
 	</div>
 	<div class="c-input">

--- a/stash/stash_datacite/db/migrate/20211029195912_add_identifier_type_to_dcs_contributor.rb
+++ b/stash/stash_datacite/db/migrate/20211029195912_add_identifier_type_to_dcs_contributor.rb
@@ -1,0 +1,17 @@
+class AddIdentifierTypeToDcsContributor < ActiveRecord::Migration[5.2]
+  def up
+    add_column :dcs_contributors, :identifier_type, "ENUM('isni', 'grid', 'crossref_funder_id', 'ror', 'other') DEFAULT NULL",
+               after: :contributor_type
+
+    # because up to now, anything filled in with a name_identifier_id is of identifier_type 'crossref_funder_id'
+    execute <<-SQL
+      UPDATE dcs_contributors
+      SET identifier_type = 'crossref_funder_id'
+      WHERE name_identifier_id LIKE '%dx.doi.org%';
+    SQL
+  end
+
+  def down
+    remove_column :dcs_contributors, :identifier_type
+  end
+end


### PR DESCRIPTION
This adds the identifier_type specifically to the contributors table.  Before everything in contributors was assumed to be a funder.

Also adds both identifierType and identifier to the API.

Fixes the UI where it it submitted so it has correct identifier type as part of the form.

Added tests. examples. migrations.

It's optional, so if people use the API the old way then these aren't set and they are not required so shouldn't break compatibility.