### PR TITLE
Treadway report -- Curation status dates

### DIFF
--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -554,7 +554,7 @@ namespace :curation_stats do
 
   desc 'Report on first date for each status'
   task status_dates: :environment do
-    launch_day = Date.new(2019, 9, 17)
+    launch_day = Date.new(2019, 9, 18)
 
     CSV.open('curation_status_dates.csv', 'w') do |csv|
       csv << %w[DOI

--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -261,54 +261,6 @@ namespace :identifiers do
     end
   end
 
-  desc 'Generate a report of the curation timeline for each dataset'
-  task curation_timeline_report: :environment do
-    launch_day = Date.new(2019, 9, 17)
-    datasets = StashEngine::Identifier.publicly_viewable.where(created_at: launch_day..Date.today)
-    CSV.open('curation_timeline_report.csv', 'w') do |csv|
-      csv << %w[DOI CreatedDate CurationStartDate TimesCurated ApprovalDate Size NumFiles FileFormats]
-      datasets.each do |i|
-        approval_date_str = i.approval_date&.strftime('%Y-%m-%d')
-        created_date_str = i.created_at&.strftime('%Y-%m-%d')
-        next unless i.resources.submitted.present?
-
-        curation_start_date = i.resources.submitted.each do |r|
-          break r.curation_start_date if r.curation_start_date.present?
-        end
-        next unless curation_start_date > launch_day
-
-        curation_start_date_str = curation_start_date&.strftime('%Y-%m-%d')
-
-        times_curated = 0
-        in_curation = false
-        i.resources.each do |r|
-          r.curation_activities.each do |ca|
-            if in_curation && %w[embargoed withdrawn published action_required].include?(ca.status)
-              # detect moves from in_curation to out
-              in_curation = false
-            elsif !in_curation && %w[curation].include?(ca.status)
-              # detect and count moves from out of curation to in_curation
-              in_curation = true
-              times_curated += 1
-            end
-          end
-        end
-
-        # Skip datasets that bypassed the normal curation process. These are mostly items that
-        # had problems during the migration from the v1 server, so they were "created" after
-        # launch day, even though they are actually older items.
-        next unless times_curated > 0
-
-        num_files = i.latest_resource.data_files.size
-
-        file_formats = i.latest_resource.data_files.map(&:upload_content_type).uniq.sort
-
-        csv << [i.identifier, created_date_str, curation_start_date_str, times_curated, approval_date_str,
-                i.storage_size, num_files, file_formats]
-      end
-    end
-  end
-
   desc 'Generate a report of items that have been published in a given month'
   task shopping_cart_report: :environment do
     # Get the year-month specified in YEAR_MONTH environment variable.
@@ -549,6 +501,93 @@ namespace :curation_stats do
       print '.'
       stats = StashEngine::CurationStats.find_or_create_by(date: date)
       stats.recalculate unless stats.created_at > 2.seconds.ago
+    end
+  end
+
+  desc 'Generate a report of the curation timeline for each dataset'
+  task curation_timeline_report: :environment do
+    launch_day = Date.new(2019, 9, 17)
+    datasets = StashEngine::Identifier.publicly_viewable.where(created_at: launch_day..Date.today)
+    CSV.open('curation_timeline_report.csv', 'w') do |csv|
+      csv << %w[DOI CreatedDate CurationStartDate TimesCurated ApprovalDate Size NumFiles FileFormats]
+      datasets.each do |i|
+        approval_date_str = i.approval_date&.strftime('%Y-%m-%d')
+        created_date_str = i.created_at&.strftime('%Y-%m-%d')
+        next unless i.resources.submitted.present?
+
+        curation_start_date = i.resources.submitted.each do |r|
+          break r.curation_start_date if r.curation_start_date.present?
+        end
+        next unless curation_start_date > launch_day
+
+        curation_start_date_str = curation_start_date&.strftime('%Y-%m-%d')
+
+        times_curated = 0
+        in_curation = false
+        i.resources.each do |r|
+          r.curation_activities.each do |ca|
+            if in_curation && %w[embargoed withdrawn published action_required].include?(ca.status)
+              # detect moves from in_curation to out
+              in_curation = false
+            elsif !in_curation && %w[curation].include?(ca.status)
+              # detect and count moves from out of curation to in_curation
+              in_curation = true
+              times_curated += 1
+            end
+          end
+        end
+
+        # Skip datasets that bypassed the normal curation process. These are mostly items that
+        # had problems during the migration from the v1 server, so they were "created" after
+        # launch day, even though they are actually older items.
+        next unless times_curated > 0
+
+        num_files = i.latest_resource.data_files.size
+
+        file_formats = i.latest_resource.data_files.map(&:upload_content_type).uniq.sort
+
+        csv << [i.identifier, created_date_str, curation_start_date_str, times_curated, approval_date_str,
+                i.storage_size, num_files, file_formats]
+      end
+    end
+  end
+
+  desc 'Report on first date for each status'
+  task status_dates: :environment do
+    launch_day = Date.new(2019, 9, 17)
+
+    CSV.open('curation_status_dates.csv', 'w') do |csv|
+      csv << %w[DOI
+                Journal
+                PaymentType
+                InProgressDate
+                PPRDate
+                SubmittedDate
+                CurationDate
+                AARDate
+                EmbargoedDate
+                PublishedDate
+                WithdrawnDate]
+      # For each dataset, submitted after launch day...
+      StashEngine::Identifier.where("created_at > '#{launch_day}'").each do |i|
+        r = i.first_submitted_resource
+        next unless r
+
+        cas = i.resources.map(&:curation_activities).flatten
+        next unless cas.present?
+
+        csv << [i.identifier, # DOI
+                i.journal&.title,
+                i.payment_type,
+                cas.find(&:in_progress?)&.created_at,
+                cas.find(&:peer_review?)&.created_at,
+                cas.find(&:submitted?)&.created_at,
+                cas.find(&:curation?)&.created_at,
+                cas.find(&:action_required?)&.created_at,
+                cas.find(&:embargoed?)&.created_at,
+                cas.find(&:published?)&.created_at,
+                cas.find(&:withdrawn?)&.created_at]
+      end
     end
   end
 


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1650

New report of the datasets, indicating the first date that each curation status was reached. This report is much more simplistic than related reports of curation activity, but hopefully it will still be useful.

(Also moved the `curation_timeline_report` into the section with other curation reports, but I didn't actually change its contents.)