### PR TITLE
Pulls in extra funding info we got from Ted

### DIFF
--- a/stash/stash_engine/lib/tasks/funders.rake
+++ b/stash/stash_engine/lib/tasks/funders.rake
@@ -72,4 +72,44 @@ namespace :funders do
       puts ''
     end
   end
+
+  # had to do this to fix crazy Tedfile with inconsistent line endings
+  # File.open('funderOutputCrossrefFixed__20211006.csv', 'w') do |outfile|
+  #   File.foreach('funderOutputCrossref__20211006.csv') do |line|
+  #     better_line = line.strip
+  #     next if better_line.empty?
+  #     outfile.puts better_line
+  #   end
+  # end
+  # This also created a crazy unprintable character on the first line as part of the "doi" field which was hard to
+  # troubleshoot.  Had to edit it out in binary mode in vi.
+
+  desc 'imports Tedsheet which is something someone gave us with IDs for some funders'
+  task import_tedsheet: :environment do
+    CSV.foreach('/Users/sfisher/Downloads/funderOutputCrossrefFixed__20211006.csv', headers: true) do |row|
+      # relevant fields are 'doi', 'funderName', 'funderIdentifier', there seem to be a lot of blank rows
+      next if row['funderIdentifier'].blank?
+
+      stash_identifier = StashEngine::Identifier.where(identifier: row['doi']).first
+      next if stash_identifier.nil?
+
+      res = stash_identifier.latest_resource_with_public_metadata
+      next if res.nil?
+
+      existing_count = res.contributors.where(contributor_type: 'funder', contributor_name: row['funderName']).count
+      next if existing_count.positive? # it already got added, so skip
+
+      full_id = "http://dx.doi.org/#{row['funderIdentifier']}" # because dx.doi.org is how fundref presents them
+
+      StashDatacite::Contributor.create!(
+        contributor_name: row['funderName'],b
+        contributor_type: 'funder',
+        name_identifier_id: full_id,
+        resource_id: res.id,
+        award_number: row['awardNumber']
+      )
+
+      puts "Added #{row['funderName']} as funder for #{row['doi']}"
+    end
+  end
 end

--- a/stash/stash_engine/lib/tasks/funders.rake
+++ b/stash/stash_engine/lib/tasks/funders.rake
@@ -73,7 +73,7 @@ namespace :funders do
     end
   end
 
-  # had to do this to fix crazy Tedfile with inconsistent line endings
+  # had to do this to fix Tedfile with inconsistent line endings and even multiple line endings (making blank lines)
   # File.open('funderOutputCrossrefFixed__20211006.csv', 'w') do |outfile|
   #   File.foreach('funderOutputCrossref__20211006.csv') do |line|
   #     better_line = line.strip

--- a/stash/stash_engine/lib/tasks/funders/utils.rb
+++ b/stash/stash_engine/lib/tasks/funders/utils.rb
@@ -44,5 +44,21 @@ module Funders
 
       best_matches[pair_matches.index(pair_matches.max)]
     end
+
+    # tries to do an exact match and return an id
+    def id_match(name:)
+      name = name.strip.downcase
+      # return from the Fundref info if exact match
+      return @lookup[name][:uri] unless @lookup[name].nil?
+
+      # otherwise see if we can find a string match in our database that has funder id filled in
+      matching_contrib =
+        StashDatacite::Contributor.where(contributor_type: 'funder')
+          .where(contributor_name: name)
+          .where("name_identifier_id IS NOT NULL AND name_identifier_id <> ''").first
+      return nil if matching_contrib.nil?
+
+      matching_contrib[:name_identifier_id]
+    end
   end
 end


### PR DESCRIPTION
We got a spreadsheet from Ted with additional funders for some datasets.  These were to be added to the datasets.

Some had IDs and some didn't.

- If they have an ID filled by Ted then use that ID.
- If no filled ID, then do an exact match against our Fundref dump of names/ids.  If still no ID, try to find any records in our database with that name string for funder and an ID filled in for it.
- Create the funder record in our database.  We hope it has an ID, but if it doesn't we add it without one.

It seemed like only a small percentage of items without IDs that Ted gave us were direct matches against fundref names or something already in our database with an ID.  I'd guess maybe 10-20% at most.

If someone decides they want to do some more manual matching I can export the unmatched items again as a spreadsheet.  Last time we did this, I went through the top 250 or so items and did some manual lookups on things I could easily figure out and it took me a few hours.  Trying to go through all of them will be tedious and lots of time and work.

IDK if we'll ever get all of them to match because the fundref database is limited and people put lots of small funders that may not be in the fundref database.  Also, there seem to be lots of english-version names for funder names in other languages which are a little hard to figure out sometimes without a lot of googling or speaking those languages better.  Also, lots of acronyms (some from foreign languages/govts).