### PR TITLE
Optimize curation so that it loads only results needed for display

### DIFF
--- a/spec/features/stash_datacite/dataset_versioning_spec.rb
+++ b/spec/features/stash_datacite/dataset_versioning_spec.rb
@@ -105,7 +105,7 @@ RSpec.feature 'DatasetVersioning', type: :feature do
         before(:each, js: true) do
           sign_in(@curator)
           find('summary', text: 'Admin').click
-          click_link 'Dataset Curation'
+          visit stash_url_helpers.ds_admin_path
         end
 
         it 'displays the proper information on the Admin page', js: true do
@@ -162,14 +162,15 @@ RSpec.feature 'DatasetVersioning', type: :feature do
 
         sign_in(@curator)
         find('summary', text: 'Admin').click
-        click_link 'Dataset Curation'
+        visit stash_url_helpers.ds_admin_path
+
         # Edit the Dataset as an admin
         find('button[title="Edit Dataset"]').click
         expect(page).to have_text("You are editing #{@author.name}'s dataset.")
         update_dataset(curator: true)
         @resource.reload
-        find('summary', text: 'Admin').click
-        click_link 'Dataset Curation'
+
+        visit stash_url_helpers.ds_admin_path
       end
 
       it 'has a resource_state (Merritt status) of "submitted"', js: true do
@@ -245,7 +246,9 @@ RSpec.feature 'DatasetVersioning', type: :feature do
       it 'displays the proper information on the Admin page', js: true do
         sign_in(@curator)
         find('summary', text: 'Admin').click
-        click_link 'Dataset Curation'
+
+        visit stash_url_helpers.ds_admin_path
+
         within(:css, '.c-lined-table__row') do
           # Make sure the appropriate buttons are available
           # Make sure the right text is shown
@@ -260,7 +263,7 @@ RSpec.feature 'DatasetVersioning', type: :feature do
       it 'displays the proper information on the Activity Log page', js: true do
         sign_in(@curator)
         find('summary', text: 'Admin').click
-        click_link 'Dataset Curation'
+        visit stash_url_helpers.ds_admin_path
 
         within(:css, '.c-lined-table__row') do
           find('button[aria-label="View Activity Log"]').click

--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -132,9 +132,7 @@ RSpec.feature 'Admin', type: :feature do
       it 'allows assigning a curator', js: true do
         @curator = create(:user, role: 'superuser', tenant_id: 'dryad')
 
-        visit root_path
-        find('.o-sites__summary', text: 'Admin').click
-        find('.o-sites__group-item', text: 'Dataset Curation').click
+        visit stash_url_helpers.ds_admin_path
 
         expect(page).to have_text('Admin Dashboard')
         expect(page).to have_css('button[title="Update curator"]')
@@ -151,9 +149,7 @@ RSpec.feature 'Admin', type: :feature do
       it 'allows un-assigning a curator', js: true do
         @curator = create(:user, role: 'superuser', tenant_id: 'dryad')
 
-        visit root_path
-        find('.o-sites__summary', text: 'Admin').click
-        find('.o-sites__group-item', text: 'Dataset Curation').click
+        visit stash_url_helpers.ds_admin_path
 
         expect(page).to have_text('Admin Dashboard')
         expect(page).to have_css('button[title="Update curator"]')
@@ -162,7 +158,7 @@ RSpec.feature 'Admin', type: :feature do
         click_button('Submit')
 
         within(:css, '.c-lined-table__row', wait: 10) do
-          expect(page).not_to have_text(@curator.name.to_s)
+          expect(page).not_to have_text(@curator.name_last_first)
         end
 
       end

--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -14,7 +14,7 @@ module StashEngine
     TENANT_IDS = Tenant.all.map(&:tenant_id)
 
     # the admin datasets main page showing users and stats, but slightly different in scope for curators vs tenant admins
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def index
       my_tenant_id = (%w[admin tenant_curator].include?(current_user.role) ? current_user.tenant_id : nil)
       tenant_limit = (%w[admin tenant_curator].include?(current_user.role) ? current_user.tenant : nil)
