### PR TITLE
Improve note when resource owner auto-assigned by API

### DIFF
--- a/app/models/stash_api/dataset_parser.rb
+++ b/app/models/stash_api/dataset_parser.rb
@@ -24,11 +24,14 @@ module StashApi
     # this is the basic required metadata
     def parse
       clear_previous_metadata
+      owning_user_id = establish_owning_user_id
+      owning_user = StashEngine::User.find(owning_user_id)
+      user_note = "Created by API user, assigned ownership to #{owning_user&.name} (#{owning_user_id})"
       @resource.curation_activities << StashEngine::CurationActivity.create(status: @resource.current_curation_status || 'in_progress',
                                                                             user_id: @user.id,
                                                                             resource_id: @resource.id,
-                                                                            note: 'Created by API user')
-      owning_user_id = establish_owning_user_id
+                                                                            note: user_note)
+
       @resource.update(
         title: remove_html(@hash['title']),
         user_id: owning_user_id,


### PR DESCRIPTION
Previously, most auto-assignment was performed using an "edit code". Since #610, it is more common for the auto-assignment to happen at the time the dataset is initially created. So this PR updates the note to inform curators about the owner that is assigned at creation.