### PR TITLE
Index file types

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -41,6 +41,7 @@ FIELDS:
   :TITLE: 'dc_title_s'
   :RELATED_PUBLICATION_NAME: 'dryad_related_publication_name_s'
   :AUTHOR_AFFILIATION_NAME: 'dryad_author_affiliation_name_sm'
+  :DATASET_FILE_EXT: 'dryad_dataset_file_ext_sm'
 
 # Institution deployed at
 INSTITUTION: 'Dryad'

--- a/config/solr_config/schema.xml
+++ b/config/solr_config/schema.xml
@@ -191,6 +191,7 @@
   <!-- sfisher 08/22/2019 - fields to store the affiliation of authors -->
   <copyField source="dryad_author_affiliation_name_sm" dest="dryad_author_affiliation_name_tmi" maxChars="1000"/>
   <copyField source="dryad_author_affiliation_id_sm" dest="dryad_author_affiliation_id_tmi" maxChars="100"/>
+  <copyField source="dryad_dataset_file_ext_sm" dest="dryad_dataset_file_ext_tmi" maxChars="10"/>
 
 
   <!-- core text search -->

--- a/config/solr_config/solrconfig.xml
+++ b/config/solr_config/solrconfig.xml
@@ -170,6 +170,8 @@
       <str name="facet.field">dryad_related_publication_name_s</str>
       <!-- sfisher 08/22/2019 - provide a facet for author affiliation(s) -->
       <str name="facet.field">dryad_author_affiliation_name_sm</str>
+      <!-- sfisher 11/15/2021 -- provide a facet for file extension -->
+      <str name="facet.field">dryad_dataset_file_ext_sm</str>
 
       <str name="spellcheck">true</str>
     </lst>

--- a/documentation/technical_notes/geoblacklight.md
+++ b/documentation/technical_notes/geoblacklight.md
@@ -1,0 +1,25 @@
+# Information about Geoblacklight and SOLR
+
+## How to add another facet to the data and search interface
+
+1. Set up the additional item(s) in the SOLR schema for Geoblacklight
+   - edit `config/solr_config/solrconfig.xml` in our code and add a facet field
+      like those already shown. Look at the dynamic naming at the end `s` is for string,
+      `m` is multiple, `i` is integer.  The `schema.xml` in same directory gives more info.
+2. Edit `schema.xml` in this same directory.  Add a copyField for scoring or
+   full-text search.  Follow the examples if you need to include in search or queryfilters. (see 3 below)
+3. Back in `solrconfig.xml` add to the `qf` and `pf` sections (queryFilter and phraseBoost).
+   These use the copied fields you set up in number 2.
+4. You will need to copy (scp) these completed files into the geoblacklight core on
+   each server you want to use it on.  Start by testing on dev.  The core is someplace
+   like `~/apps/solr/server/solr/geoblacklight/conf`.  You'll need to restart SOLR
+   afterwards (right now from `~/init.d` script).
+5. Double-check search is still working as expected without error after restarting.
+6. Add constants to the geoblacklight example and config for your new facet.
+   `dryad-config-example/settings.yml` and `config/settings.yml`. For example
+    ```ruby
+    :DATASET_FILE_EXT: 'dryad_dataset_file_ext_sm'
+    ```
+7. Add indexing to populate the data you desire into each record at
+   `stash/stash_datacite/lib/stash_indexer/indexing_resource.rb` and update the tests.
+8. Update all the SOLR records: `RAILS_ENV=<env> bundle exec rails rsolr:reindex`

--- a/dryad-config-example/settings.yml
+++ b/dryad-config-example/settings.yml
@@ -30,6 +30,7 @@ FIELDS:
   :TITLE: 'dc_title_s'
   :RELATED_PUBLICATION_NAME: 'dryad_related_publication_name_s'
   :AUTHOR_AFFILIATION_NAME: 'dryad_author_affiliation_name_sm'
+  :DATASET_FILE_EXT: 'dryad_dataset_file_ext_sm'
 
 # Institution deployed at
 INSTITUTION: 'Dryad'

--- a/spec/lib/stash_datacite/indexing_resource_spec.rb
+++ b/spec/lib/stash_datacite/indexing_resource_spec.rb
@@ -90,7 +90,8 @@ module Stash
         @right = create(:right, resource_id: @resource.id)
         @subject1 = create(:subject, resources: [@resource])
         @subject2 = create(:subject, subject: 'parsimonious', resources: [@resource])
-        @data_files = [ create(:data_file, resource_id: @resource.id), create(:data_file, resource_id: @resource.id), create(:data_file, resource_id: @resource.id) ]
+        @data_files = [create(:data_file, resource_id: @resource.id),
+                       create(:data_file, resource_id: @resource.id), create(:data_file, resource_id: @resource.id)]
         @resource.reload
         @ir = IndexingResource.new(resource: @resource)
       end
@@ -287,8 +288,8 @@ module Stash
           # just assembled into the mega-hash for SOLR
           @resource.geolocations = []
           mega_hash = @ir.to_index_document