@@ -34,7 +34,7 @@ module StashEngine
 
       if request.format.to_s == 'text/csv' # we want all the results to put in csv
         page = 1
-        page_size = 1000000
+        page_size = 1_000_000
       else
         page = @page.to_i
         page_size = @page_size.to_i
@@ -60,7 +60,7 @@ module StashEngine
         end
       end
     end
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     # Unobtrusive Javascript (UJS) to do AJAX by running javascript
     def data_popup

--- a/stash/stash_engine/app/helpers/stash_engine/admin_datasets_helper.rb
+++ b/stash/stash_engine/app/helpers/stash_engine/admin_datasets_helper.rb
@@ -26,7 +26,7 @@ module StashEngine
     def editor_select
       curators = StashEngine::User.curators
       curators.sort { |a, b| a.last_name <=> b.last_name }.map do |c|
-        [c.name, c.id]
+        [c.name_last_first, c.id]
       end
     end
 

--- a/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
+++ b/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
@@ -105,6 +105,7 @@ module StashEngine
         # The funders, if set, limits to items associated with one of the given funders.
         #
         # if resource_id is set then only returns that resource id
+        # rubocop:disable Metrics/ParameterLists
         def where(params:, tenant: nil, journals: nil, funders: nil, identifier_id: nil, page: 1, page_size: 10)
           # If a search term was provided include the relevance score in the results for sorting purposes
           relevance = params.fetch(:q, '').blank? ? '' : ", (#{add_term_to_clause(SEARCH_CLAUSE, params.fetch(:q, ''))}) relevance"
@@ -133,6 +134,7 @@ module StashEngine
           # If the user is trying to sort by author names, then
           (column == 'author_names' ? sort_by_author_names(results, params.fetch(:direction, '')) : results)
         end
+        # rubocop:enable Metrics/ParameterLists
 
         private
 
@@ -190,7 +192,8 @@ module StashEngine
         end
 
         def build_limit_clause(page:, page_size:)
-          # rows start at 0 and limit is offset, row_count.  I add 1 to the page size so we know if there is a next page of results
+          # rows start at 0 and limit is offset, row_count.  I multiply page size so we know if there are a few pages afterward
+          # LIMIT [offset,] row_count;
           " LIMIT #{(page - 1) * page_size}, #{4 * page_size}"
         end
 

--- a/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
+++ b/stash/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
@@ -105,7 +105,7 @@ module StashEngine
         # The funders, if set, limits to items associated with one of the given funders.
         #
         # if resource_id is set then only returns that resource id
-        def where(params:, tenant: nil, journals: nil, funders: nil, identifier_id: nil)
+        def where(params:, tenant: nil, journals: nil, funders: nil, identifier_id: nil, page: 1, page_size: 10)
           # If a search term was provided include the relevance score in the results for sorting purposes
           relevance = params.fetch(:q, '').blank? ? '' : ", (#{add_term_to_clause(SEARCH_CLAUSE, params.fetch(:q, ''))}) relevance"
           # editor_name is derived from 2 DB fields so use the last_name instead
@@ -126,6 +126,7 @@ module StashEngine
                                  admin_funders: funders,
                                  identifier_id: identifier_id)}
             #{build_order_clause(column, params.fetch(:direction, ''), params.fetch(:q, ''))}
+            #{build_limit_clause(page: page, page_size: page_size)}
           "
           curator_ids = StashEngine::User.curators.map(&:id)
           results = ApplicationRecord.connection.execute(query).map { |result| new(result, curator_ids) }
@@ -186,6 +187,11 @@ module StashEngine
           else
             (column.present? && column != 'author_names' ? "ORDER BY #{column} #{direction || 'ASC'}" : '')
           end
+        end
+
+        def build_limit_clause(page:, page_size:)
+          # rows start at 0 and limit is offset, row_count.  I add 1 to the page size so we know if there is a next page of results
+          " LIMIT #{(page - 1) * page_size}, #{4 * page_size}"
         end
 
         def sort_by_author_names(results, direction)

