### PR TITLE
Improve robustness of curation milestones report

### DIFF
--- a/stash/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash/stash_engine/app/models/stash_engine/identifier.rb
@@ -521,6 +521,13 @@ module StashEngine
       nil
     end
 
+    def date_available_for_curation
+      resources.map(&:curation_activities).flatten.each do |ca|
+        return ca.created_at if ca.submitted?
+      end
+      nil
+    end
+
     def curation_completed_date
       return nil unless %w[action_required published embargoed].include?(pub_state)
 
@@ -532,6 +539,13 @@ module StashEngine
         break
       end
       found_cc_date
+    end
+
+    def date_first_curated
+      resources.map(&:curation_activities).flatten.each do |ca|
+        return ca.created_at if ca.curation?
+      end
+      nil
     end
 
     def date_last_curated

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -574,8 +574,8 @@ namespace :curation_stats do
         next unless r
 
         # TimeToCuration = time from first availability (CurationStartDate) to first actual curation note
-        ttc_start = r.curation_activities.order(:id).where("status = 'submitted'")&.first&.created_at
-        ttc_end = r.curation_activities.order(:id).where("status = 'curation'")&.first&.created_at
+        ttc_start = i.date_available_for_curation
+        ttc_end = i.date_first_curated
         time_to_curation = (ttc_end - ttc_start).to_i / 1.day if ttc_start && ttc_end
 
         # TimeInCuration = time from first actual curation to approval


### PR DESCRIPTION
The original curator milestones report assumed that the first submitted version of a dataset would be the first version that was curated. Unfortunately, this is only true for about 50% of datasets. When a dataset goes through PPR, there is often a second version in which the submitter removes the PPR status. Additionally, some datasets are versioned multiple times before curation just because the submitter is making changes.

This update takes those circumstances into account.