### PR TITLE
Standardize autocomplete

### DIFF
--- a/spec/features/stash_datacite/affiliation_autofill_spec.rb
+++ b/spec/features/stash_datacite/affiliation_autofill_spec.rb
@@ -30,21 +30,22 @@ RSpec.feature 'AffiliationAutofill', type: :feature do
       stub_ror_id_lookup(university: 'University of Testing v2')
       fill_in 'author[affiliation][long_name]', with: 'Testing'
       first('.ui-menu-item-wrapper', wait: 1).click
-      expect(find('#author_affiliation_ror_id', visible: false).value).to eql('https://ror.org/TEST2')
+      expect(find('.js-affiliation_id', visible: false).value).to eql('https://ror.org/TEST2')
     end
 
     it 'allows entries that are not registered with ROR', js: true do
       fill_in 'author[affiliation][long_name]', with: 'Testing a non-ROR organization'
-      expect(find('#author_affiliation_ror_id', visible: false).value).to eql('')
+      expect(find('.js-affiliation_id', visible: false).value).to eql('')
     end
 
     it 'allows changing from a ROR-based value to a non-ROR value', js: true do
       stub_ror_id_lookup(university: 'University of Testing v2')
       fill_in 'author[affiliation][long_name]', with: 'Testing'
       first('.ui-menu-item-wrapper', wait: 1).click
-      expect(find('#author_affiliation_ror_id', visible: false).value).to eql('https://ror.org/TEST2')
+      expect(find('.js-affiliation_id', visible: false).value).to eql('https://ror.org/TEST2')
       fill_in 'author[affiliation][long_name]', with: 'Testing a non-ROR organization'
-      expect(find('#author_affiliation_ror_id', visible: false).value).to eql('')
+      find('.js-author_first_name').set('meow') # get out of this field
+      expect(find('.js-affiliation_id', visible: false).value).to eql('')
     end
 
   end

--- a/spec/features/stash_datacite/research_facility_autofill_spec.rb
+++ b/spec/features/stash_datacite/research_facility_autofill_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature 'ResearchFacilityAutofill', type: :feature do
       first('.ui-menu-item-wrapper', wait: 1).click
       expect(find('#facility_name_identifier_id', visible: false).value).to eql('https://ror.org/TEST2')
       fill_in 'contributor_research_facility', with: 'Testing a non-ROR organization'
+      find('.js-author_first_name').set('meow') # get out of this field
       expect(find('#facility_name_identifier_id', visible: false).value).to eql('')
     end
   end

--- a/stash/stash_datacite/app/assets/javascripts/stash_datacite/affiliations.js
+++ b/stash/stash_datacite/app/assets/javascripts/stash_datacite/affiliations.js
@@ -1,2 +1,94 @@
 // Place all the behaviors and hooks related to the matching controller here.
 // All this logic will automatically be available in application.js.
+
+/* need this info to get autocomplete working
+  1. Text field for the value
+  2. Hidden field to store the ID once it is selected
+  3. It is assumed that the parent form above either of these elements is the one that will be submitted with changes.
+  4. URL to hit with the autocomplete query (including item to indicate where to substitute the query string)
+  5. Assuming JSON is returned, info on how to get the text
+  6. Assuming JSON is returned, info on how to get the ID
+
+  We also need to track what changes in the text field (enter/leaving) and do the following
+  1) Store the starting value when entering the field or when autocomplete is selected
+  1) Submit parent form on blur or after selection
+  2) Clear the ID on blur and before form submission if the text value has changed since entry or when it was updated
+     by selecting from the list.
+ */
+
+function setupAutocomplete(txtFieldId, idFieldId, autoURL, txtKey, idKey){
+  const txtField = $(`#${txtFieldId}`);
+  const idField = $(`#${idFieldId}`);
+  const parentForm = txtField.parents('form');
+
+  console.log(`parent form ${parentForm.attr('id')}`);
+
+  // get rid of any existing event handlers for these items
+  txtField.unbind('click');
+  txtField.unbind('blur');
+  txtField.unbind('focus');
+
+  txtField.focus(function() {
+    txtField.attr('data-starting', txtField.val());
+    console.log(`focused on autocomplete with ${txtField.val()}`);
+  });
+
+  txtField.blur(function() {
+    // only submit again if the value has changed since last save
+    if (txtField.attr('data-starting') !== txtField.val()){
+      $(parentForm).trigger('submit.rails');
+    }
+  });
+
+  $(txtField).bind( "keydown", function( event ) {
+    // prevent tab from navigating out if it is for autocomplete
+    if ( event.keyCode === $.ui.keyCode.TAB &&
+      $( this ).autocomplete( "instance" ).menu.active ) {
+        event.preventDefault();
+      }
+    }
+  );
+
+  $(txtField).autocomplete({
+    source: function (request, response) {
+      $.ajax({
+        url: autoURL,
+        dataType: "json",
+        data: {
+          term: request.term
+        },
+        success: function (data) {
+          response($.map(data, function (item) {
+            return {
+              value: item.long_name,
+              id: item.id
+            }
+          }));
+        }
+      });
+    },
+    minLength: 2,
+    focus: function () {
+      // prevent value inserted on focus
+      return false;
+    },
+    select: function (event, ui) {
+      console.log(ui);
+      console.log(event);
+      console.log(`idField: ${idField.val()}`);
+      console.log(`txtField: ${txtField.val()}`);
+      txtField.val(ui.item.value); // be sure the selected item is set, since it sometimes isn't
+      idField.val(ui.item.id); // set hidden field ror_id
+      txtField.attr('data-starting', txtField.val());
+      $(parentForm).trigger('submit.rails');
+    },
+    open: function (event, ui) {
+    },
+    close: function (event, ui) {
+      // $(this).focus();
+    },
+    change: function( event, ui ) {
+    }
+  });
+
+} // end of setupAutocomplete

