### PR TITLE
Reports: Datasets associated with rejected manuscripts, PPR to curation

### DIFF
--- a/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -284,8 +284,27 @@ namespace :identifiers do
     end
   end
 
+  desc 'Generate a report of PPR to Curation'
+  task ppr_to_curation_report: :environment do
+    puts 'Writing ppr_to_curation.csv'
+    CSV.open('ppr_to_curation.csv', 'w') do |csv|
+      csv << %w[DOI CreatedAt]
+      StashEngine::Identifier.all.each_with_index do |i, ind|
+        puts ind.to_s if (ind % 100) == 0
+        ppr_found = false
+        i.resources.map(&:curation_activities).flatten.each do |ca|
+          ppr_found = true if ca.peer_review?
+          if ca.curation? && ppr_found
+            csv << [i.identifier, i.created_at]
+            break
+          end
+        end
+      end
+    end
+  end
+
   desc 'Generate a report of datasets with associated rejection notices'
-  task rejected_datasets: :environment do
+  task rejected_datasets_report: :environment do
     puts 'Writing rejected_datasets.csv'
     CSV.open('rejected_datasets.csv', 'w') do |csv|
       csv << %w[DOI CreatedAt MSID NumNotifications Published? CurrentStatus]


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1602

Saving copies of these reports so we don't need to re-create them. I'm not sure this file is the best to keep them in. We should probably move all the random reports into their own file at some point....