### PR TITLE
This adds bold appearance for strong text

### DIFF
--- a/stash/stash_engine/app/assets/stylesheets/stash_engine/ui.css
+++ b/stash/stash_engine/app/assets/stylesheets/stash_engine/ui.css
@@ -5524,6 +5524,10 @@ table.c-table_institutions ul li {
     margin: 0;
     font-size: 1.2em; } }
 
+strong {
+  font-weight: bold;
+  text-shadow: 0 0; }
+
 blockquote.c-text_styles {
   line-height: 135%; }
   blockquote.c-text_styles strong {

--- a/stash/stash_engine/app/assets/stylesheets/stash_engine/ui.css
+++ b/stash/stash_engine/app/assets/stylesheets/stash_engine/ui.css
@@ -5525,6 +5525,7 @@ table.c-table_institutions ul li {
     font-size: 1.2em; } }
 
 strong {
+  font-size: 1.1em;
   font-weight: bold;
   text-shadow: 0 0; }
 

--- a/stash/stash_engine/ui-library/scss/_text-styles.scss
+++ b/stash/stash_engine/ui-library/scss/_text-styles.scss
@@ -1,4 +1,5 @@
 strong {
+  font-size: 1.1em;
   font-weight: bold;
   text-shadow: 0 0;
 }

--- a/stash/stash_engine/ui-library/scss/_text-styles.scss
+++ b/stash/stash_engine/ui-library/scss/_text-styles.scss
@@ -1,3 +1,8 @@
+strong {
+  font-weight: bold;
+  text-shadow: 0 0;
+}
+
 blockquote.c-text_styles {
   line-height: 135%;
   strong {


### PR DESCRIPTION
There is something weird about our default font that doesn't show bold.  I can display bold by adding a shadow style which seems to work fine in both Chrome and Firefox.  The dataset at \<dev-domain\>/stash/dataset/doi:10.5072/FK2QR4XG4M shows an example.