### PR TITLE
Fixes submit button not being disabled on errors in some circumstances

### DIFF
--- a/spec/features/stash_datacite/review_dataset_spec.rb
+++ b/spec/features/stash_datacite/review_dataset_spec.rb
@@ -33,8 +33,9 @@ RSpec.feature 'ReviewDataset', type: :feature do
 
     before(:each) do
       start_new_dataset
-      navigate_to_review
       fill_required_fields
+      navigate_to_review
+      agree_to_everything
     end
 
     it 'submit button should be enabled', js: true do

--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -1,5 +1,6 @@
 RSpec.feature 'Admin', type: :feature do
 
+  include DatasetHelper
   include Mocks::CurationActivity
   include Mocks::Datacite
   include Mocks::Ror
@@ -40,7 +41,9 @@ RSpec.feature 'Admin', type: :feature do
       expect(page).to have_css('button[title="Edit Dataset"]')
       find('button[title="Edit Dataset"]').click
       expect(page).to have_text("You are editing #{@user.name}'s dataset.")
+      add_required_data_files
       click_link 'Review and Submit'
+      agree_to_everything
       expect(page).to have_css('input#user_comment')
     end
 
@@ -259,7 +262,9 @@ RSpec.feature 'Admin', type: :feature do
       expect(page).to have_css('button[title="Edit Dataset"]')
       find('button[title="Edit Dataset"]').click
       expect(page).to have_text("You are editing #{@user.name}'s dataset.")
+      add_required_data_files
       click_link 'Review and Submit'
+      agree_to_everything
       expect(page).to have_css('input#user_comment')
     end
 

--- a/spec/features/stash_engine/curation_activity_spec.rb
+++ b/spec/features/stash_engine/curation_activity_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 # require 'pry-remote'
 
 RSpec.feature 'CurationActivity', type: :feature do
-
   include Mocks::Aws
   include Mocks::Stripe
   include Mocks::Ror
@@ -218,6 +217,7 @@ RSpec.feature 'CurationActivity', type: :feature do
       it 'allows curation editing of users dataset and returning to admin list in same state afterward' do
         # the button to edit has this class on it
         find('.js-trap-curator-url').click
+        add_required_data_files
         navigate_to_review
         agree_to_everything
         fill_in 'user_comment', with: Faker::Lorem.sentence

--- a/spec/support/helpers/dataset_helper.rb
+++ b/spec/support/helpers/dataset_helper.rb
@@ -33,14 +33,12 @@ module DatasetHelper
 
   def navigate_to_review
     click_link 'Review and Submit'
-    page.send_keys :escape if page.has_content?('Include at least one data file')
     expect(page).to have_content('Review Description')
   end
 
   def fill_required_fields
     fill_required_metadata
     add_required_data_files
-    agree_to_everything
   end
 
   def fill_required_metadata
@@ -63,8 +61,7 @@ module DatasetHelper
   end
 
   def submit_form
-    navigate_to_review
-    submit = find_button('submit_dataset', disabled: :all)
+    submit = find_button('submit_dataset')
     submit.click
   end
 
@@ -111,10 +108,8 @@ module DatasetHelper
   end
 
   def agree_to_everything
-    navigate_to_review
-    find('#agree_to_license').click
-    find('#agree_to_tos').click
-    find('#agree_to_payment').click
+    # navigate_to_review  # do we really have to re-navigate each time?
+    all(:css, '.js-agrees').each {|i| i.click unless i.checked? } # this does the same if they're present, but doesn't always wait
   end
 
   def attach_files

--- a/spec/support/helpers/dataset_helper.rb
+++ b/spec/support/helpers/dataset_helper.rb
@@ -109,7 +109,7 @@ module DatasetHelper
 
   def agree_to_everything
     # navigate_to_review  # do we really have to re-navigate each time?
-    all(:css, '.js-agrees').each {|i| i.click unless i.checked? } # this does the same if they're present, but doesn't always wait
+    all(:css, '.js-agrees').each { |i| i.click unless i.checked? } # this does the same if they're present, but doesn't always wait
   end
 
   def attach_files

--- a/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
@@ -96,7 +96,9 @@ $(document).ready(function(){
       // console.log( index + ": " + $( this ).text() );
     });
 
-    if (allChecked) {
+		let hasErrors = ($('div.c-error-box').length > 0) && ($('div.c-error-box')[0].innerHTML.length > 0);
+
+    if (allChecked && !hasErrors) {
         $('.js-submission').attr('disabled', false); //enable input
     } else {
         $('.js-submission').attr('disabled', true); //disable input

--- a/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
@@ -162,7 +162,6 @@
   }
 
   function updateSubmitCommentDisabled(){
-    alert('hello world!');
     let hasErrors = ($('div.c-error-box').length > 0) && ($('div.c-error-box')[0].innerHTML.length > 0);
     if($('#all_filled').length && $('#user_comment').val().length > 0 && !hasErrors){
       $('#submit_dataset').prop('disabled', false);

--- a/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
+++ b/stash/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
@@ -127,7 +127,7 @@
   <%= link_to 'Back to Upload', stash_url_helpers.up_code_resource_path(@resource), id: 'dashboard_path',
           class: 'o-button__icon-left', role: 'button' %>
 
-  <% if @data.blank? # valid data %>
+  <% if @error_items.blank? # valid data %>
     <%= form_with(url: stash_datacite.resources_submission_path, local: true) do -%>
       <%= hidden_field_tag :resource_id, @resource.id %>
       <%= hidden_field_tag :software_license, @resource&.identifier&.software_license&.identifier || 'MIT' %>
@@ -162,7 +162,9 @@
   }
 
   function updateSubmitCommentDisabled(){
-    if($('#all_filled').length && $('#user_comment').val().length > 0){
+    alert('hello world!');
+    let hasErrors = ($('div.c-error-box').length > 0) && ($('div.c-error-box')[0].innerHTML.length > 0);
+    if($('#all_filled').length && $('#user_comment').val().length > 0 && !hasErrors){
       $('#submit_dataset').prop('disabled', false);
     }else{
       $('#submit_dataset').prop('disabled', true);

--- a/stash/stash_engine/app/views/stash_engine/data_files/_show_merritt.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/data_files/_show_merritt.html.erb
@@ -5,7 +5,7 @@
     <% resource.data_files.each do |fu| %>
 	<div class="<%= 'strike-deleted' if fu.file_state == 'deleted' %>">
 	    <li>
-		<% if fu.file_state == 'copied' && uploaded %>
+		<% if fu.file_state == 'copied' && uploaded && fu.last_version_file&.id.present? %>
 		    <%= link_to fu.upload_file_name, stash_url_helpers.download_stream_path(file_id: fu.last_version_file&.id), target: '_blank' %>
 		<% else %>
 		    <%= fu.upload_file_name %>


### PR DESCRIPTION
This fixes the issue we saw in some cases where it would show errors for the title not being filled, but still allowed submission after the other "accept" buttons were checked.

The error was fairly easy to fix, but then it caused lots of errors with other tests where readme.txt files weren't set up or the accept buttons weren't checked.  There were also some tests that were extra slow since they were loading the review page 3 times or more.  I think this fixes the issue and those tests.