### PR TITLE
Curation workflow updates

### DIFF
--- a/documentation/technical_notes/curation_workflow.md
+++ b/documentation/technical_notes/curation_workflow.md
@@ -1,0 +1,36 @@
+
+Curation Workflow
+==================
+
+Dryad attempts to assist curators with their work while retaining as much
+flexibility as possible.
+
+
+Automatic assignment process
+----------------------------
+
+When a version of dataset a dataset is submitted, it is most efficient if it is
+worked on by the same curator that worked on previous versions. Dryad will
+attempt to automatically assign the previous curator.
+
+If the previous curator is no longer with Dryad, a backup curator will be
+assigned. This is the curator who has been with Dryad the longest, but who is
+not a superuser, since superusers typically have many non-curation duties.
+
+
+Automatic status changes
+------------------------
+
+Dryad attempts to set the status of a newly-submitted dataset based on its
+history. The primary goal is that while a dataset is being actively curated, it
+will be in "curation" status. A submitted version that the curator wasn't
+expecting (e.g., author updates a dataset post-publication) results in
+"submitted" status, so the curator can pick it up when they have time.
+
+Workflow sequences and their resultant status:
+- author submits, then updates themselves.... --> submitted
+- author submits, curator edits --> curation 
+- author submits, curator publishes, author resubmits --> submitted w/ curator assigned
+- author submits, curator publishes, author resubmits, curator edits --> curation 
+- author submits, curator returns aar, author edits --> curation 
+- author submits, curator returns aar, author edits, curator edits --> curation 

--- a/documentation/technical_notes/curation_workflow.md
+++ b/documentation/technical_notes/curation_workflow.md
@@ -27,6 +27,10 @@ will be in "curation" status. A submitted version that the curator wasn't
 expecting (e.g., author updates a dataset post-publication) results in
 "submitted" status, so the curator can pick it up when they have time.
 
+Major rules:
+- If it has been in curation since the last published version, return it to curation
+- If it has not been in curation since the last published version, leave it as submitted 
+
 Workflow sequences and their resultant status:
 - author submits, then updates themselves.... --> submitted
 - author submits, curator edits --> curation 

--- a/spec/features/stash_datacite/dataset_versioning_spec.rb
+++ b/spec/features/stash_datacite/dataset_versioning_spec.rb
@@ -323,44 +323,12 @@ RSpec.feature 'DatasetVersioning', type: :feature do
         expect(@resource.current_editor_id).to eql(@curator.id)
       end
 
-      context :published_or_embargoed do
+      context :curator_workflow do
 
         before(:each) do
           ActionMailer::Base.deliveries = []
           mock_datacite!
           mock_stripe!
-        end
-
-        it "has a curation status of 'curation' when prior version was :embargoed", js: true do
-          create(:curation_activity, user_id: @curator.id, resource_id: @resource.id, status: 'embargoed')
-          @resource.reload
-
-          sign_in(@author)
-          click_link 'My Datasets'
-          within(:css, '#user_submitted') do
-            click_button 'Update'
-          end
-          update_dataset
-          @resource.reload
-
-          expect(@resource.current_curation_status).to eql('curation')
-          expect(@resource.current_editor_id).to eql(@curator.id)
-        end
-
-        it "has a curation status of 'curation' when prior version was :published", js: true do
-          create(:curation_activity, user_id: @curator.id, resource_id: @resource.id, status: 'published')
-          @resource.reload
-
-          sign_in(@author)
-          click_link 'My Datasets'
-          within(:css, '#user_submitted') do
-            click_button 'Update'
-          end
-          update_dataset
-          @resource.reload
-
-          expect(@resource.current_curation_status).to eql('curation')
-          expect(@resource.current_editor_id).to eql(@curator.id)
         end
 
         it 'has a backup curator when the previous curator is no longer available', js: true do
@@ -379,7 +347,7 @@ RSpec.feature 'DatasetVersioning', type: :feature do
           update_dataset
           @resource.reload
 
-          expect(@resource.current_curation_status).to eql('curation')
+          expect(@resource.current_curation_status).to eql('submitted')
           expect(@resource.current_editor_id).to eql(curator2.id)
         end
 