-          df = @data_files.map { |df| File.extname("#{df.upload_file_name}").gsub(/^./, '').downcase }
-                          .flatten.reject(&:blank?).uniq
+          df = @data_files.map { |d| File.extname(d.upload_file_name.to_s).gsub(/^./, '').downcase }
+            .flatten.reject(&:blank?).uniq
           expected_mega_hash = {
             uuid: @resource.identifier.to_s,
             dc_identifier_s: @resource.identifier.to_s,

--- a/spec/lib/stash_datacite/indexing_resource_spec.rb
+++ b/spec/lib/stash_datacite/indexing_resource_spec.rb
@@ -90,6 +90,7 @@ module Stash
         @right = create(:right, resource_id: @resource.id)
         @subject1 = create(:subject, resources: [@resource])
         @subject2 = create(:subject, subject: 'parsimonious', resources: [@resource])
+        @data_files = [ create(:data_file, resource_id: @resource.id), create(:data_file, resource_id: @resource.id), create(:data_file, resource_id: @resource.id) ]
         @resource.reload
         @ir = IndexingResource.new(resource: @resource)
       end
@@ -286,6 +287,8 @@ module Stash
           # just assembled into the mega-hash for SOLR
           @resource.geolocations = []
           mega_hash = @ir.to_index_document
+          df = @data_files.map { |df| File.extname("#{df.upload_file_name}").gsub(/^./, '').downcase }
+                          .flatten.reject(&:blank?).uniq
           expected_mega_hash = {
             uuid: @resource.identifier.to_s,
             dc_identifier_s: @resource.identifier.to_s,
@@ -307,7 +310,8 @@ module Stash
             dryad_author_affiliation_name_sm: [@affil1.long_name,
                                                @affil2.long_name],
             dryad_related_publication_name_s: 'Journal of Testing Fun',
-            dryad_related_publication_id_s: 'manuscript123 pubmed123 doi123'
+            dryad_related_publication_id_s: 'manuscript123 pubmed123 doi123',
+            dryad_dataset_file_ext_sm: df
           }
           expect(mega_hash).to eql(expected_mega_hash)
         end

--- a/stash/stash_datacite/lib/stash/indexer/indexing_resource.rb
+++ b/stash/stash_datacite/lib/stash/indexer/indexing_resource.rb
@@ -86,7 +86,8 @@ module Stash
           dryad_related_publication_name_s: related_publication_name,
           dryad_related_publication_id_s: related_publication_id,
           dryad_author_affiliation_name_sm: author_affiliations,
-          dryad_author_affiliation_id_sm: author_affiliation_ids
+          dryad_author_affiliation_id_sm: author_affiliation_ids,
+          dryad_dataset_file_ext_sm: dataset_file_exts
         }
       end
 
@@ -240,6 +241,12 @@ module Stash
       def author_affiliation_ids
         @resource.authors.map do |author|
           author.affiliations.map(&:ror_id)
+        end.flatten.reject(&:blank?).uniq
+      end
+
+      def dataset_file_exts
+        @resource.data_files.present_files.map do |df|
+          File.extname("#{df.upload_file_name}").gsub(/^./, '').downcase
         end.flatten.reject(&:blank?).uniq
       end
 

--- a/stash/stash_datacite/lib/stash/indexer/indexing_resource.rb
+++ b/stash/stash_datacite/lib/stash/indexer/indexing_resource.rb
@@ -246,7 +246,7 @@ module Stash
 
       def dataset_file_exts
         @resource.data_files.present_files.map do |df|
-          File.extname("#{df.upload_file_name}").gsub(/^./, '').downcase
+          File.extname(df.upload_file_name.to_s).gsub(/^./, '').downcase
         end.flatten.reject(&:blank?).uniq
       end
 

--- a/stash/stash_discovery/app/controllers/catalog_controller.rb
+++ b/stash/stash_discovery/app/controllers/catalog_controller.rb
@@ -88,6 +88,7 @@ class CatalogController < ApplicationController
     config.add_facet_field Settings.FIELDS.PART_OF, label: 'Collection', limit: 8
     config.add_facet_field Settings.FIELDS.RELATED_PUBLICATION_NAME, label: 'Journal', limit: 8
     config.add_facet_field Settings.FIELDS.AUTHOR_AFFILIATION_NAME, label: 'Institution', limit: 8
+    config.add_facet_field Settings.FIELDS.DATASET_FILE_EXT, label: 'File Extension', limit: 8
 
     # config.add_facet_field Settings.FIELDS.RIGHTS, label: 'Access', limit: 8, partial: "icon_facet"
     # config.add_facet_field Settings.FIELDS.GEOM_TYPE, label: 'Data type', limit: 8, partial: "icon_facet"
@@ -120,6 +121,7 @@ class CatalogController < ApplicationController
     # config.add_index_field Settings.FIELDS.PUBLISHER
     config.add_index_field Settings.FIELDS.RELATED_PUBLICATION_NAME
     config.add_index_field Settings.FIELDS.AUTHOR_AFFILIATION_NAME
+    config.add_index_field Settings.FIELDS.DATASET_FILE_EXT
 
     # solr fields to be displayed in the show (single result) view
     #  The ordering of the field names is the order of the display


### PR DESCRIPTION
This gets the file extension facet working.

The two config files need to be copied over to a solr server, but this is already done on dev if you're testing there.  If you run this branch against the dev solr instance it should work and allow faceting by file extension.

Added instructions for how to do it all since we do this pretty rarely and it takes a little time to re-figure-out each time without instructions.