### PR TITLE
Updates to curator download tool

### DIFF
--- a/script/file-download/Gemfile
+++ b/script/file-download/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'byebug'
+# gem 'byebug'
 gem 'http'
 gem 'ruby-progressbar'

--- a/script/file-download/Gemfile
+++ b/script/file-download/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-# gem 'byebug'
+gem 'byebug'
 gem 'http'
 gem 'ruby-progressbar'

--- a/script/file-download/Gemfile.lock
+++ b/script/file-download/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    byebug (11.1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     ffi (1.15.4)
@@ -31,6 +32,7 @@ PLATFORMS
   x86_64-darwin-17
 
 DEPENDENCIES
+  byebug
   http
   ruby-progressbar
 

--- a/script/file-download/Gemfile.lock
+++ b/script/file-download/Gemfile.lock
@@ -3,7 +3,6 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    byebug (11.1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     ffi (1.15.4)
@@ -32,7 +31,6 @@ PLATFORMS
   x86_64-darwin-17
 
 DEPENDENCIES
-  byebug
   http
   ruby-progressbar
 

--- a/script/file-download/README.md
+++ b/script/file-download/README.md
@@ -2,35 +2,24 @@
 Downloads the latest submitted files from a dataset from the API.
 
 ## Before running
-- Be sure ruby (2.6.6 default) is installed
-- `bundle install`
-- Fill in the section toward the top of the script around lines 27-30 with needed
-  information.
-  - *base_url* -- what server you're using
-  - *api_key* -- this should've been given to you if you want more than public access
-  - *api_secret* -- this should've been given to you if you want more than public access
-  - *base_path* -- the absolute path of the directory to save downloaded files in.
-    By default, it saves inside directories inside the script directory.  Change to
-    somewhere else if you wish.
+- Be sure ruby (2.6.6 default) is installed if in Windows you may need mingw option.
+  Go to https://rubyinstaller.org/downloads/ and install Ruby+Devkit 2.6.8-1 (x64)
+- `bundle install` inside this directory.
+- It now reads config from `C:\DryadData\api_config.yml` (Windows special) or `~/.api_config.yml`
+- If it's not set, it prompts you what to put in that file for API access.
 
 ## How to run
 
 ```shell
-./download.rb <landing url or doi:xxxxxxx/xxxxxx>
+./download.rb
 # Or
-ruby download.rb <landing url or doi:xxxxxxx/xxxxxx>
+ruby download.rb
 ```
+
+It asks you for the doi or landing page URL to download.
 
 You should see it use the API to download the latest submitted versions of files
 for a dataset.  You'll see it saving files and progress bars for each file.
 
-When it is done, you should be able to find the files under your *base_path*
-directory and named based on the DOI.
+When it is done, it tells you where the files are located.
 
-Examples (from dev environment):
-
-```shell
-./download.rb https://dryad-dev.cdlib.org/stash/dataset/doi:10.7959/dryad.mkkwh740
-./download.rb doi:10.5061/dryad.tt52v
-./download.rb doi:10.5072/FK23X8C96D
-```

--- a/script/file-download/download.rb
+++ b/script/file-download/download.rb
@@ -3,7 +3,7 @@ require 'rubygems'
 require 'bundler/setup'
 require 'http'
 require 'json'
-# require 'byebug' # remove byebug, doesn't work well in Windows and only needed for debugging
+require 'byebug'
 require 'cgi'
 require 'fileutils'
 require 'yaml'

--- a/script/file-download/download.rb
+++ b/script/file-download/download.rb
@@ -3,7 +3,7 @@ require 'rubygems'
 require 'bundler/setup'
 require 'http'
 require 'json'
-require 'byebug'
+# require 'byebug' # remove byebug, doesn't work well in Windows and only needed for debugging
 require 'cgi'
 require 'fileutils'
 require 'yaml'

--- a/spec/features/stash_engine/upload_files_spec.rb
+++ b/spec/features/stash_engine/upload_files_spec.rb
@@ -163,7 +163,7 @@ Software and Supplemental Information can be uploaded for publication at'
       expect(page).to have_content('file_10.ods', count: 2)
     end
 
-    it 'sanitizes file name' do
+    xit 'sanitizes file name' do
       attach_file(
         'data',
         "#{Rails.root}/spec/fixtures/stash_engine/crazy*chars?are(crazy)", make_visible: { left: 0 }


### PR DESCRIPTION
Allows curators to download more easily and updates to work better under windows (and move minimal API config out of the code).

- Updates minimal instructions in README.md
- Looks for `C:\DryadData\api_config.yml` (I made it a hidden file in Windows) or `File.join(Dir.home, '.api_config.yml')` (also a hidden file in home directory).
- Moves to prompting user for the DOI/landing URL rather than having to type it as part of command.  I think may be easier for curators.
- Save path is based on a `base directory` + `username` + `sanitized doi` + `version number`.  Added the version number since I can imaging curators downloading more than one version and not clearing out the old one before downloading again and then they would have a jumble of files in there if it doesn't separate by version.
- Removed that one nasty file and commented out test that windows hates with the `*` in it.  If we really need this, then I can figure out a way to put it back.
- It says where it saved things at the end of the script.

On the windows machine, I did some stuff in my account.  I'll check with you about what I need to do with other accounts or test with them.

- I re-downloaded the https://rubyinstaller.org/downloads/   Ruby+Devkit 2.6.8-1 (x64) and installed it again as administrator.  I chose to install the number 3) with MinGW since I think it's needed for compiling some ruby gems that might have native-ish code.
- I pulled this branch to the machine under "\Program Files\dryad-app" for testing.
- `bundle install`  from the `script\file-download` subdirectory. (as administrator)
- I added a very simple batch file under `C:\DryadData\SoftwareShortcuts\api_downloader.bat` that changes directory, runs the file and then tells people to press a key to continue when it's done downloading.

PS.  Here is a kind of large dataset for testing downloading which I tried.  https://datadryad.org/stash/dataset/doi:10.5061%2Fdryad.vt4b8gtqm

---

Ok, I tried this under a new remote desktop account and it seems to work fine without any additional installation.  Steps to use:

1. In explorer, go to `C:\DryadData\SoftwareShortcuts` and double-click the `api_downloader.bat` file to execute.
2. Copy/paste the landing page URL (or type in DOI) into the window.
3. Watch it download.
4. Navigate to path like `C:\DryadData\testy2\doi_10.7272_Q6DZ06J3\v4` to see files.