--- a/stash/stash_datacite/app/assets/javascripts/stash_datacite/affiliations.js
+++ b/stash/stash_datacite/app/assets/javascripts/stash_datacite/affiliations.js
@@ -6,8 +6,8 @@
   2. Hidden field to store the ID once it is selected
   3. It is assumed that the parent form above either of these elements is the one that will be submitted with changes.
   4. URL to hit with the autocomplete query (including item to indicate where to substitute the query string)
-  5. Assuming JSON is returned, info on how to get the text
-  6. Assuming JSON is returned, info on how to get the ID
+  5. Give a function to map an object to an {'id':,  'value': } object in case they're called
+     something different when returned from the data source.
 
   We also need to track what changes in the text field (enter/leaving) and do the following
   1) Store the starting value when entering the field or when autocomplete is selected
@@ -16,7 +16,7 @@
      by selecting from the list.
  */
 
-function setupAutocomplete(txtFieldId, idFieldId, autoURL, txtKey, idKey){
+function setupAutocomplete(txtFieldId, idFieldId, autoURL, itemMapper){
   const txtField = $(`#${txtFieldId}`);
   const idField = $(`#${idFieldId}`);
   const parentForm = txtField.parents('form');
@@ -36,6 +36,7 @@ function setupAutocomplete(txtFieldId, idFieldId, autoURL, txtKey, idKey){
   txtField.blur(function() {
     // only submit again if the value has changed since last save
     if (txtField.attr('data-starting') !== txtField.val()){
+      idField.val(''); // reset the idField if the value of the text has changed since the id was last saved
       $(parentForm).trigger('submit.rails');
     }
   });
@@ -59,10 +60,7 @@ function setupAutocomplete(txtFieldId, idFieldId, autoURL, txtKey, idKey){
         },
         success: function (data) {
           response($.map(data, function (item) {
-            return {
-              value: item.long_name,
-              id: item.id
-            }
+            return itemMapper(item);
           }));
         }
       });

--- a/stash/stash_datacite/app/controllers/stash_datacite/authors_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/authors_controller.rb
@@ -81,10 +81,11 @@ module StashDatacite
       end
 
       ror_val = ( args['affiliation']['ror_id'].present? ? args['affiliation']['ror_id'] : nil )
+      name = "#{args['affiliation']['long_name']}#{ ror_val.blank? ? '*' : '' }" # add that star to pollute our names and make non-atomic
       # find the affiliation with this name and ror_id
-      affil = StashDatacite::Affiliation.where(long_name: args['affiliation']['long_name'], ror_id: ror_val).first
+      affil = StashDatacite::Affiliation.where(long_name: name, ror_id: ror_val).first
       if affil.nil?
-        affil = StashDatacite::Affiliation.create(long_name: args['affiliation']['long_name'], ror_id: ror_val)
+        affil = StashDatacite::Affiliation.create(long_name: name, ror_id: ror_val)
       end
 
       @author.affiliation = affil

--- a/stash/stash_datacite/app/controllers/stash_datacite/authors_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/authors_controller.rb
@@ -74,19 +74,18 @@ module StashDatacite
     # find correct affiliation based on long_name and ror_id and set it, create one if needed.
     def process_affiliation
       return nil unless @author.present?
+
       args = author_params
       if args['affiliation']['long_name'].blank?
         @author.affiliations.destroy_all
         return
       end
 
-      ror_val = ( args['affiliation']['ror_id'].present? ? args['affiliation']['ror_id'] : nil )
-      name = "#{args['affiliation']['long_name']}#{ ror_val.blank? ? '*' : '' }" # add that star to pollute our names and make non-atomic
+      ror_val = (args['affiliation']['ror_id'].present? ? args['affiliation']['ror_id'] : nil)
+      name = "#{args['affiliation']['long_name']}#{ror_val.blank? ? '*' : ''}" # add that star to pollute our names and make non-atomic
       # find the affiliation with this name and ror_id
       affil = StashDatacite::Affiliation.where(long_name: name, ror_id: ror_val).first
-      if affil.nil?
-        affil = StashDatacite::Affiliation.create(long_name: name, ror_id: ror_val)
-      end
+      affil = StashDatacite::Affiliation.create(long_name: name, ror_id: ror_val) if affil.nil?
 
       @author.affiliation = affil
       @author.save

--- a/stash/stash_datacite/app/controllers/stash_datacite/contributors_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/contributors_controller.rb
@@ -81,7 +81,8 @@ module StashDatacite
         # init with the contrib name as-is
       else
         # init with contrib name getting an asterisk unless I can get an exact name match from fundref
-        @contributor.contributor_name = "#{args['contributor_name']}*" unless set_exact_match(contributor_name: args[:contributor_name])
+        @contributor.contributor_name = "#{args['contributor_name']}*" unless args[:contributor_type] == 'funder' &&
+                            set_exact_match(contributor_name: args[:contributor_name])
         @contributor.contributor_name = nil if @contributor.contributor_name == '*'
       end
 

--- a/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
@@ -11,65 +11,13 @@
 
 <script type="text/javascript">
 
-	// txtFieldId, idFieldId, autoURL, txtKey, idKey
+	const itemMapper = (item) => {
+		return {id: item.id, value: item.long_name};
+	}
+
+	// txtFieldId, idFieldId, autoURL, resultMapper
 	setupAutocomplete('<%= my_txt %>',
 			'<%= my_id %>',
 			"<%= stash_datacite.affiliations_autocomplete_path %>",
-			null,
-			null);
-
-	/*
- $(function () {
-     $('<%= "##{form_id}" %> .js-affiliation')
-     // don't navigate away from the field on tab when selecting an item
-	 .bind( "keydown", function( event ) {
-             if ( event.keyCode === $.ui.keyCode.TAB &&
-		  $( this ).autocomplete( "instance" ).menu.active ) {
-		 event.preventDefault();
-             }
-	     $('<%= "##{form_id}" %> #author_affiliation_ror_id').val('') // clear any ROR that was saved previously
-	 })
-	 .autocomplete({
-             source: function (request, response) {
-		 $.ajax({
-		     url: "<%= stash_datacite.affiliations_autocomplete_path %>",
-		     dataType: "json",
-		     data: {
-			 term: request.term
-		     },
-		     success: function (data) {
-			 response($.map(data, function (item) {
-			     return {
-				 value: item.long_name,
-				 id: item.id
-			     }
-			 }));
-		     }
-		 });
-             },
-             minLength: 1,
-             focus: function () {
-		 // prevent value inserted on focus
-		 return false;
-             },
-             select: function (event, ui) {
-		 $('<%= "##{form_id}" %> #author_affiliation_ror_id').val(ui.item.id); // set hidden field ror_id
-		 $('<%= "##{form_id}" %> #author_affiliation_id').val(''); // clear the hidden field id for the affiliation object
-		 var form = $(this).parents('form');
-		 $(form).trigger('submit.rails');
-		 var savedval = $('<%= "##{form_id}" %> #author_affiliation_ror_id').val();
-             },
-             open: function (event, ui) {
-             },
-             close: function (event, ui) {
-		 $(this).focus();
-             },
-	     change: function( event, ui ) {
-	     }
-	 }).blur(function (event) {
-	     var form = $(this).parents('form');
-	     $(form).trigger('submit.rails');
-	 });
- });
- */
+			itemMapper);
 </script>

