### PR TITLE
Recalculate payment when journal changes

### DIFF
--- a/spec/models/stash_engine/identifier_spec.rb
+++ b/spec/models/stash_engine/identifier_spec.rb
@@ -38,8 +38,8 @@ module StashEngine
       end
 
       @fake_issn = 'bogus-issn-value'
-      int_datum_issn = InternalDatum.new(identifier_id: @identifier.id, data_type: 'publicationISSN', value: @fake_issn)
-      int_datum_issn.save!
+      @int_datum_issn = InternalDatum.new(identifier_id: @identifier.id, data_type: 'publicationISSN', value: @fake_issn)
+      @int_datum_issn.save!
       @fake_manuscript_number = 'bogus-manuscript-number'
       int_datum_manu = InternalDatum.new(identifier_id: @identifier.id, data_type: 'manuscriptNumber', value: @fake_manuscript_number)
       int_datum_manu.save!
@@ -381,6 +381,15 @@ module StashEngine
         Journal.create(issn: @fake_issn, payment_plan_type: 'SUBSCRIPTION')
         @identifier.record_payment
         expect(@identifier.payment_type).to match(/journal/)
+      end
+
+      it 'replaces a journal payment when the associated journal has changed' do
+        Journal.create(issn: @fake_issn, payment_plan_type: 'SUBSCRIPTION')
+        @identifier.record_payment
+        expect(@identifier.payment_type).to match(/journal/)
+        @int_datum_issn.update(value: 'not the journal issn')
+        @identifier.record_payment
+        expect(@identifier.payment_type).to match(/unknown/)
       end
 
       it 'records an institution payment' do

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -507,7 +507,7 @@ module StashEngine
       self.payment_id = nil
       save
     end
-    
+
     def abstracts
       return '' unless latest_resource.respond_to?(:descriptions)
 

--- a/stash/stash_engine/lib/stash/payments/invoicer.rb
+++ b/stash/stash_engine/lib/stash/payments/invoicer.rb
@@ -31,21 +31,6 @@ module Stash
         invoice.send_invoice
       end
 
-      # For a journal, generate an invoice item for the DPC.
-      # Don't create the actual invoice, because we don't want to
-      # send it until the end of the month.
-      def charge_journal_via_invoice
-        set_api_key
-        customer_id = stripe_journal_customer_id
-        return unless customer_id.present?
-
-        # the following line was creating invoice_item from return value, but didn't seem used anywhere
-        create_invoice_items_for_dpc(customer_id)
-        resource.identifier.payment_id = "#{resource.identifier&.publication_issn}-#{invoice_item&.id}"
-        resource.identifier.payment_type = 'journal'
-        resource.identifier.save
-      end
-
       def external_service_online?
         set_api_key
         latest = StashEngine::Identifier.where.not(payment_id: nil).order(updated_at: :desc).first


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1146

Not a lot of code changes, but some subtle interactions here...
- When journal information is changed, and the journal was set to pay, the payment information will be recalculated.
- Payment is *not* recalculated for other types of payment (e.g., if we manually apply a waiver)
- Payment is *not* recalculated for datasets that are already in the system at the time a journal discontinues its payment plan. As long as the journal associated with the dataset remains consistent, we don't change it out from under the depositor. We only change it when the depositor actively switches journals.
- This PR also removes a stub feature for invoicing journals through Stripe, which we never used.