### PR TITLE
Trying to get rid of babel warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     }
   },
   "dependencies": {
+    "@babel/plugin-proposal-private-methods": "^7.16.0",
     "@babel/preset-react": "^7.14.5",
     "@cdl-dryad/frictionless-components": "^0.3.14",
     "@rails/webpacker": "5.2.1",


### PR DESCRIPTION
They happened in the puppet deploy on stg, but this changes fixes them.