--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -167,9 +167,9 @@ RSpec.feature 'Admin', type: :feature do
           expect(page).not_to have_text(@curator.name_last_first)
         end
         @resource.reload
-        
+
         expect(@resource.current_editor_id).to eq(nil)
-        expect(@resource.current_curation_status).to eq('peer_review')        
+        expect(@resource.current_curation_status).to eq('peer_review')
       end
 
       it 'allows un-assigning a curator, changing status if it is curation', js: true do
@@ -191,12 +191,12 @@ RSpec.feature 'Admin', type: :feature do
         click_button('Submit')
         within(:css, '.c-lined-table__row', wait: 10) do
           expect(page).not_to have_text(@curator.name_last_first)
-        end        
+        end
         @resource.reload
 
         puts "XXX res status: #{@resource.current_curation_status}"
         expect(@resource.current_editor_id).to eq(nil)
-        expect(@resource.current_curation_status).to eq('submitted')        
+        expect(@resource.current_curation_status).to eq('submitted')
       end
 
       # Skipping this test that fails intermittently, for a feature we're not actually using

--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -149,7 +149,7 @@ RSpec.feature 'Admin', type: :feature do
       it 'allows un-assigning a curator, keeping status if it is peer_review', js: true do
         @curator = create(:user, role: 'superuser', tenant_id: 'dryad')
         puts "XXX res status: #{@resource.current_curation_status}"
-        ca = create(:curation_activity, resource: @resource, status: 'peer_review', note: 'forcing to peer_review')
+        create(:curation_activity, resource: @resource, status: 'peer_review', note: 'forcing to peer_review')
         @resource.reload
         puts "XXX res status: #{@resource.current_curation_status}"
 
@@ -175,7 +175,7 @@ RSpec.feature 'Admin', type: :feature do
       it 'allows un-assigning a curator, changing status if it is curation', js: true do
         @curator = create(:user, role: 'superuser', tenant_id: 'dryad')
         puts "XXX res status: #{@resource.current_curation_status}"
-        ca = create(:curation_activity, resource: @resource, status: 'curation', note: 'forcing to curation')
+        create(:curation_activity, resource: @resource, status: 'curation', note: 'forcing to curation')
         @resource.reload
         puts "XXX res status: #{@resource.current_curation_status}"
 

--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -148,10 +148,8 @@ RSpec.feature 'Admin', type: :feature do
 
       it 'allows un-assigning a curator, keeping status if it is peer_review', js: true do
         @curator = create(:user, role: 'superuser', tenant_id: 'dryad')
-        puts "XXX res status: #{@resource.current_curation_status}"
         create(:curation_activity, resource: @resource, status: 'peer_review', note: 'forcing to peer_review')
         @resource.reload
-        puts "XXX res status: #{@resource.current_curation_status}"
 
         visit stash_url_helpers.ds_admin_path
 
@@ -174,10 +172,8 @@ RSpec.feature 'Admin', type: :feature do
 
       it 'allows un-assigning a curator, changing status if it is curation', js: true do
         @curator = create(:user, role: 'superuser', tenant_id: 'dryad')
-        puts "XXX res status: #{@resource.current_curation_status}"
         create(:curation_activity, resource: @resource, status: 'curation', note: 'forcing to curation')
         @resource.reload
-        puts "XXX res status: #{@resource.current_curation_status}"
 
         visit stash_url_helpers.ds_admin_path
 
@@ -194,7 +190,6 @@ RSpec.feature 'Admin', type: :feature do
         end
         @resource.reload
 
-        puts "XXX res status: #{@resource.current_curation_status}"
         expect(@resource.current_editor_id).to eq(nil)
         expect(@resource.current_curation_status).to eq('submitted')
       end

--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -146,8 +146,12 @@ RSpec.feature 'Admin', type: :feature do
 
       end
 
-      it 'allows un-assigning a curator', js: true do
+      it 'allows un-assigning a curator, keeping status if it is peer_review', js: true do
         @curator = create(:user, role: 'superuser', tenant_id: 'dryad')
