### PR TITLE
modify journal autocomplete to show all journals 

### DIFF
--- a/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -45,7 +45,7 @@ module StashEngine
                                                                      funders: funder_limit,
                                                                      page: page.to_i,
                                                                      page_size: page_size.to_i)
-      @publications = @datasets.collect(&:publication_name).compact.uniq.sort { |a, b| a <=> b }
+      @publications = StashEngine::Journal.order(:title).map(&:title)
       @pub_name = params[:publication_name] || nil
 
       # paginate for display


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1646

On the Admin dashboard, the journal autocomplete was not finding all of the journals in the results. Only the journal names from the first page of results were being loaded. This is a first-step fix that allows the autocomplete to use all known journal names.

This will probably need to be modified more once we finish standardizing the autocompletes within React, but now it's at least functional.