### PR TITLE
Update to diff from the latest curated version

### DIFF
--- a/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
@@ -1,7 +1,7 @@
 <h1 class="o-heading__level1">Finalize Submission</h1>
 
     <!-- If a curator is viewing this page, highlight the changed fields -->
-    <% highlight_fields = current_user.curator? ? @resource.changed_from_previous : [] %>
+    <% highlight_fields = current_user.curator? ? @resource.changed_from_previous_curated : [] %>
 
     <%= render partial: "stash_datacite/resources/missing_mandatory_data", locals: { data: @data } %>
     <h2 class="o-heading__page-span">Review Description</h2>
@@ -62,7 +62,14 @@
     <h3 class="o-heading__level2">Data Files Hosted by Dryad</h3>
 
     <div class="c-review-files">
-        <%= render partial: "stash_engine/data_files/show_merritt", locals: { resource: @resource, highlight: highlight_fields.include?('data_files') } %>
+	<% if highlight_fields.include?('data_files') %>
+            <%= render partial: "stash_engine/data_files/show_merritt",
+		       locals: { resource: @resource,
+			   highlight_files: @resource.files_changed_since(other_resource: @resource.previous_curated_resource,
+									  association: 'data_files') } %>
+	<% else %>
+	    <%= render partial: "stash_engine/data_files/show_merritt", locals: { resource: @resource, highlight_files: [] } %>
+	<% end %>
         <%= link_to 'Edit Files', stash_engine.upload_resource_path(@resource),
                   class: 'c-review-files-button o-button__icon-left', role: 'button' %>
     </div>
@@ -73,10 +80,17 @@
 
     <% if @review.software_files.count.positive? %>
     <h3 class="o-heading__level2">Software Files Hosted by <a href="https://zenodo.org" target="_blank">Zenodo</a></h3>
-
-      <div class="c-review-files">
+	<div class="c-review-files">
+    	  <% if highlight_fields.include?('software_files') %>
+            <%= render partial: "stash_engine/data_files/show_zenodo",
+		       locals: { resource: @resource,
+			   zenodo_type: 'software',
+			   highlight_files: @resource.files_changed_since(other_resource: @resource.previous_curated_resource,
+									  association: 'software_files') } %>
+	<% else %>
           <%= render partial: "stash_engine/data_files/show_zenodo",
-		     locals: { resource: @resource, zenodo_type: 'software', highlight: highlight_fields.include?('software_files') } %>
+		     locals: { resource: @resource, zenodo_type: 'software', highlight_files: [] } %>
+	<% end %>
       </div>
     <% end %>
 
@@ -84,8 +98,16 @@
       <h3 class="o-heading__level2">Supplemental Files Hosted by <a href="https://zenodo.org" target="_blank">Zenodo</a></h3>
 
       <div class="c-review-files">
+    	  <% if highlight_fields.include?('supp_files') %>
+            <%= render partial: "stash_engine/data_files/show_zenodo",
+		       locals: { resource: @resource,
+			   zenodo_type: 'supp',
+			   highlight_files: @resource.files_changed_since(other_resource: @resource.previous_curated_resource,
+									  association: 'supp_files') } %>
+	<% else %>
           <%= render partial: "stash_engine/data_files/show_zenodo",
-		     locals: { resource: @resource, zenodo_type: 'supp', highlight: highlight_fields.include?('supp_files') } %>
+		     locals: { resource: @resource, zenodo_type: 'supp', highlight_files: [] } %>
+	<% end %>
       </div>
     <% end %>
 

--- a/stash/stash_engine/app/views/stash_engine/data_files/_show_merritt.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/data_files/_show_merritt.html.erb
@@ -1,9 +1,9 @@
 <%# the resource is passed in. Only link previously submitted files. %>
 <ul class="c-review-files__list">
-<% uploaded = resource.previous_resource&.submitted? %>
+    <% uploaded = resource.previous_resource&.submitted? %>
 
     <% resource.data_files.each do |fu| %>
-	<div class="<%= 'strike-deleted' if fu.file_state == 'deleted' %> <%= 'highlight' if (highlight && %w[created deleted].include?(fu.file_state)) %>">
+	<div class="<%= 'strike-deleted' if fu.file_state == 'deleted' %>">
 	    <li>
 		<% if fu.file_state == 'copied' && uploaded %>
 		    <%= link_to fu.upload_file_name, stash_url_helpers.download_stream_path(file_id: fu.last_version_file&.id), target: '_blank' %>
