### PR TITLE
Announces downloads for screen readers

### DIFF
--- a/stash/stash_engine/app/views/stash_engine/downloads/_download_popup_initial.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/downloads/_download_popup_initial.html.erb
@@ -11,6 +11,6 @@
   <div id="progressbar"></div>
 
   <p>
-    <%= button_tag 'Close', type: 'button', id: 'cancel_dialog' %>
+    <%= button_tag 'Cancel', type: 'button', id: 'cancel_dialog' %>
   </p>
 </div>

--- a/stash/stash_engine/app/views/stash_engine/downloads/_download_timeout_message.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/downloads/_download_timeout_message.html.erb
@@ -10,6 +10,6 @@
   <p>The Dryad team has been notified of this problem.</p>
 
   <p>
-    <%= button_tag 'Close', type: 'button', id: 'cancel_dialog' %>
+    <%= button_tag 'Cancel', type: 'button', id: 'cancel_dialog' %>
   </p>
 </div>

--- a/stash/stash_engine/app/views/stash_engine/downloads/download_resource.js.erb
+++ b/stash/stash_engine/app/views/stash_engine/downloads/download_resource.js.erb
@@ -2,6 +2,7 @@ function delayedEnable() {
   // wait a bit so download starts before re-enabling so they don't machine gun click
   setTimeout(function(){
     $('.js-download').prop('disabled', false).removeClass('o-download__wait').addClass('o-download__files');
+    $('#accessible-dl-msg').text("Your download has started");
   }, 5000);
 }
 

--- a/stash/stash_engine/app/views/stash_engine/landing/_download.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/landing/_download.html.erb
@@ -4,6 +4,8 @@
 
   <%= button_to "Download dataset", download_resource_path(resource.id), remote: true,
                 class: 'o-download__files js-download', id: "dl_res_#{resource.id}" %>
+
+  <div class="screen-reader-only" id="accessible-dl-msg" aria-live="assertive"></div>
 </div>
 
 <script>


### PR DESCRIPTION
Adds an aria live region and updates it with an announcement when the download begins.

If you want to see it happening, you can change the class of the element with id="accessible-dl-msg" in _download.html.erb from `screen-reader-only` to something else and it displays text on the screen.  Or edit the class in your browser inspector.  It is right by the download link on the page in the same div.