### PR TITLE
Changes for ordering

### DIFF
--- a/app/controllers/stash_datacite/authors_controller.rb
+++ b/app/controllers/stash_datacite/authors_controller.rb
@@ -51,8 +51,10 @@ module StashDatacite
     def reorder
       respond_to do |format|
         format.json {
-          byebug
-          # author.where()
+          js = params['_json'].map{|i| {id: i[:id], author_order: i[:order]} } # convert weird params objs to hashes
+          grouped_authors = js.index_by{|author| author[:id] }
+          resp = StashEngine::Author.update(grouped_authors.keys, grouped_authors.values)
+          render json: resp, status: :ok
         }
       end
 

--- a/app/controllers/stash_datacite/authors_controller.rb
+++ b/app/controllers/stash_datacite/authors_controller.rb
@@ -50,14 +50,13 @@ module StashDatacite
     # takes a list of author ids and their new orders like [{id: 3323, order: 0},{id:3324, order: 1}] etc
     def reorder
       respond_to do |format|
-        format.json {
-          js = params['_json'].map{|i| {id: i[:id], author_order: i[:order]} } # convert weird params objs to hashes
-          grouped_authors = js.index_by{|author| author[:id] }
+        format.json do
+          js = params['_json'].map { |i| { id: i[:id], author_order: i[:order] } } # convert weird params objs to hashes
+          grouped_authors = js.index_by { |author| author[:id] }
           resp = StashEngine::Author.update(grouped_authors.keys, grouped_authors.values)
           render json: resp, status: :ok
-        }
+        end
       end
-
     end
 
     private
@@ -106,7 +105,7 @@ module StashDatacite
     end
 
     def check_reorder_valid
-      @authors = StashEngine::Author.where(id: params["_json"].map{|i| i["id"] })
+      @authors = StashEngine::Author.where(id: params['_json'].map { |i| i['id'] })
 
       # you can only order things belonging to one resource
       render json: { error: 'bad request' }, status: :bad_request unless @authors.map(&:resource_id)&.uniq&.length == 1

--- a/app/models/stash_api/dataset_parser.rb
+++ b/app/models/stash_api/dataset_parser.rb
@@ -144,7 +144,8 @@ module StashApi
         author_last_name: json_author[:lastName],
         author_email: json_author[:email],
         author_orcid: json_author[:orcid] || @previous_orcids["#{json_author[:firstName]} #{json_author[:lastName]}"],
-        resource_id: @resource.id
+        resource_id: @resource.id,
+        author_order: json_author[:order] || nil
       )
 
       # If the affiliation was provided, prefer the ROR id over a textual name.

--- a/app/models/stash_api/dataset_parser/example.json
+++ b/app/models/stash_api/dataset_parser/example.json
@@ -6,14 +6,16 @@
       "lastName": "Fisher",
       "email": "Scott.Fisher@ucop.edu",
       "affiliation": "UC Office of the President",
-      "orcid": "0000-0001-6422-6998"
+      "orcid": "0000-0001-6422-6998",
+      "order": 0
     },
     {
       "firstName": "Norah",
       "lastName": "Moraga",
       "email": "Norah.Moraga@example.com",
       "affiliation": "UC Davis",
-      "orcid": null
+      "orcid": null,
+      "order": 1
     }
   ],
   "abstract": "<p>Information theorists agree that \"fuzzy\" models are an interesting new topic in the field of machine learning, and hackers worldwide concur. In fact, few electrical engineers would disagree with the emulation of replication, which embodies the compelling principles of cryptoanalysis. Weight, our new method for journaling file systems, is the solution to all of these grand challenges.</p>\r\n",

--- a/app/models/stash_api/version/metadata/authors.rb
+++ b/app/models/stash_api/version/metadata/authors.rb
@@ -15,7 +15,8 @@ module StashApi
               email: a.author_email,
               affiliation: a.try(:affiliation).try(:smart_name),
               affiliationROR: a.try(:affiliation).try(:ror_id),
-              orcid: a.author_orcid
+              orcid: a.author_orcid,
+              order: a.author_order
             }
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -180,6 +180,7 @@ Rails.application.routes.draw do
     post 'authors/create', to: 'authors#create'
     patch 'authors/update', to: 'authors#update'
     delete 'authors/:id/delete', to: 'authors#delete', as: 'authors_delete'
+    patch 'authors/reorder', to: 'authors#reorder', as: 'authors_reorder'
     
     get 'contributors/new', to: 'contributors#new'
     get 'contributors/autocomplete', to: 'contributors#autocomplete'

