### PR TITLE
Correct "something went wrong" for funder admins

### DIFF
--- a/stash/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash/stash_engine/app/models/stash_engine/resource.rb
@@ -585,8 +585,8 @@ module StashEngine
       resource_funders = contributors
       return unless user_funders.present? && resource_funders.present?
 
-      user_funder_ids = user_funders.map(&:funder_id).reject(&:empty?)
-      resource_funder_ids = resource_funders.map(&:name_identifier_id).reject(&:empty?)
+      user_funder_ids = user_funders.map(&:funder_id).compact.reject(&:empty?)
+      resource_funder_ids = resource_funders.map(&:name_identifier_id).compact.reject(&:empty?)
       user_funder_ids.&(resource_funder_ids).present?
     end
 


### PR DESCRIPTION
Normally, `funder_id` and `name_identifier_id` have either a value or an empty string. This protects against instances where the field has a `NULL`.