+        puts "XXX res status: #{@resource.current_curation_status}"
+        ca = create(:curation_activity, resource: @resource, status: 'peer_review', note: 'forcing to peer_review')
+        @resource.reload
+        puts "XXX res status: #{@resource.current_curation_status}"
 
         visit stash_url_helpers.ds_admin_path
 
@@ -156,11 +160,43 @@ RSpec.feature 'Admin', type: :feature do
         find('button[title="Update curator"]').click
         find("#resource_current_editor_id option[value='#{@curator.id}']").select_option
         click_button('Submit')
-
+        find('button[title="Update curator"]').click
+        find("#resource_current_editor_id option[value='0']").select_option
+        click_button('Submit')
         within(:css, '.c-lined-table__row', wait: 10) do
           expect(page).not_to have_text(@curator.name_last_first)
         end
+        @resource.reload
+        
+        expect(@resource.current_editor_id).to eq(nil)
+        expect(@resource.current_curation_status).to eq('peer_review')        
+      end
 
+      it 'allows un-assigning a curator, changing status if it is curation', js: true do
+        @curator = create(:user, role: 'superuser', tenant_id: 'dryad')
+        puts "XXX res status: #{@resource.current_curation_status}"
+        ca = create(:curation_activity, resource: @resource, status: 'curation', note: 'forcing to curation')
+        @resource.reload
+        puts "XXX res status: #{@resource.current_curation_status}"
+
+        visit stash_url_helpers.ds_admin_path
+
+        expect(page).to have_text('Admin Dashboard')
+        expect(page).to have_css('button[title="Update curator"]')
+        find('button[title="Update curator"]').click
+        find("#resource_current_editor_id option[value='#{@curator.id}']").select_option
+        click_button('Submit')
+        find('button[title="Update curator"]').click
+        find("#resource_current_editor_id option[value='0']").select_option
+        click_button('Submit')
+        within(:css, '.c-lined-table__row', wait: 10) do
+          expect(page).not_to have_text(@curator.name_last_first)
+        end        
+        @resource.reload
+
+        puts "XXX res status: #{@resource.current_curation_status}"
+        expect(@resource.current_editor_id).to eq(nil)
+        expect(@resource.current_curation_status).to eq('submitted')        
       end
 
       # Skipping this test that fails intermittently, for a feature we're not actually using

--- a/spec/models/stash_engine/identifier_spec.rb
+++ b/spec/models/stash_engine/identifier_spec.rb
@@ -87,6 +87,28 @@ module StashEngine
         end
       end
 
+      describe '#most_recent_curator' do
+        it 'finds the most recent curator' do
+          user = create(:user, role: 'user')
+          cur1 = create(:user, role: 'curator')
+          cur2 = create(:user, role: 'curator')
+          @res3.update(current_editor_id: user.id)
+          @res2.update(current_editor_id: cur1.id)
+          @res1.update(current_editor_id: cur2.id)
+          @identifier.reload
+          expect(@identifier.most_recent_curator).to eq(cur1)
+        end
+
+        it 'returns nil when there is no curator' do
+          user = create(:user, role: 'user')
+          @res3.update(current_editor_id: user.id)
+          @res2.update(current_editor_id: user.id)
+          @res1.update(current_editor_id: user.id)
+          @identifier.reload
+          expect(@identifier.most_recent_curator).to be_nil
+        end
+      end
+
       describe '#in_progress_resource' do
         it 'returns the in-progress version' do
           ipv = @identifier.in_progress_resource

--- a/spec/models/stash_engine/identifier_spec.rb
+++ b/spec/models/stash_engine/identifier_spec.rb
@@ -186,6 +186,44 @@ module StashEngine
           end
         end
 
