### PR TITLE
Make API documentation more approachable for new users

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -35,7 +35,7 @@ Our demo instance of Dryad is available at [https://dryad-stg.cdlib.org](https:/
 * A basic generalized introduction to Dryad's architecture is
   available at https://datadryad.org/stash/our_platform .
 
-* API documentation: [Summary of the main APIs](https://datadryad.org/api/v2/docs/), and [descriptions of other APIs](apis)
+* API documentation: [API README](apis/README.md), [Specification for the main APIs](https://datadryad.org/api/v2/docs/), and [descriptions of other APIs](apis)
 
 * A (somewhat dated) database [Entity-Relationship diagram](other_files/dash_er_2018-06.pdf).
 

--- a/documentation/apis/README.md
+++ b/documentation/apis/README.md
@@ -3,7 +3,41 @@ Dryad APIs
 
 This directory contains documentation for Dryad's various APIs.
 
-Our most frequently-used API endpoints are summarized at
-https://datadryad.org/api/v2/docs/, with more details in the
-[Submisison API Document](submission.md).
+Search API
+---------------
+
+The easiest API to use is the [Search API](search.md), which allows anonymous
+users to locate datasets of interest. URLs for the Search API may be used in a
+browser, or with many tools.
+
+REST API and GET requests
+-------------------------
+
+The [REST API](https://datadryad.org/api/v2/docs/) allows detailed interaction
+with Dryad contents. The most common case is to use GET requests to retrieve
+information about datasets, versions, and files.
+
+When using the API, any DOI included must be
+[URL-encoded](https://www.w3schools.com/tags/ref_urlencode.ASP) to ensure correct processing.
+
+Some examples:
+- Listing of datasets: `https://datadryad.org/api/v2/datasets`
+- Information about a dataset: `https://datadryad.org/api/v2/datasets/doi%3A10.5061%2Fdryad.j1fd7`
+- Versions of the dataset: `https://datadryad.org/api/v2/datasets/doi%3A10.5061%2Fdryad.j1fd7/versions`
+- Files from a version: `https://datadryad.org/api/v2/versions/26724/files`
+
+# Authentication and accessing private content
+
+To access more powerful features, an API account is required. API accounts allow users to:
+- Access the API at higher rates
+- Access datasets that are not yet public, but are associated with the account's community (institution, journal, etc.)
+- Update datasets associated with the account's community
+
+See the [API accounts](api_accounts.md) document for more information on requesting an API account and using it to access datasets.
+
+# Submission
+
+The [Submisison API](submission.md) is used by systems that want to partner
+more closely with Dryad and create dataset submissions directly.
+
 

--- a/documentation/apis/api_accounts.md
+++ b/documentation/apis/api_accounts.md
@@ -1,0 +1,83 @@
+Dryad API Accounts
+==================
+
+An API account is required to use advanced features of Dryad's APIs.
+
+Obtain a Dryad API account
+--------------------------
+
+Before you can submit from the API, you must have an account for the
+API. It is easiest if you first create an account through the Dryad
+web interface. Dryad staff can then add API capabilities to this
+account. Log in to Dryad at least once to create a user record and (if
+applicable) associate it with your associated campus/organization.
+
+In some cases, an API account will be needed that is not attached to a
+single user. In this case, the account will not be associated with an
+ORCID, which means that the API account will not be able to log in to
+the Dryad web interface. We will still need an email address to
+receive notifications associated with the account.
+
+Please [contact us](mailto:help@datadryad.org) to request API access. In your
+request, please specify whether you are associated with an institution
+or journal that is a Dryad member. Dryad developers will then [grant
+you the necessary permissions](adding_api_accounts.md).
+
+
+Get a token for making requests for secure parts of the API
+-----------------------------------------------------------
+
+Before making secure requests to the Dryad API, you'll need a token.  Currently our tokens last 10 hours and a token will need to be renewed when it expires.  You may get a token using these examples from a few programming environments.  Replace &lt;bracketed&gt; items with the values you were given.  For testing, you may choose to use a bash shell, a programming environment or a tool such as Postman.
+
+
+```bash
+# get token with curl
+curl -X POST https://<domain-name>/oauth/token -d "client_id=<application-id>&client_secret=<secret>&grant_type=client_credentials" -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8"
+```
+
+Or
+
+```ruby
+# get token with Ruby
+require 'rest-client'
+require 'json'
+app_id = '<application-id>'
+secret = '<secret>'
+domain_name = '<domain-name>'
+response = RestClient.post "https://#{domain_name}/oauth/token", {
+  grant_type: 'client_credentials',
+  client_id: app_id,
+  client_secret: secret
+}
+token = JSON.parse(response)['access_token']
+```
+
+### Renewing your token
+
+Tokens are only valid for a limited amount of time.  See documentation
+about [retrying_requests made with expired tokens](retrying_expired.md) for more information.
+
+
+Test that your token works
+--------------------------
+
+Now make sure you can use your token to access secured areas of the API.  Test with some code like the following.
+
+```bash
+curl -i -H "Accept: application/json" -H "Content-Type: application/json" -H "Authorization: Bearer <token>" -X GET https://<domain>/api/v2/test
+```
+
+or
+
+```ruby
+# this Ruby example continues from the section above and assumes the variables above are already set
+headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{token}" }
+
+resp = RestClient.get "https://#{domain_name}/api/v2/test", headers
+
+j = JSON.parse(resp)
+```
+
+You should see a 200 response and some information something like:
+
+{"message" => "Welcome application owner &lt;name&gt;", "user_id" => &lt;number&gt;}

--- a/documentation/apis/submission.md
+++ b/documentation/apis/submission.md
@@ -1,81 +1,15 @@
-# Doing a basic submission and an version update with the Dryad API
-The Dryad API now enables submission.  For authentication, it uses an OAuth2 client credentials grant (see [A Guide To OAuth 2.0 Grants](https://alexbilbie.com/guide-to-oauth-2-grants/)).
+Dryad Submission API
+====================
+
+The Dryad Submission API enables submission and update of datasets.  For authentication, it uses an OAuth2 client credentials grant (see [A Guide To OAuth 2.0 Grants](https://alexbilbie.com/guide-to-oauth-2-grants/)).
 
 This document gives practical information for working with the API in order to submit a dataset and [fuller API documentation is available](https://datadryad.org/api/v2/docs/index.html).
 
-## Obtain a Dryad API account
 
-Before you can submit from the API, you must have an account for the
-API. It is easiest if you first create an account through the Dryad
-web interface. Dryad staff can then add API capabilities to this
-account. Log in to Dryad at least once to create a user record and (if
-applicable) associate it with your associated campus/organization.
+## Obtain an API Account
 
-In some cases, an API account will be needed that is not attached to a
-single user. In this case, the account will not be associated with an
-ORCID, which means that the API account will not be able to log in to
-the Dryad web interface. We will still need an email address to
-receive notifications associated with the account.
+Before using the submission API, each user must have an [API Account](api_accounts.md).
 
-Please [contact us](mailto:help@datadryad.org) to request API access. In your
-request, please specify whether you are associated with an institution
-or journal that is a Dryad member. Dryad developers will then [grant
-you the necessary permissions](adding_api_accounts.md).
-
-## Get a token for making requests for secure parts of the API
-
-Before making secure requests to the Dryad API, you'll need a token.  Currently our tokens last 10 hours and a token will need to be renewed when it expires.  You may get a token using these examples from a few programming environments.  Replace &lt;bracketed&gt; items with the values you were given.  For testing, you may choose to use a bash shell, a programming environment or a tool such as Postman.
-
-
-```bash
-# get token with curl
-curl -X POST https://<domain-name>/oauth/token -d "client_id=<application-id>&client_secret=<secret>&grant_type=client_credentials" -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8"
-```
-
-Or
-
-```ruby
-# get token with Ruby
-require 'rest-client'
-require 'json'
-app_id = '<application-id>'
-secret = '<secret>'
-domain_name = '<domain-name>'
-response = RestClient.post "https://#{domain_name}/oauth/token", {
-  grant_type: 'client_credentials',
-  client_id: app_id,
-  client_secret: secret
-}
-token = JSON.parse(response)['access_token']
-```
-
-### Renewing your token
-
-Tokens are only valid for a limited amount of time.  See documentation
-about [retrying_requests made with expired tokens](retrying_expired.md) for more information.
-
-
-## Test that your token works
-Now make sure you can use your token to access secured areas of the API.  Test with some code like the following.
-
-```bash
-curl -i -H "Accept: application/json" -H "Content-Type: application/json" -H "Authorization: Bearer <token>" -X GET https://<domain>/api/v2/test
-```
-
-or
-
-```ruby
-# this Ruby example continues from the section above and assumes the variables above are already set
-headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{token}" }
-
-resp = RestClient.get "https://#{domain_name}/api/v2/test", headers
-
-j = JSON.parse(resp)
-```
-
-You should see a 200 response and some information something like:
-
-{"message" => "Welcome application owner &lt;name&gt;", "user_id" => &lt;number&gt;}
 
 ## Create metadata for the dataset
 


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1508

- Expand the README in the `api` directory to include more overview and some simple examples.
- Move information about accounts and OAUTH into a separate document that can be referenced independently of the submission document
- Other minor cleanup 