### PR TITLE
Add FOS keywords to API

### DIFF
--- a/documentation/apis/sample_dataset.json
+++ b/documentation/apis/sample_dataset.json
@@ -40,6 +40,7 @@
 	"Noodlecast",
 	"Intercropping"
     ],
+    "fieldOfScience": "Animal and dairy science",
     "locations": [ 
 	{
 	    "place": "Grogan's Mill, USA",

--- a/spec/fixtures/stash_api/metadata.rb
+++ b/spec/fixtures/stash_api/metadata.rb
@@ -152,6 +152,10 @@ module Fixtures
         )
       end
 
+      def add_keywords(number: 3)
+        @metadata[:keywords] = Faker::Lorem.words(number: number)
+      end
+
     end
   end
 end

--- a/spec/requests/stash_api/datasets_controller_spec.rb
+++ b/spec/requests/stash_api/datasets_controller_spec.rb
@@ -71,7 +71,30 @@ module StashApi
         expect(ret_fund[:identifier]).to eq(funder[:identifier])
         expect(ret_fund[:identifierType]).to eq(funder[:identifierType])
       end
-      it 'creates a new dataset with a userId explicitly set by superuser)' do
+
+      it 'creates a new dataset with specified keywords' do
+        @meta.add_keywords(number: 3)
+        response_code = post '/api/v2/datasets', params: @meta.json, headers: default_authenticated_headers
+        output = response_body_hash
+        expect(response_code).to eq(201)
+        expect(output[:keywords]).to be
+        expect(output[:keywords].size).to eq(3)
+        expect(output[:keywords].first).to eq(@meta.hash[:keywords].first)
+        expect(output[:keywords].second).to eq(@meta.hash[:keywords].second)
+        expect(output[:keywords].third).to eq(@meta.hash[:keywords].third)
+      end
+
+      it 'creates a new dataset with specified field of science' do
+        fos = Faker::Science.science(:natural)
+        StashDatacite::Subject.create(subject: fos, subject_scheme: 'fos') # the fos field must exist in the database to be recognized
+        @meta.add_field(field_name: 'fieldOfScience', value: fos)
+        response_code = post '/api/v2/datasets', params: @meta.json, headers: default_authenticated_headers
+        output = response_body_hash
+        expect(response_code).to eq(201)
+        expect(output[:fieldOfScience]).to eq(fos)
+      end
+
+      it 'creates a new dataset with a userId explicitly set by superuser' do
         test_user = StashEngine::User.create(first_name: Faker::Name.first_name,
                                              last_name: Faker::Name.last_name,
                                              email: Faker::Internet.email)

--- a/stash/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser.rb
@@ -4,7 +4,7 @@ module StashApi
 
     include Stash::Organization
 
-    TO_PARSE = %w[Funders Methods UsageNotes Keywords RelatedWorks Locations TemporalCoverages].freeze
+    TO_PARSE = %w[Funders Methods UsageNotes Keywords FieldOfScience RelatedWorks Locations TemporalCoverages].freeze
     INTERNAL_DATA_FIELDS = %w[publicationISSN publicationName manuscriptNumber].freeze
 
     # If  id_string is set, then populate the desired (doi) into the identifier in format like doi:xxxxx/yyyyy for new dataset.

--- a/stash/stash_api/app/models/stash_api/dataset_parser/field_of_science.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser/field_of_science.rb
@@ -1,0 +1,26 @@
+module StashApi
+  class DatasetParser
+    class FieldOfScience < StashApi::DatasetParser::BaseParser
+
+      # looks like this
+      # "fieldOfScience": "Animal and dairy science"
+
+      def parse
+        return if @hash['fieldOfScience'].blank?
+
+        clear_fos
+
+        fos = StashDatacite::Subject.where(subject: @hash['fieldOfScience'], subject_scheme: 'fos')
+        # Only use the fos if it matches a pre-existing fos keyword; don't create a new one
+        @resource.subjects << fos.first unless fos.blank?
+      end
+
+      private
+
+      def clear_fos
+        @resource.subjects.delete(@resource.subjects.fos)
+      end
+
+    end
+  end
+end

--- a/stash/stash_api/app/models/stash_api/dataset_parser/keywords.rb
+++ b/stash/stash_api/app/models/stash_api/dataset_parser/keywords.rb
@@ -12,8 +12,9 @@ module StashApi
       # ]
 
       def parse
-        clear
         return if @hash['keywords'].blank?
+
+        clear
 
         @hash['keywords'].each do |kw|
           next if kw.blank?
@@ -25,7 +26,7 @@ module StashApi
       private
 
       def clear
-        @resource.subjects.clear
+        @resource.subjects.delete(@resource.subjects.non_fos)
       end
 
       def find_or_create_subject(keyword:)

--- a/stash/stash_api/app/models/stash_api/version/metadata.rb
+++ b/stash/stash_api/app/models/stash_api/version/metadata.rb
@@ -17,6 +17,7 @@ module StashApi
           abstract: Abstract.new(resource: @resource).value,
           funders: Funders.new(resource: @resource).value,
           keywords: Keywords.new(resource: @resource).value,
+          fieldOfScience: @resource.subjects.fos.first&.subject,
           methods: Methods.new(resource: @resource).value,
           usageNotes: UsageNotes.new(resource: @resource).value,
           locations: Locations.new(resource: @resource).value,


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1534

Update API to include the Field of Science keywords. Only one FOS is allowed per dataset, and it is treated separately from the other keywords. Also, API users can only use the FOS values that are already present in Dryad; they may not add new ones.