### PR TITLE
Show more journals on journals page

### DIFF
--- a/stash/stash_engine/app/controllers/stash_engine/journals_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/journals_controller.rb
@@ -10,7 +10,14 @@ module StashEngine
       params.permit(:q)
       params[:sort] = 'title' if params[:sort].blank?
       @all_journals = Journal.all
-      @journals = Journal.joins(:sponsor).where.not(payment_plan_type: [nil, '']).order(helpers.sortable_table_order, title: :asc)
+
+      metadata_journal_clause = 'stash_engine_journals.id IN ' \
+                                "(select distinct journal_id from stash_engine_manuscripts where created_at > '#{1.year.ago.iso8601}')"
+      metadata_journals = Journal.where(metadata_journal_clause).map(&:id)
+      sponsoring_journals = Journal.where.not(payment_plan_type: [nil, '']).map(&:id)
+      display_journals = metadata_journals | sponsoring_journals
+
+      @journals = Journal.joins(:sponsor).where(id: display_journals).order(helpers.sortable_table_order, title: :asc)
 
       respond_to do |format|
         format.html


### PR DESCRIPTION
https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1637

Expand the journals page to include all journals that have sent a metadata email in the past year, regardless of payment status. 

This does two queries (one for payment status and one for metadata status), then combines the results and issues a third query. It could be made more efficient using a single SQL statement, but that statement would be much more complex and difficult to maintain, and we don't have enough journals for the speed to be a concern at this point.