### PR TITLE
This gives us a quick and dirty way to download a large number of files from S3

### DIFF
--- a/lib/tasks/dev_ops/download_s3.rb
+++ b/lib/tasks/dev_ops/download_s3.rb
@@ -1,0 +1,26 @@
+require 'http'
+
+module DevOps
+  class DownloadS3
+
+    def initialize(path:)
+      @path = path
+      @http = HTTP.follow(max_hops: 2)
+    end
+
+    def download(file_obj:)
+      dl_url = file_obj.direct_s3_presigned_url
+      resp = @http.get(dl_url)
+
+      File.open(File.join(@path, file_obj.upload_file_name), "wb") do |dest|
+        dest.write(resp.body) # slurp it all at once
+
+        # below writes streaming chunk by chunk which may be better and reduce resource usage for large files
+        # stream it a chunk at a time
+        # resp.body.each do |chunk|
+        #   dest.write(chunk)
+        # end
+      end
+    end
+  end
+end

--- a/lib/tasks/dev_ops/download_s3.rb
+++ b/lib/tasks/dev_ops/download_s3.rb
@@ -12,7 +12,7 @@ module DevOps
       dl_url = file_obj.direct_s3_presigned_url
       resp = @http.get(dl_url)
 
-      File.open(File.join(@path, file_obj.upload_file_name), "wb") do |dest|
+      File.open(File.join(@path, file_obj.upload_file_name), 'wb') do |dest|
         dest.write(resp.body) # slurp it all at once
 
         # below writes streaming chunk by chunk which may be better and reduce resource usage for large files


### PR DESCRIPTION
A basic rake task to download files from S3 since it becomes unwieldy to retrieve a large number of files from S3 by hand.

A user uploaded 15,169 individual files.  Our limit is 1,000 files.  This will give us a way to download them and zip them for her if we need to do that and create a zip container for her.

(The review page will not load because of the large number of files, but even if it did--it wouldn't allow submission of over 1,000 files.)

This only works on new files at S3 and goes through each and downloads into a directory named after the resource id in Rails.root.

BTW, tested this manually on an item with 10 files like:

`RAILS_ENV=local_dev bundle exec rails dev_ops:download_s3 3575`