--- a/stash/stash_engine/app/views/kaminari/_paginator.html.erb
+++ b/stash/stash_engine/app/views/kaminari/_paginator.html.erb
@@ -25,6 +25,6 @@
       <% end -%>
     <% end -%>
     <%= next_page_tag unless current_page.last? %>
-    <%= last_page_tag unless current_page.last? %>
+    <%= last_page_tag unless current_page.last? || params[:show_last_page] == false %>
   </nav>
 <% end -%>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/index.csv.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/index.csv.erb
@@ -13,7 +13,7 @@
             resource.views,
             resource.downloads,
             resource.citations,
-            StashEngine::Tenant.find(resource.tenant_id).long_name
+            StashEngine::Tenant.find(resource.tenant_id)&.long_name
     ]
 -%><%= row.to_csv(row_sep: nil).html_safe %>
 <% end -%>

--- a/stash/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
@@ -12,7 +12,7 @@
   <%= render partial: 'datasets_table', locals: { datasets: @datasets } %>
 
   <div class="c-space-paginator">
-    <%= paginate @datasets, params: { page_size: @page_size, show_all: false } %><br/>
+    <%= paginate @datasets, params: { page_size: @page_size, show_all: false, show_last_page: false } %><br/>
     Page Size:
     <%
       current_ps = params[:page_size].to_i

--- a/stash/stash_engine/app/views/stash_engine/pages/_nav.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/pages/_nav.html.erb
@@ -16,7 +16,8 @@
           <details class="o-showhide o-sites__details" role="group">
             <summary class="o-showhide__summary o-sites__summary">Admin</summary>
             <div class="o-sites__group">
-		<%= link_to 'Dataset Curation', stash_url_helpers.url_for(controller: 'stash_engine/admin_datasets', action: 'index', only_path: true), class: 'o-sites__group-item' %>
+		<%= link_to 'Dataset Curation', stash_url_helpers.url_for(controller: 'stash_engine/admin_datasets', action: 'index',
+                                                              editor_id: current_user.id, curation_status: 'submitted', only_path: true), class: 'o-sites__group-item' %>
 		<%= link_to 'Curation Stats', stash_url_helpers.curation_stats_path, class: 'o-sites__group-item' %>
 		<%= link_to 'Journals', stash_url_helpers.journals_path, class: 'o-sites__group-item' %>
 		<%= link_to 'Publication Updater', stash_url_helpers.publication_updater_path, class: 'o-sites__group-item' %>


### PR DESCRIPTION
It looked like this originally loaded all results from the database (about 66,000) and then dumped most of them out of the array to display 10 items in Kaminari (pager).

I had to point my development against production and test a bit against a bigger database to see the slow times more clearly.  (62 seconds to load the first time and then maybe some caching or something.)  After optimizing with LIMIT then that query was about 500 milliseconds.

- Only returns the results from SQL needed to get current page and a few pages after (for making the pager look better).
- No longer has a "Last page" just like there isn't a "Last page" of Google. I don't think there is any compelling reason to rerun a full search with COUNT in order to get an exact last page number.  If people want the end, they can sort something in the reverse direction or limit or search in some smarter way.
- Had to hack in a bunch of nil values onto the front of the Array since Kaminari is kind of annoying and expects them.  I looked for workarounds for a few hours and didn't find a lot else that was a really better solution.  BTW, github has tickets complaining about Kaminari and some slow queries in their codebase because people used it badly there, so we're not the only ones and they wanted Rubocop warnings about it so people didn't use it for paging on some complex SQL queries. ;-)
- Changed the menu item for dataset curation to limit to the current user and submitted status since that is what they generally start from.
- Changed the curator list to display as `lastname, firstname` since it sorts by lastname and without it displayed that way it made it look like it was sorting in a random order.
- Fixed a bunch of tests (mostly caused by the new filter when navigating with the menus).
- Made sure it does the full query for CSV since that shouldn't be paged and dumps everything.