### PR TITLE
Fix issues with libv8 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,8 +40,8 @@ gem 'uc3-ssm', git: 'https://github.com/CDLUC3/uc3-ssm', branch: '0.3.0rc0'
 
 gem 'coffee-rails', '~> 4.1'
 gem 'jquery-rails'
-gem 'sass-rails', '~> 5.0'
 gem 'libv8', '~> 3.16.14'
+gem 'sass-rails', '~> 5.0'
 gem 'therubyracer', platforms: :ruby
 gem 'turbolinks'
 gem 'uglifier', '~> 4.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'uc3-ssm', git: 'https://github.com/CDLUC3/uc3-ssm', branch: '0.3.0rc0'
 gem 'coffee-rails', '~> 4.1'
 gem 'jquery-rails'
 gem 'sass-rails', '~> 5.0'
+gem 'libv8', '~> 3.16.14'
 gem 'therubyracer', platforms: :ruby
 gem 'turbolinks'
 gem 'uglifier', '~> 4.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -465,8 +465,9 @@ GEM
       addressable (~> 2.7)
     leaflet-rails (1.7.0)
       rails (>= 4.2.0)
+    libv8 (3.16.14.19)
     libv8 (3.16.14.19-x86_64-darwin-17)
-    libv8 (3.16.14.19-x86_64-linux)	
+    libv8 (3.16.14.19-x86_64-linux)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -864,6 +865,7 @@ DEPENDENCIES
   irb (~> 1.3.7)
   jbuilder
   jquery-rails
+  libv8 (~> 3.16.14)
   listen
   mocha
   mysql2 (~> 0.5.3)


### PR DESCRIPTION
After moving the `stash-api` engine in #755, libv8 worked by default on some versions of Linux, but did not load properly on GitHub Actions, requiring an update to the Gemfile.lock. But even this did not work on our staging server, so I'm adding an explicit require for libv8 gem at the top level of the app.