+        describe '#date_last_curated' do
+          it 'selects the correct date_last_curated' do
+            target_date = DateTime.new(2010, 2, 3).utc
+            @res1.curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: '2000-01-01')
+            @res1.curation_activities << CurationActivity.create(status: 'curation', user: @user, created_at: target_date)
+            @res2.curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: '2020-01-01')
+            @res3.curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: '2030-01-01')
+            expect(@identifier.date_last_curated).to eq(target_date)
+          end
+
+          it 'gives no date_last_curated for uncurated items' do
+            @res1.curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: '2000-01-01')
+            @res1.curation_activities << CurationActivity.create(status: 'peer_review', user: @user, created_at: '2010-01-01')
+            @res2.curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: '2020-01-01')
+            @res3.curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: '2030-01-01')
+            expect(@identifier.date_last_curated).to eq(nil)
+          end
+        end
+
+        describe '#date_last_published' do
+          it 'selects the correct date_last_published' do
+            target_date = DateTime.new(2010, 2, 3).utc
+            @res1.curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: '2000-01-01')
+            @res1.curation_activities << CurationActivity.create(status: 'published', user: @user, created_at: target_date)
+            @res2.curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: '2020-01-01')
+            @res3.curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: '2030-01-01')
+            expect(@identifier.date_last_published).to eq(target_date)
+          end
+
+          it 'gives no date_last_published for unpublished items' do
+            @res1.curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: '2000-01-01')
+            @res1.curation_activities << CurationActivity.create(status: 'peer_review', user: @user, created_at: '2010-01-01')
+            @res2.curation_activities << CurationActivity.create(status: 'curation', user: @user, created_at: '2020-01-01')
+            @res3.curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: '2030-01-01')
+            expect(@identifier.date_last_published).to eq(nil)
+          end
+        end
+
         describe '#latest_resource_with_public_metadata' do
 
           it 'finds the last published resource' do

--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -132,15 +132,12 @@ module StashEngine
           @resource = @identifier.resources.order(id: :desc).first # the last resource of all, even not submitted
           decipher_curation_activity
           editor_id = params[:resource][:current_editor][:id]
-          puts "XXXX changing curator #{@resource.current_editor_id}"
           if editor_id&.to_i == 0
             @resource.update(current_editor_id: nil)
-            puts "XXXXa changing curator #{@resource.current_editor_id}"
             editor_name = 'unassigned'
             @status = 'submitted' if @resource.current_curation_status == 'curation'
           else
             @resource.update(current_editor_id: editor_id)
-            puts "XXXXb changing curator #{@resource.current_editor_id}"
             editor_name = StashEngine::User.find(editor_id)&.name
           end
           @note = "Changing current editor to #{editor_name}. " + params[:resource][:curation_activity][:note]
@@ -150,7 +147,6 @@ module StashEngine
           @resource.reload
           # Refresh the page the same way we would for a change of curation activity
           @curation_row = StashEngine::AdminDatasets::CurationTableRow.where(params: {}, tenant: nil, identifier_id: @resource.identifier.id).first
-          puts "XXXXdone changing curator #{@resource.current_editor_id}"
           render :curation_activity_change
         end
       end

--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -132,22 +132,25 @@ module StashEngine
           @resource = @identifier.resources.order(id: :desc).first # the last resource of all, even not submitted
           decipher_curation_activity
           editor_id = params[:resource][:current_editor][:id]
+          puts "XXXX changing curator #{@resource.current_editor_id}"
           if editor_id&.to_i == 0
-            @resource.current_editor_id = nil
+            @resource.update(current_editor_id: nil)
+            puts "XXXXa changing curator #{@resource.current_editor_id}"
             editor_name = 'unassigned'
-            @status = 'submitted'
+            @status = 'submitted' if @resource.current_curation_status == 'curation'
           else
-            @resource.current_editor_id = editor_id
+            @resource.update(current_editor_id: editor_id)
+            puts "XXXXb changing curator #{@resource.current_editor_id}"
             editor_name = StashEngine::User.find(editor_id)&.name
           end
           @note = "Changing current editor to #{editor_name}. " + params[:resource][:curation_activity][:note]
           @resource.curation_activities << CurationActivity.create(user_id: current_user.id,
                                                                    status: @status,
                                                                    note: @note)