--- a/public/openapi.yml
+++ b/public/openapi.yml
@@ -757,6 +757,8 @@ components:
           type: string
         orcid:
           type: string
+        order:
+          type: integer
     simple_author:
       properties:
         firstName:

--- a/spec/fixtures/stash_api/metadata.rb
+++ b/spec/fixtures/stash_api/metadata.rb
@@ -23,6 +23,16 @@ module Fixtures
         add_research_domain
       end
 
+      def make_minimal_ordered_authors
+        add_title
+        add_abstract
+        @metadata[:authors] = [] # reset to 0 authors
+        add_author(order: 2)
+        add_author(order: 1)
+        add_author(order: 0)
+        add_research_domain
+      end
+
       def add_field(field_name:, value: nil)
         @metadata[field_name.to_sym] = value
       end
@@ -31,7 +41,7 @@ module Fixtures
         @metadata.merge!(title: Faker::Book.title)
       end
 
-      def add_author
+      def add_author(order: nil)
         create_key_and_array(key: :authors)
         @metadata[:authors].push(
           { "firstName": Faker::Name.first_name,
@@ -39,7 +49,9 @@ module Fixtures
             email: Faker::Internet.email,
             orcid: "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}-" \
                    "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}",
-            affiliation: Faker::University.name }.with_indifferent_access
+            affiliation: Faker::University.name,
+            order: order
+          }.with_indifferent_access
         )
       end
 

--- a/spec/fixtures/stash_api/metadata.rb
+++ b/spec/fixtures/stash_api/metadata.rb
@@ -50,8 +50,7 @@ module Fixtures
             orcid: "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}-" \
                    "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}",
             affiliation: Faker::University.name,
-            order: order
-          }.with_indifferent_access
+            order: order }.with_indifferent_access
         )
       end
 

--- a/spec/models/stash_engine/author_spec.rb
+++ b/spec/models/stash_engine/author_spec.rb
@@ -26,6 +26,22 @@ module StashEngine
         expect(author.author_html_email_string).to eq('<a href="mailto:lmeitner@example.edu">Lise Meitner</a>')
       end
 
