### PR TITLE
Improve precision of API searches using modifiedSince

### DIFF
--- a/app/controllers/stash_api/datasets_controller.rb
+++ b/app/controllers/stash_api/datasets_controller.rb
@@ -350,7 +350,7 @@ module StashApi
 
       if params['modifiedSince']
         # ["timestamp:[2020-10-08T10:24:53Z TO NOW]"]
-        fq_array << "timestamp:[#{params['modifiedSince']} TO NOW]"
+        fq_array << "updated_at_dt:[#{params['modifiedSince']} TO NOW]"
       end
 
       fq_array

--- a/documentation/technical_notes/geoblacklight.md
+++ b/documentation/technical_notes/geoblacklight.md
@@ -1,5 +1,28 @@
 # Information about Geoblacklight and SOLR
 
+## Overview of config files
+
+`stash/stash_datacite/lib/stash_indexer/indexing_resource.rb`
+- Creates the actual document that will be sent to solr for indexing
+
+`config/solr_config/schema.xml`
+- Defines what is actually stored/indexed in SOLR
+- Contains generic field names like "*_i", "*_sm", so fields can be added to the
+  record without needing to change the schema or the SOLR server. Each of these
+  field names has reasonable settings for stored/indexed/etc.
+- Contains `copyField` declarations to copy fields into similar fields with
+  suffixes like "*_tmi", so they can have varying weights in query processing
+  (though it's unclear why we coudln't just use the original fields for this)
+- Contains `copyField` declarations to ensure all textual fields are available
+  for text searching
+
+`config/solr_config/solrconfig.xml`
+- Defines query handling.
+
+`config/settings.yml`
+- UI settings for GeoBlacklight
+
+
 ## How to add another facet to the data and search interface
 
 1. Set up the additional item(s) in the SOLR schema for Geoblacklight

--- a/documentation/technical_notes/geoblacklight.md
+++ b/documentation/technical_notes/geoblacklight.md
@@ -3,10 +3,10 @@
 ## Overview of config files
 
 `stash/stash_datacite/lib/stash_indexer/indexing_resource.rb`
-- Creates the actual document that will be sent to solr for indexing
+- Creates the actual document that will be sent to SOLR for indexing
 
 `config/solr_config/schema.xml`
-- Defines what is actually stored/indexed in SOLR
+- Defines the fields that will be stored/indexed in SOLR
 - Contains generic field names like "*_i", "*_sm", so fields can be added to the
   record without needing to change the schema or the SOLR server. Each of these
   field names has reasonable settings for stored/indexed/etc.

--- a/spec/lib/stash_datacite/indexing_resource_spec.rb
+++ b/spec/lib/stash_datacite/indexing_resource_spec.rb
@@ -312,7 +312,8 @@ module Stash
                                                @affil2.long_name],
             dryad_related_publication_name_s: 'Journal of Testing Fun',
             dryad_related_publication_id_s: 'manuscript123 pubmed123 doi123',
-            dryad_dataset_file_ext_sm: df
+            dryad_dataset_file_ext_sm: df,
+            updated_at_dt: @resource.updated_at.iso8601
           }
           expect(mega_hash).to eql(expected_mega_hash)
         end

--- a/spec/mocks/rsolr.rb
+++ b/spec/mocks/rsolr.rb
@@ -12,7 +12,7 @@ module Mocks
       stub_request(:get, %r{solr/geoblacklight}).to_return(status: 200, body: default_results, headers: {})
       stub_request(:post, %r{solr/geoblacklight}).to_return(status: 200, body: [], headers: {})
       stub_request(:get, %r{solr/geoblacklight.*fq=dryad_author_affiliation}).to_return(status: 200, body: trivial_results, headers: {})
-      stub_request(:get, %r{solr/geoblacklight.*fq=timestamp}).to_return(status: 200, body: trivial_results, headers: {})
+      stub_request(:get, %r{solr/geoblacklight.*fq=updated_at_dt}).to_return(status: 200, body: trivial_results, headers: {})
 
       # The StashDiscovery::LatestController.index attempts to contact Solr and the Rails.cache for
       # the list of 'Recent Datasets' on the home page. We have to set one of the controller's instance

--- a/stash/stash_datacite/lib/stash/indexer/indexing_resource.rb
+++ b/stash/stash_datacite/lib/stash/indexer/indexing_resource.rb
@@ -87,7 +87,8 @@ module Stash
           dryad_related_publication_id_s: related_publication_id,
           dryad_author_affiliation_name_sm: author_affiliations,
           dryad_author_affiliation_id_sm: author_affiliation_ids,
-          dryad_dataset_file_ext_sm: dataset_file_exts
+          dryad_dataset_file_ext_sm: dataset_file_exts,
+          updated_at_dt: updated_at_str
         }
       end
 
@@ -248,6 +249,11 @@ module Stash
         @resource.data_files.present_files.map do |df|
           File.extname(df.upload_file_name.to_s).gsub(/^./, '').downcase
         end.flatten.reject(&:blank?).uniq
+      end
+
+      def updated_at_str
+        # for solr, dates must follow ISO 8601 format
+        @resource.updated_at.iso8601
       end
 
       private


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1620

Previously, API searches for `modifiedSince` used the `timestamp` field in SOLR. This field is updated every time SOLR is reindexed, so it produces a lot of false positives. This PR changes the behavior to use a new field, `updated_at_dt`, which uses the `updated_at` field from the resource being indexed.