@@ -17,5 +17,21 @@
 		<% end %>
 	    </li>
 	</div>
+    <% end %>
+
+    <%# If curator, show all changed files from prev versionse %>
+    <% if current_user.curator? && highlight_files.present? %>
+	<li class="highlight">Changed since previous curated version</li>
+	<% highlight_files.each do |fu| %>
+	    <div class="<%= 'strike-deleted' if fu.file_state == 'deleted' %> highlight">
+		<li>
+		    <%= fu.upload_file_name %>
+		    &nbsp;&nbsp;&nbsp;<%= filesize(fu.upload_file_size) %>		    
+		    <% if fu.file_state == 'created' %>
+			&nbsp;&nbsp;&nbsp;<small>new</small>
+		    <% end %>
+		</li>
+	    </div>
+	<% end %>	
     <% end %>
 </ul>

--- a/stash/stash_engine/app/views/stash_engine/data_files/_show_merritt.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/data_files/_show_merritt.html.erb
@@ -21,7 +21,7 @@
 
     <%# If curator, show all changed files from prev versionse %>
     <% if current_user.curator? && highlight_files.present? %>
-	<li class="highlight">Changed since previous curated version</li>
+	<li class="highlight"><b>=== Changed since previous curated version ===</b></li>
 	<% highlight_files.each do |fu| %>
 	    <div class="<%= 'strike-deleted' if fu.file_state == 'deleted' %> highlight">
 		<li>

--- a/stash/stash_engine/app/views/stash_engine/data_files/_show_zenodo.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/data_files/_show_zenodo.html.erb
@@ -21,7 +21,7 @@
 
 <%# If curator, show all changed files from prev versionse %>
 <% if current_user.curator? && highlight_files.present? %>
-    <li class="highlight">Changed since previous curated version</li>
+    <li class="highlight"><b>=== Changed since previous curated version ===</b></li>
     <% highlight_files.each do |fu| %>
 	<div class="<%= 'strike-deleted' if fu.file_state == 'deleted' %> highlight">
 	    <li>

--- a/stash/stash_engine/app/views/stash_engine/data_files/_show_zenodo.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/data_files/_show_zenodo.html.erb
@@ -3,7 +3,7 @@
 <% uploaded = resource.previous_resource&.zenodo_submitted?(type: zenodo_type) %>
 
 <% resource.send("#{zenodo_type}_files").each do |fu| %>
-  <div class="<%= 'strike-deleted' if fu.file_state == 'deleted' %> <%= 'highlight' if (highlight && %w[created deleted].include?(fu.file_state)) %>">
+  <div class="<%= 'strike-deleted' if fu.file_state == 'deleted' %>">
     <li>
       <% if fu.file_state == 'copied' && uploaded %>
         <%= link_to fu.upload_file_name, stash_url_helpers.download_zenodo_path(file_id: fu.last_version_file&.id), target: '_blank' %>
@@ -18,4 +18,21 @@
     </li>
   </div>
 <% end %>
+
+<%# If curator, show all changed files from prev versionse %>
+<% if current_user.curator? && highlight_files.present? %>
+    <li class="highlight">Changed since previous curated version</li>
+    <% highlight_files.each do |fu| %>
+	<div class="<%= 'strike-deleted' if fu.file_state == 'deleted' %> highlight">
+	    <li>
+		<%= fu.upload_file_name %>
+		&nbsp;&nbsp;&nbsp;<%= filesize(fu.upload_file_size) %>		    
+		<% if fu.file_state == 'created' %>
+		    &nbsp;&nbsp;&nbsp;<small>new</small>
+		<% end %>
+	    </li>
+	</div>
+    <% end %>
+<% end %>
 </ul>
+


### PR DESCRIPTION
This is an update to https://github.com/CDL-Dryad/dryad-app/pull/708

The previous PR only highlighted changes between the current version and the immediately preceding version. This does not work well with normal curation practices. In the normal practice, a user will submit a version (e.g., version 3), and the curator will hit the "Edit" button to review the metadata. When the "Edit" button is pressed, a new version is created (4), which is exactly the same, so it is useless to display differences between version 3 and 4. What we really want is the difference between the current version (4) and the previously curated version (2).