--- a/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/_affiliation.html.erb
@@ -1,14 +1,24 @@
-<% my_suffix = field_suffix(author) %>
+<% my_suffix = field_suffix(author)
+	 my_txt = "instit_affil_#{my_suffix}"
+	 my_id = "instit_id_#{my_suffix}"
+%>
 
 <%= form.fields_for :affiliation, author.affiliation do |affil_fields| %>
-		<label class="c-input__label required" for="instit_affil_<%= my_suffix %>">Institutional Affiliation</label>
-    <%= affil_fields.text_field(:long_name, id: "instit_affil_#{my_suffix}", class: 'c-input__text js-affiliation') %>
-    <%= affil_fields.hidden_field :id %>
-    <%= affil_fields.hidden_field :ror_id, class: 'js-affiliation_id' %>
+		<label class="c-input__label required" for="<%= my_txt %>">Institutional Affiliation</label>
+    <%= affil_fields.text_field(:long_name, id: my_txt, class: 'c-input__text js-affiliation') %>
+    <%= affil_fields.hidden_field :ror_id, id: my_id, class: 'js-affiliation_id' %>
 <% end %>
 
 <script type="text/javascript">
 
+	// txtFieldId, idFieldId, autoURL, txtKey, idKey
+	setupAutocomplete('<%= my_txt %>',
+			'<%= my_id %>',
+			"<%= stash_datacite.affiliations_autocomplete_path %>",
+			null,
+			null);
+
+	/*
  $(function () {
      $('<%= "##{form_id}" %> .js-affiliation')
      // don't navigate away from the field on tab when selecting an item
@@ -61,4 +71,5 @@
 	     $(form).trigger('submit.rails');
 	 });
  });
+ */
 </script>

