### PR TITLE
Fix formatting in sshuttle IP list

### DIFF
--- a/config/script/sshuttle.sh
+++ b/config/script/sshuttle.sh
@@ -2,11 +2,10 @@
 FILE=~/sshuttle.pid
 
 # these are the servers we want to tunnel through the server that has access
-domain_arr="uc3-dryadsolrx2-dev.cdlib.org \                                                                                 
-uc3-dryadsolrx2-stg.cdlib.org \     
+domain_arr="uc3-dryadsolrx2-dev.cdlib.org uc3-dryadsolrx2-stg.cdlib.org \
 rds-uc3-dryad-prd.cmcguhglinoa.us-west-2.rds.amazonaws.com \
-uc3-dryadsolrx2-prd.cdlib.org \                                                                                               
-merritt-stage.cdlib.org mrtsword-stg.cdlib.org mrtoai-stg.cdlib.org \                                                       
+uc3-dryadsolrx2-prd.cdlib.org \
+merritt-stage.cdlib.org mrtsword-stg.cdlib.org mrtoai-stg.cdlib.org \
 ias-puppet2-ops.cdlib.org puppet.cdlib.org \
 search-os-uc3-logging-stg-suwz42vownvyte6ivqazeifz44.us-west-2.es.amazonaws.com"
 


### PR DESCRIPTION
The whitespace works on some environments, but not OSX.