### PR TITLE
Allow journals to specify that their datasets should default to PPR

### DIFF
--- a/app/controllers/stash_datacite/publications_controller.rb
+++ b/app/controllers/stash_datacite/publications_controller.rb
@@ -64,6 +64,10 @@ module StashDatacite
 
       parsed_msid = parse_msid(issn: params[:publication_issn], msid: params[:msid])
       @msid = manage_internal_datum(identifier: @se_id, data_type: 'manuscriptNumber', value: parsed_msid)
+
+      # if the newly-set journal wants PPR by default, set the PPR value for this resource
+      @resource.update(hold_for_peer_review: @se_id.journal&.default_to_ppr)
+
       save_doi
     end
 

--- a/db/migrate/20220323211615_add_default_ppr_to_journals.rb
+++ b/db/migrate/20220323211615_add_default_ppr_to_journals.rb
@@ -1,0 +1,5 @@
+class AddDefaultPprToJournals < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stash_engine_journals, :default_to_ppr, :boolean, after: :allow_blackout, default: 0
+  end
+end

--- a/documentation/apis/journals.md
+++ b/documentation/apis/journals.md
@@ -35,6 +35,8 @@ Options for processing in `StashEngine::Journal`
   "hide" a dataset until the associated article was published. Now
   controls whether an automatic 1-year blackout/embargo is added to
   the dataset.
+- *default_to_ppr* -- Whether the Peer Review checkbox should be checked by
+  default when a new dataset is associated with this journal.
 
 Adding journal administrators
 -------------------------------


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1664

Adds a setting to `stash_engine_journals` that allows journals to specify that any dataset associated with that journal should default to PPR. When a journal name is set or changed, the journal setting will be used to determine the status of the `hold_for_peer_review` option (i.e., whether the PPR checkbox is checked).