+      describe :ordering do
+        before(:each) do
+          @resource.authors.destroy_all
+          temp_auths = Array.new(7) { |_i| create(:author, resource_id: @resource.id)}
+          @authors = temp_auths.shuffle
+          @authors.each_with_index {|auth, idx| auth.update(author_order: idx)}
+        end
+
+        it 'orders by the author_order instead of id if it is set' do
+          @retrieved_authors = Author.where(resource_id: @resource.id)
+          @retrieved_authors.each_with_index do |ret, idx|
+            expect(ret.id).to eq(@authors[idx].id)
+          end
+        end
+      end
+
       describe :author_email do
         it 'is optional' do
           author = Author.create(

--- a/spec/models/stash_engine/author_spec.rb
+++ b/spec/models/stash_engine/author_spec.rb
@@ -29,9 +29,9 @@ module StashEngine
       describe :ordering do
         before(:each) do
           @resource.authors.destroy_all
-          temp_auths = Array.new(7) { |_i| create(:author, resource_id: @resource.id)}
+          temp_auths = Array.new(7) { |_i| create(:author, resource_id: @resource.id) }
           @authors = temp_auths.shuffle
-          @authors.each_with_index {|auth, idx| auth.update(author_order: idx)}
+          @authors.each_with_index { |auth, idx| auth.update(author_order: idx) }
         end
 
         it 'orders by the author_order instead of id if it is set' do

--- a/spec/requests/stash_api/datasets_controller_spec.rb
+++ b/spec/requests/stash_api/datasets_controller_spec.rb
@@ -57,6 +57,23 @@ module StashApi
         expect(out_author[:affiliation]).to eq(in_author[:affiliation])
       end
 
+      it 'creates a new dataset from minimal metadata and ordered authors (title, author info, abstract)' do
+        @meta.make_minimal_ordered_authors
+        # the following works for post with headers
+        response_code = post '/api/v2/datasets', params: @meta.json, headers: default_authenticated_headers
+        output = response_body_hash
+        expect(response_code).to eq(201)
+        expect(/doi:10./).to match(output[:identifier])
+        hsh = @meta.hash
+        expect(hsh[:title]).to eq(output[:title])
+        expect(hsh[:abstract]).to eq(output[:abstract])
+        # should be swapped because we put reverse order
+        in_author = hsh[:authors].first
+        out_author = output[:authors].last
+        expect(out_author[:email]).to eq(in_author[:email])
+        expect(out_author[:affiliation]).to eq(in_author[:affiliation])
+      end
+
       it 'creates a new dataset from minimal metadata with funder' do
         # the following works for post with headers
         funder = @meta.add_funder

--- a/spec/requests/stash_datacite/authors_controller_spec.rb
+++ b/spec/requests/stash_datacite/authors_controller_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+require 'uri'
+require_relative '../stash_api/helpers'
+
+# see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
+module StashDatacite
+  RSpec.describe AuthorsController, type: :request do
+
+    before(:each) do
+      @user = create(:user, role: 'user')
+      @resource = create(:resource, user_id: @user.id)
+      @authors = Array.new(7) { |_i| create(:author, resource: @resource) }
+      allow_any_instance_of(AuthorsController).to receive(:session).and_return({ user_id: @user.id }.to_ostruct)
+    end
+
+    describe 'reorder' do
+      it 'detects if not all author ids are for same resource' do
+        @resource2 = create(:resource, user_id: @user.id)
+        @bad_author = create(:author, resource: @resource2)
+        update_info = (@authors + [@bad_author]).map{|author| {id: author.id, order: author.author_order} }
+
+        response_code = patch "/stash_datacite/authors/reorder",
+                             params: update_info.to_json,
+                             headers: default_json_headers
+
+        expect(response_code).to eq(400) # gives 400, bad request
+      end
+
+      it "detects if user not authorized to modify this resource" do
+        @user2 = create(:user, role: 'user')
+        @resource2 = create(:resource, user_id: @user2.id)
+        @authors2 = Array.new(7) { |_i| create(:author, resource: @resource2) }
+        update_info = @authors2.map{|author| {id: author.id, order: author.author_order} }
+
+        response_code = patch "/stash_datacite/authors/reorder",
+                              params: update_info.to_json,
+                              headers: default_json_headers
+
+        expect(response_code).to eq(403) # no permission to modify these
+      end
+
+      it "updates the author order to the order given" do
+        update_info = @authors.map{|author| {id: author.id, order: author.author_order} }.shuffle
+        update_info.map!{|author, idx| {id: author[:id], order: idx} }
+
+        response_code = patch "/stash_datacite/authors/reorder",
+                              params: update_info.to_json,
+                              headers: default_json_headers
+
+        byebug
+      end
+    end
+  end
+end

--- a/spec/requests/stash_datacite/authors_controller_spec.rb
+++ b/spec/requests/stash_datacite/authors_controller_spec.rb
@@ -17,7 +17,7 @@ module StashDatacite
       it 'detects if not all author ids are for same resource' do
         @resource2 = create(:resource, user_id: @user.id)
         @bad_author = create(:author, resource: @resource2)
-        update_info = (@authors + [@bad_author]).map { |author| {id: author.id, order: author.author_order} }
+        update_info = (@authors + [@bad_author]).map { |author| { id: author.id, order: author.author_order } }
 
         response_code = patch '/stash_datacite/authors/reorder',
                               params: update_info.to_json,
@@ -30,7 +30,7 @@ module StashDatacite
         @user2 = create(:user, role: 'user')
         @resource2 = create(:resource, user_id: @user2.id)
         @authors2 = Array.new(7) { |_i| create(:author, resource: @resource2) }
-        update_info = @authors2.map { |author| {id: author.id, order: author.author_order} }
+        update_info = @authors2.map { |author| { id: author.id, order: author.author_order } }
 
         response_code = patch '/stash_datacite/authors/reorder',
                               params: update_info.to_json,
@@ -40,9 +40,9 @@ module StashDatacite
       end
 
       it 'updates the author order to the order given' do
-        update_info = @authors.map { |author| {id: author.id, order: author.author_order} }.shuffle
+        update_info = @authors.map { |author| {  id: author.id, order: author.author_order } }.shuffle
         update_info = update_info.each_with_index.map do |author, idx|
-          {id: author[:id], order: idx}
+          { id: author[:id], order: idx }
         end
 
         response_code = patch '/stash_datacite/authors/reorder',

--- a/spec/requests/stash_datacite/authors_controller_spec.rb
+++ b/spec/requests/stash_datacite/authors_controller_spec.rb
@@ -41,13 +41,22 @@ module StashDatacite
 
       it "updates the author order to the order given" do
         update_info = @authors.map{|author| {id: author.id, order: author.author_order} }.shuffle
-        update_info.map!{|author, idx| {id: author[:id], order: idx} }
+        update_info = update_info.each_with_index.map do |author, idx|
+          {id: author[:id], order: idx}
+        end
 
         response_code = patch "/stash_datacite/authors/reorder",
                               params: update_info.to_json,
                               headers: default_json_headers
 
-        byebug
+        expect(response_code).to eq(200)
+
+        ret_json = JSON.parse(body)
+
+        update_info.each_with_index do |item, idx|
+          expect(item[:id]).to eq(ret_json[idx]['id'])
+          expect(item[:order]).to eq(ret_json[idx]['author_order'])
+        end
       end
     end
   end

--- a/spec/requests/stash_datacite/authors_controller_spec.rb
+++ b/spec/requests/stash_datacite/authors_controller_spec.rb
@@ -17,35 +17,35 @@ module StashDatacite
       it 'detects if not all author ids are for same resource' do
         @resource2 = create(:resource, user_id: @user.id)
         @bad_author = create(:author, resource: @resource2)
-        update_info = (@authors + [@bad_author]).map{|author| {id: author.id, order: author.author_order} }
+        update_info = (@authors + [@bad_author]).map { |author| {id: author.id, order: author.author_order} }
 
-        response_code = patch "/stash_datacite/authors/reorder",
-                             params: update_info.to_json,
-                             headers: default_json_headers
+        response_code = patch '/stash_datacite/authors/reorder',
+                              params: update_info.to_json,
+                              headers: default_json_headers
 
         expect(response_code).to eq(400) # gives 400, bad request
       end
 
-      it "detects if user not authorized to modify this resource" do
+      it 'detects if user not authorized to modify this resource' do
         @user2 = create(:user, role: 'user')
         @resource2 = create(:resource, user_id: @user2.id)
         @authors2 = Array.new(7) { |_i| create(:author, resource: @resource2) }
-        update_info = @authors2.map{|author| {id: author.id, order: author.author_order} }
+        update_info = @authors2.map { |author| {id: author.id, order: author.author_order} }
 
-        response_code = patch "/stash_datacite/authors/reorder",
+        response_code = patch '/stash_datacite/authors/reorder',
                               params: update_info.to_json,
                               headers: default_json_headers
 
         expect(response_code).to eq(403) # no permission to modify these
       end
 
-      it "updates the author order to the order given" do
-        update_info = @authors.map{|author| {id: author.id, order: author.author_order} }.shuffle
+      it 'updates the author order to the order given' do
+        update_info = @authors.map { |author| {id: author.id, order: author.author_order} }.shuffle
         update_info = update_info.each_with_index.map do |author, idx|
           {id: author[:id], order: idx}
         end
 
-        response_code = patch "/stash_datacite/authors/reorder",
+        response_code = patch '/stash_datacite/authors/reorder',
                               params: update_info.to_json,
                               headers: default_json_headers
 

--- a/stash/stash_engine/app/models/stash_engine/author.rb
+++ b/stash/stash_engine/app/models/stash_engine/author.rb
@@ -6,6 +6,9 @@ module StashEngine
     belongs_to :resource, class_name: 'StashEngine::Resource'
     has_and_belongs_to_many :affiliations, class_name: 'StashDatacite::Affiliation', join_table: 'dcs_affiliations_authors'
 
+    # I believe the default to ordering by author oder is fin and it falls back to the ID order (order of creation) as secondary
+    default_scope { order(author_order: :asc, id: :asc) }
+
     accepts_nested_attributes_for :affiliations
 
     EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i.freeze

--- a/stash/stash_engine/db/migrate/20220322215307_add_author_order_to_stash_engine_authors.rb
+++ b/stash/stash_engine/db/migrate/20220322215307_add_author_order_to_stash_engine_authors.rb
@@ -1,0 +1,5 @@
+class AddAuthorOrderToStashEngineAuthors < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stash_engine_authors, :author_order, :integer, default: nil
+  end
+end


### PR DESCRIPTION
- Makes default order by the author order id if present
- Adds to api as the field "order" and allows viewing and setting and adds to swagger
- Adds test to model (shuffling authors)

Looked in our UI and it orders correctly on test data I put in manually in all the UI pages and also outputs to Merritt/Datacite and other places correctly since it's not default order if the order gets set.

(I put in names as originalnumber for the original number and reordernumber for the new order.)

![Screen Shot 2022-03-24 at 3 19 09 PM](https://user-images.githubusercontent.com/105433/160026857-cd50c657-a42b-43b3-86ec-28aab9e16b25.png)

