### PR TITLE
Treat tenant_curators as curators too

### DIFF
--- a/spec/features/stash_datacite/dataset_versioning_spec.rb
+++ b/spec/features/stash_datacite/dataset_versioning_spec.rb
@@ -336,6 +336,24 @@ RSpec.feature 'DatasetVersioning', type: :feature do
           expect(@resource.current_editor_id).to eql(curator2.id)
         end
 
+        it 'does not use the backup curator when the previous curator is a tenant_curator', js: true do
+          @curator.update(role: 'tenant_curator')
+          create(:user, role: 'curator') # backup curator
+          create(:curation_activity, user_id: @curator.id, resource_id: @resource.id, status: 'published')
+          @resource.reload
+
+          sign_in(@author)
+          click_link 'My Datasets'
+          within(:css, '#user_submitted') do
+            click_button 'Update'
+          end
+          update_dataset
+          @resource.reload
+
+          expect(@resource.current_curation_status).to eql('submitted')
+          expect(@resource.current_editor_id).to eql(@curator.id)
+        end
+
       end
 
     end

--- a/stash/stash_engine/app/models/stash_engine/user.rb
+++ b/stash/stash_engine/app/models/stash_engine/user.rb
@@ -37,7 +37,7 @@ module StashEngine
     end
 
     def curator?
-      role == 'superuser' || role == 'curator'
+      role == 'superuser' || role == 'curator' || role == 'tenant_curator'
     end
 
     def journals_as_admin

--- a/stash/stash_engine/app/views/stash_engine/pages/_nav.html.erb
+++ b/stash/stash_engine/app/views/stash_engine/pages/_nav.html.erb
@@ -10,7 +10,7 @@
     <% if current_user && %w[development test local_dev].include?(Rails.env) %>
       <span class="c-header__nav-item" title="<%= current_user.email %>" style="color: blue;">[<%= current_user.name %>@<%= current_tenant&.tenant_id %>]</span>
     <% end %>
-    <% if current_user && current_user.curator? %>
+    <% if current_user && current_user.curator? && !(current_user.role == 'tenant_curator') %>
       <div class="c-header__nav-item">
         <div class="o-sites">
           <details class="o-showhide o-sites__details" role="group">


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1590

When performing a check of whether a user is a 'curator', including auto-assignment of curators for versioned datasets, treat a `tenant_curator` role the same as a `curator` role.