### PR TITLE
Fix GMail authorization

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -830,7 +830,7 @@ GEM
       xml-mapping (~> 0.10)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yaml (0.2.0)
+    yaml (0.1.1)
     yui-compressor (0.12.0)
     zaru (0.3.0)
 


### PR DESCRIPTION
GMail messages have not imported since January 19th. Apparently, upgrading the Yaml gem breaks something in the current Gmail gem.

To test:
`bundle exec rails journal_email:validate_gmail_connection RAILS_ENV=local`
(you will either receive an exception or a message stating it is working)