### PR TITLE
Prevents problems if the identifier_id isn't filled in correctly in zenodo_copies table

### DIFF
--- a/stash/stash_engine/app/views/stash_engine/zenodo_queue/_status_table.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/zenodo_queue/_status_table.html.erb
@@ -33,7 +33,11 @@
   <% @zenodo_copies.each do |zc| %>
     <tr class="c-lined-table__row">
       <td><%= link_to(zc.id, zenodo_queue_item_details_path(zc.id)) %></td>
-      <td><%= link_to(zc.identifier_id, zenodo_queue_identifier_details_path(zc.identifier_id)) %></td>
+      <td>
+        <% unless zc.identifier_id.blank? %>
+          <%= link_to(zc.identifier_id, zenodo_queue_identifier_details_path(zc.identifier_id)) %>
+        <% end %>
+      </td>
       <td><%= zc.resource_id %></td>
       <td><%= zc.state %></td>
       <td><%= formatted_datetime(zc.updated_at) %></td>


### PR DESCRIPTION
Did this on accident while trying to fix an error.  Then it gave "wicked_pdf" errors which masked the real error when I would go to that page.  Kind of frustrating to track down and troubleshoot with wicked_pdf hijacking error messages.

Easy to fix, but annoying to find.