### PR TITLE
Make `end_with?` safe

### DIFF
--- a/lib/tasks/dev_ops/passenger.rb
+++ b/lib/tasks/dev_ops/passenger.rb
@@ -28,8 +28,8 @@ module DevOps
         matches = section.match(/^(\d+).+Memory *: *(\S+)/m)
         pid = matches[1]
         memory = 0
-        memory = matches[2].to_i if matches[2].end_with?('M')
-        memory = matches[2].to_i * 1000 if matches[2].end_with?('G')
+        memory = matches[2].to_i if matches[2]&.end_with?('M')
+        memory = matches[2].to_i * 1000 if matches[2]&.end_with?('G')
         @bloated_pids.push(pid) if memory > BLOATED_MB
       end
       @bloated_pids

--- a/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -213,7 +213,7 @@ module StashDatacite
     # Check whether the journal name ends with an asterisk that can be removed, because the journal name
     # exactly matches a name we have in the database
     def fix_removable_asterisk
-      return unless @pub_name.end_with?('*')
+      return unless @pub_name&.end_with?('*')
 
       journal = StashEngine::Journal.find_by_title(@pub_name)
       return unless journal.present?

--- a/stash/stash_datacite/app/models/stash_datacite/affiliation.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/affiliation.rb
@@ -20,7 +20,7 @@ module StashDatacite
       return '' if short_name.blank? && long_name.blank?
 
       chosen_name = (short_name.blank? ? long_name.strip : short_name.strip)
-      if chosen_name.end_with?('*') && !show_asterisk
+      if chosen_name&.end_with?('*') && !show_asterisk
         chosen_name[0..-2]
       else
         chosen_name

--- a/stash/stash_datacite/app/models/stash_datacite/contributor.rb
+++ b/stash/stash_datacite/app/models/stash_datacite/contributor.rb
@@ -55,7 +55,7 @@ module StashDatacite
     end
 
     def contributor_name_friendly(show_asterisk: false)
-      if contributor_name.end_with?('*') && !show_asterisk
+      if contributor_name&.end_with?('*') && !show_asterisk
         contributor_name[0..-2]
       else
         contributor_name

--- a/stash/stash_engine/app/models/stash_engine/journal.rb
+++ b/stash/stash_engine/app/models/stash_engine/journal.rb
@@ -15,7 +15,7 @@ module StashEngine
     def self.find_by_title(title)
       return unless title.present?
 
-      title = title.chop if title.end_with?('*')
+      title = title.chop if title&.end_with?('*')
       journal = StashEngine::Journal.where(title: title).first
 
       unless journal.present?

--- a/stash/stash_engine/app/views/stash_engine/resources/upload_manifest.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/resources/upload_manifest.html.erb
@@ -20,7 +20,7 @@
 </div>
 
 <div class="o-dataset-nav">
-  <% if params[:controller].end_with?('resources') && params[:action].include?('upload') %>
+  <% if params[:controller]&.end_with?('resources') && params[:action].include?('upload') %>
     <!-- standard upload page -->
     <%= link_to 'Back to Describe Dataset', metadata_entry_pages_find_or_create_path(resource_id: params[:id]), class: 'o-button__icon-left', role: 'button', id: 'describe_back' %>
 

--- a/stash/stash_engine/app/views/stash_engine/shared/_dataset_steps_nav.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/shared/_dataset_steps_nav.html.erb
@@ -1,16 +1,16 @@
 <div class="c-progress">
   <%= link_to 'Describe Dataset', {controller: 'metadata_entry_pages', action: 'find_or_create', resource_id: @resource.id},
-              class: "c-progress__tab1#{ (params[:controller].end_with?('metadata_entry_pages') && params[:action] == 'find_or_create' ? '--active' : '' )} js-nav-out" %>
+              class: "c-progress__tab1#{ (params[:controller]&.end_with?('metadata_entry_pages') && params[:action] == 'find_or_create' ? '--active' : '' )} js-nav-out" %>
 
   <%= link_to 'Upload Files', stash_engine.upload_resource_path(@resource.id),
-                    class: "c-progress__tab2#{ (params[:controller].end_with?('resources') && params[:action].include?('upload') ? '--active' : '') } js-nav-out" %>
+                    class: "c-progress__tab2#{ (params[:controller]&.end_with?('resources') && params[:action].include?('upload') ? '--active' : '') } js-nav-out" %>
 
 <!--  <%= link_to 'Upload Data', stash_engine.upload_resource_path(@resource.id),
-            class: "c-progress__tab2#{ (params[:controller].end_with?('resources') && params[:action].include?('upload') ? '--active' : '') } js-nav-out" %> -->
+            class: "c-progress__tab2#{ (params[:controller]&.end_with?('resources') && params[:action].include?('upload') ? '--active' : '') } js-nav-out" %> -->
 
 <!--  <%= link_to 'Upload Software', stash_engine.up_code_resource_path(@resource.id),
-            class: "c-progress__tab2#{ (params[:controller].end_with?('resources') && params[:action].include?('up_') ? '--active' : '') } js-nav-out" %> -->
+            class: "c-progress__tab2#{ (params[:controller]&.end_with?('resources') && params[:action].include?('up_') ? '--active' : '') } js-nav-out" %> -->
 
   <%= link_to 'Review and Submit', stash_engine.review_resource_path(@resource.id),
-            class: "c-progress__tab3#{ (params[:controller].end_with?('resources') && params[:action] == 'review' ? '--active' : '') } js-nav-out" %>
+            class: "c-progress__tab3#{ (params[:controller]&.end_with?('resources') && params[:action] == 'review' ? '--active' : '') } js-nav-out" %>
 </div>

--- a/stash/stash_engine/lib/stash/zenodo_software/copier.rb
+++ b/stash/stash_engine/lib/stash/zenodo_software/copier.rb
@@ -109,7 +109,7 @@ module Stash
         # make sure the dataset has the relationships for these things synchronized to zenodo
         StashDatacite::RelatedIdentifier.set_latest_zenodo_relations(resource: @resource)
 
-        return publish_dataset if @copy.copy_type.end_with?('_publish')
+        return publish_dataset if @copy.copy_type&.end_with?('_publish')
 
         return metadata_only_update unless files_changed?
 


### PR DESCRIPTION
We have been receiving some email errors relating to use of `end_with?` on a nil object. Unfortunately, there is javascript involved, making it difficult to get an exact stack trace to determine which `end_with?` is causing the problem. So I found every instance of `end_with?` in the code and made them robust to nil objects.