### PR TITLE
Revert "Add semantic logger"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,6 @@ gem 'jbuilder'
 gem 'net-sftp'
 gem 'oai', '~> 1.1.0'
 gem 'rack-attack'
-gem 'rails_semantic_logger'
 gem 'rb-readline', require: false
 gem 'wicked_pdf', '~> 1.4.0'
 gem 'wkhtmltopdf-binary'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,21 +150,21 @@ GEM
     autoprefixer-rails (10.3.3.0)
       execjs (~> 2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.519.0)
-    aws-sdk-core (3.121.3)
+    aws-partitions (1.510.0)
+    aws-sdk-core (3.121.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.50.0)
-      aws-sdk-core (~> 3, >= 3.121.2)
+    aws-sdk-kms (1.49.0)
+      aws-sdk-core (~> 3, >= 3.120.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.104.0)
-      aws-sdk-core (~> 3, >= 3.121.2)
+    aws-sdk-s3 (1.103.0)
+      aws-sdk-core (~> 3, >= 3.120.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
-    aws-sdk-ssm (1.120.0)
-      aws-sdk-core (~> 3, >= 3.121.2)
+    aws-sdk-ssm (1.119.0)
+      aws-sdk-core (~> 3, >= 3.120.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.4.0)
       aws-eventstream (~> 1, >= 1.0.2)
@@ -203,9 +203,8 @@ GEM
     capistrano-rails (1.6.1)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capybara (3.36.0)
+    capybara (3.35.3)
       addressable
-      matrix
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
@@ -215,7 +214,7 @@ GEM
     capybara-screenshot (1.0.25)
       capybara (>= 1.0, < 4)
       launchy
-    childprocess (4.1.0)
+    childprocess (3.0.0)
     ckeditor (4.3.0)
       orm_adapter (~> 0.5.0)
       terrapin
@@ -263,14 +262,14 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-guests (0.8.0)
+    devise-guests (0.7.0)
       devise
     diff-lcs (1.4.4)
     diffy (3.4.0)
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    doorkeeper (5.5.4)
+    doorkeeper (5.5.3)
       railties (>= 5)
     down (5.2.4)
       addressable (~> 2.8)
@@ -388,7 +387,7 @@ GEM
       webrick
     google-apis-gmail_v1 (0.9.0)
       google-apis-core (>= 0.4, < 2.a)
-    googleauth (1.1.0)
+    googleauth (1.0.0)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -415,7 +414,7 @@ GEM
       tilt (>= 1.2)
     hashdiff (1.0.1)
     hashie (3.6.0)
-    http (5.0.4)
+    http (5.0.2)
       addressable (~> 2.8)
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
@@ -465,13 +464,15 @@ GEM
     leaflet-rails (1.7.0)
       rails (>= 4.2.0)
     libv8 (3.16.14.19)
+    libv8 (3.16.14.19-x86_64-darwin-17)
+    libv8 (3.16.14.19-x86_64-linux)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     llhttp-ffi (0.4.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    logger (1.4.4)
+    logger (1.4.3)
     loofah (2.12.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -479,7 +480,6 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
-    matrix (0.4.2)
     memoist (0.16.2)
     merritt-manifest (0.1.3)
       mime-types (~> 3.1)
@@ -488,7 +488,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0901)
-    mini_mime (1.1.2)
+    mini_mime (1.1.1)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
     mize (0.4.0)
@@ -511,6 +511,10 @@ GEM
     noid (0.9.0)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -541,7 +545,7 @@ GEM
       omniauth (>= 1.0.0)
     orm_adapter (0.5.0)
     os (1.1.1)
-    ostruct (0.5.0)
+    ostruct (0.4.0)
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -558,9 +562,9 @@ GEM
       pry (~> 0.9)
       slop (~> 3.0)
     public_suffix (4.0.6)
-    puma (5.5.2)
+    puma (5.5.0)
       nio4r (~> 2.0)
-    racc (1.6.0)
+    racc (1.5.2)
     rack (2.2.3)
     rack-attack (6.5.0)
       rack (>= 1.0, < 3)
@@ -586,10 +590,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
-    rails_semantic_logger (4.6.1)
-      rack
-      railties (>= 3.2)
-      semantic_logger (~> 4.8)
     railties (5.2.6)
       actionpack (= 5.2.6)
       activesupport (= 5.2.6)
@@ -625,7 +625,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    restforce (5.1.1)
+    restforce (5.1.0)
       faraday (>= 0.9.0, <= 2.0)
       faraday_middleware (>= 0.8.8, <= 2.0)
       hashie (>= 1.2.0, < 5.0)
@@ -706,12 +706,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.0.3)
-      childprocess (>= 0.5, < 5.0)
-      rexml (~> 3.2, >= 3.2.5)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    semantic_logger (4.8.2)
-      concurrent-ruby (~> 1.0)
     semantic_range (3.0.0)
     serrano (1.0.0)
       faraday (~> 1.1)
@@ -792,7 +789,7 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (1.8.0)
-    view_component (2.41.0)
+    view_component (2.40.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     warden (1.2.9)
@@ -802,10 +799,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webdrivers (5.0.0)
+    webdrivers (4.6.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -829,12 +826,14 @@ GEM
       xml-mapping (~> 0.10)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yaml (0.2.0)
+    yaml (0.1.1)
     yui-compressor (0.12.0)
     zaru (0.3.0)
 
 PLATFORMS
   ruby
+  x86_64-darwin-17
+  x86_64-linux
 
 DEPENDENCIES
   binding_of_caller
@@ -872,7 +871,6 @@ DEPENDENCIES
   puma
   rack-attack
   rails (~> 5.2.6)
-  rails_semantic_logger
   rb-readline
   react-rails (~> 2.6.1)
   rspec-collection_matchers
@@ -906,4 +904,4 @@ DEPENDENCIES
   yui-compressor
 
 BUNDLED WITH
-   2.1.4
+   2.2.27

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,25 +56,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker   
-
-
-  ## rails_semantic_logger configs.  See: https://logger.rocketjob.io/rails.html
-
-  # Disable default file_appender to fix issue with using multiple appenders.
-  # See: https://github.com/reidmorrison/rails_semantic_logger/issues/73
-  config.rails_semantic_logger.add_file_appender = false
-
-  # Set up rails_semantic_logger file_appender instances for both local text log
-  # and a json log for indexing into OpenSearch.
-  config.semantic_logger.add_appender(file_name: "log/#{Rails.env}.log")
-  config.semantic_logger.add_appender(file_name: "log/#{Rails.env}_json.log", formatter: :json)
-
-  # Additional 'log_tag' fields
-  config.log_tags = {
-    request_id: :request_id,
-    ip:         :remote_ip,
-  } 
-
   
   Rails.application.default_url_options = { host: 'dryad-dev.cdlib.org' }
 

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,6 +1,0 @@
-#
-# Disable default file_appender to fix issue with using multiple appenders.
-# See: https://github.com/reidmorrison/rails_semantic_logger/issues/73
-#Rails.application.config.rails_semantic_logger.add_file_appender = false
-
-


### PR DESCRIPTION
I'm going to revert this inside the main branch for now since it will interfere with deploying main to stage/production until we fix it.

Before I just reverted to a separate branch and tagged from that.