-          @resource.save
           @resource.reload
           # Refresh the page the same way we would for a change of curation activity
           @curation_row = StashEngine::AdminDatasets::CurationTableRow.where(params: {}, tenant: nil, identifier_id: @resource.identifier.id).first
+          puts "XXXXdone changing curator #{@resource.current_editor_id}"
           render :curation_activity_change
         end
       end

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -157,6 +157,16 @@ module StashEngine
       submitted.by_version.first
     end
 
+    def most_recent_curator
+      resources.reverse.each do |r|
+        next unless r.current_editor_id
+
+        user = StashEngine::User.find(r.current_editor_id)
+        return user if user.curator?
+      end
+      nil
+    end
+
     # @return Resource the current 'processing' resource
     def processing_resource
       processing = resources.processing

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -498,6 +498,7 @@ module StashEngine
       cas.each do |ca|
         return ca.created_at if ca.curation?
       end
+      nil
     end
 
     def date_last_published
@@ -505,6 +506,7 @@ module StashEngine
       cas.each do |ca|
         return ca.created_at if ca.published? || ca.embargoed?
       end
+      nil
     end
 
     # ------------------------------------------------------------

--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -476,7 +476,7 @@ module StashEngine
     # ------------------------------------------------------------
     # Calculated dates
 
-    # returns the date on which this identifier was approved for publication
+    # returns the date on which this identifier was initially approved for publication
     # (i.e., the date on which it entered the status 'published' or 'embargoed'
     def approval_date
       return nil unless %w[published embargoed].include?(pub_state)
@@ -491,6 +491,20 @@ module StashEngine
         end
       end
       found_approval_date
+    end
+
+    def date_last_curated
+      cas = resources.map(&:curation_activities).flatten.reverse
+      cas.each do |ca|
+        return ca.created_at if ca.curation?
+      end
+    end
+
+    def date_last_published
+      cas = resources.map(&:curation_activities).flatten.reverse
+      cas.each do |ca|
+        return ca.created_at if ca.published? || ca.embargoed?
+      end
     end
 
     # ------------------------------------------------------------

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -866,7 +866,7 @@ module StashEngine
         target_curator = StashEngine::User.where(role: 'curator').first
       end
 
-      update(current_editor_id: target_curator.id)
+      update(current_editor_id: target_curator.id) if target_curator
     end
   end
 end

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -410,12 +410,12 @@ module StashEngine
     # ------------------------------------------------------------
     # Calculated dates
 
-    # Date on which the user first submitted this dataset
+    # Date on which the user first submitted this resource
     def submitted_date
       curation_activities.order(:id).where("status = 'submitted' OR status = 'peer_review'")&.first&.created_at
     end
 
-    # Date on which the curators first received this dataset
+    # Date on which the curators first received this resource
     # (for peer_review datasets, the date at which it came out of peer_review)
     def curation_start_date
       curation_activities.order(:id).where("status = 'submitted' OR status = 'curation'")&.first&.created_at
@@ -807,10 +807,9 @@ module StashEngine
     private
 
     # -----------------------------------------------------------
-    # Handle the 'submitted' state (happens after successful Merritt submission)
+    # Handle the 'submitted' resource state (happens after successful Merritt submission)
     # rubocop:disable Metrics/AbcSize
     def prepare_for_curation
-      # gets last resource
       prior_version = identifier.resources.includes(:curation_activities).where.not(id: id).order(created_at: :desc).first if identifier.present?
 
       # try to assign credit for the action to the same person as the immediately previous activity,
@@ -819,8 +818,7 @@ module StashEngine
         .order(id: :desc).first
       attribution = (prior_cur_act.nil? ? (current_editor_id || user_id) : prior_cur_act.user_id)
 
-      # Determine which submission status to use, :submitted or :peer_review status (if this is the inital
-      # version and the journal needs it)
+      # Determine which submission status to use, :submitted or :peer_review status
       target_status = (hold_for_peer_review? ? 'peer_review' : 'submitted')
 
       # Generate the :submitted status
@@ -835,19 +833,27 @@ module StashEngine
                                                                     note: "System noticed possible duplicate dataset #{dup_id}")
       end
 