--- a/stash/stash_datacite/app/views/stash_datacite/authors/create.js.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/authors/create.js.erb
@@ -4,7 +4,6 @@ var form = $('#<%= params[:form_id] %>');
 form.attr('id', '<%= form_id %>');
 form.attr('action', '<%= authors_update_path %>');
 form.find("#author_id").attr('value', '<%= @author.id %>');
-form.find("#author_affiliation_id").attr('value', '<%= @author.affiliations.first&.id %>');
 form.find("#form_id").attr('value', '<%= form_id %>');
 
 $('<input>').attr({
@@ -13,4 +12,4 @@ $('<input>').attr({
   value: 'patch'
 }).appendTo(form);
 hideRemoveLinkAuthors();
-hideRemoveRequiredLabelAuthors()
+hideRemoveRequiredLabelAuthors();

--- a/stash/stash_datacite/app/views/stash_datacite/contributors/_facility_form.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/contributors/_facility_form.html.erb
@@ -18,61 +18,14 @@
 <% end %>
 
 <script type="text/javascript">
+   const itemMapper = (item) => {
+      return {id: item.id, value: item.long_name};
+   }
 
-   $(function () {
-      $('#contributor_facility_form .js-facility')
-          // don't navigate away from the field on tab when selecting an item
-          .bind( "keydown", function( event ) {
-             if ( event.keyCode === $.ui.keyCode.TAB &&
-                 $( this ).autocomplete( "instance" ).menu.active ) {
-                event.preventDefault();
-             }
-             if (event.keyCode > 45 || event.keyCode === 8) {
-                // reset identifier id in there if they type some meaningful stuff in there
-                $('#contributor_facility_form #facility_name_identifier_id').val('');
-             }
-          })
-          .autocomplete({
-             source: function (request, response) {
-                $.ajax({
-                   url: "<%= stash_datacite.affiliations_autocomplete_path %>",
-                   dataType: "json",
-                   data: {
-                      term: request.term
-                   },
-                   success: function (data) {
-                      response($.map(data, function (item) {
-                         return {
-                            value: item.long_name,
-                            id: item.id
-                         }
-                      }));
-                   }
-                });
-             },
-             minLength: 2 ,
-             focus: function () {
-                // prevent value inserted on focus
-                return false;
-             },
-             select: function (event, ui) {
-                $('#contributor_facility_form #facility_name_identifier_id').val(ui.item.id); // set hidden field ror_id
-                $('#contributor_research_facility').val(ui.item.value); // set the correctly selected name in list
-                var form = $(this).parents('form');
-                $(form).trigger('submit.rails');
-             },
-             open: function (event, ui) {
-             },
-             close: function (event, ui) {
-                $(this).focus();
-             },
-             change: function( event, ui ) {
-             }
-             // end of autocomplete below
-          }).blur(function (event) {
-            var form = $(this).parents('form');
-            $(form).trigger('submit.rails');
-      });
-   });
+   // txtFieldId, idFieldId, autoURL, resultMapper
+   setupAutocomplete('contributor_research_facility',
+       'facility_name_identifier_id',
+       "<%= stash_datacite.affiliations_autocomplete_path %>",
+       itemMapper);
 </script>
 


### PR DESCRIPTION
This makes a function that will attach autocomplete and fill in a hidden id when things are selected.

I added this for author affiliations and the research facility.

We can look into other places it might be useful later.  I'm unwilling to do any more of this right now and I've already worked a 10 hour day without lunch, or going outside or getting away from a screen.  If people need things done for a shorter sprint (since I'm out next week) they will need to plan accordingly.