+      # if it's the first version, or the prior version was in the submitter's control, we're done
       return if prior_version.blank? || prior_version.current_curation_status.blank? || prior_version.current_editor_id.blank?
       return if %w[in_progress submitted].include?(prior_version.current_curation_status)
-      return unless identifier.resources.map(&:curation_activities).flatten.map(&:status).include?('curation')
+      return unless identifier.date_last_curated.present?
 
       # If we get here, the previous status was *not* controlled by the submitter,
-      # so set the item back to curation and assign it to the previous curator, with a fallback process
-      revert_status_to_curation(prior_curator_id: prior_version.current_editor_id)
+      # so assign it to the previous curator, with a fallback process
+      auto_assign_curator(prior_curator_id: prior_version.current_editor_id, target_status: target_status)
+
+      # If it has been in curation since the last published version, return it to curation
+      # If it has not been in curation since the last published version, leave it as submitted or peer_review
+      if identifier.date_last_curated > identifier.date_last_published
+        curation_activities << StashEngine::CurationActivity.create(user_id: 0, status: 'curation',
+                                                                    note: 'System set back to curation')
+      end
     end
     # rubocop:enable Metrics/AbcSize
 
-    def revert_status_to_curation(prior_curator_id:)
-      curation_activities << StashEngine::CurationActivity.create(user_id: 0, status: 'curation',
-                                                                  note: 'System set back to curation and assigned curator')
+    def auto_assign_curator(prior_curator_id:, target_status:)
+      curation_activities << StashEngine::CurationActivity.create(user_id: 0, status: target_status,
+                                                                  note: 'System auto-assigned curator')
 
       target_curator = StashEngine::User.find(prior_curator_id)
       if target_curator.nil? || !target_curator.curator?

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -833,16 +833,9 @@ module StashEngine
                                                                     note: "System noticed possible duplicate dataset #{dup_id}")
       end
 
-      puts 'xxx returns'
       # if it's the first version, or the prior version was in the submitter's control, we're done
       return if prior_version.blank? || prior_version.current_curation_status.blank?
-
-      puts 'xxx returns a'
-      #      return if %w[in_progress submitted].include?(prior_version.current_curation_status)
-      puts 'xxx returns b'
       return unless identifier.date_last_curated.present?
-
-      puts 'xxx returns c'
 
       # If we get here, the previous status was *not* controlled by the submitter,
       # meaning there was a curator
@@ -853,7 +846,6 @@ module StashEngine
       # OR it has been in curation more recently than the last published version,
       # OR the last user to edit it was the current_editor
       # return it to curation status
-      puts "xxxxx lca #{last_curation_activity.user_id} -- #{current_editor_id}"
       return unless identifier.date_last_published.blank? ||
                     identifier.date_last_curated > identifier.date_last_published ||
                     last_curation_activity.user_id == current_editor_id

--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -842,12 +842,12 @@ module StashEngine
       # so assign it to the previous curator, with a fallback process
       auto_assign_curator(prior_curator_id: prior_version.current_editor_id, target_status: target_status)
 
-      # If it has been in curation since the last published version, return it to curation
-      # If it has not been in curation since the last published version, leave it as submitted or peer_review
-      if identifier.date_last_curated > identifier.date_last_published
-        curation_activities << StashEngine::CurationActivity.create(user_id: 0, status: 'curation',
-                                                                    note: 'System set back to curation')
-      end
+      # If it has never been published, or it has been in curation more recently than
+      # the last published version, return it to curation status
+      return unless identifier.date_last_published.blank? || identifier.date_last_curated > identifier.date_last_published
+
+      curation_activities << StashEngine::CurationActivity.create(user_id: 0, status: 'curation',
+                                                                  note: 'System set back to curation')
     end
     # rubocop:enable Metrics/AbcSize
 


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1480, https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1552, https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1556

- Reworking of the logic for auto-assigning curators and statuses after a dataset is processed by Merritt. See the included documentation file for an overview of the new rules.
- When a curator is unassigned, retain the current curation status, unless the status was `curation`