### PR TITLE
Remove old debugging array

### DIFF
--- a/stash/stash_engine/app/models/stash_engine/ror_org.rb
+++ b/stash/stash_engine/app/models/stash_engine/ror_org.rb
@@ -12,11 +12,6 @@ module StashEngine
       query = query.downcase
       results = []
 
-      x = []
-      all.each do |r|
-        x << { id: r.ror_id, name: r.name }
-      end
-
       # First, find matches at the beginning of the name string, or anywhere in the
       # acronyms/aliases
       resp = where('LOWER(name) LIKE ? OR LOWER(acronyms) LIKE ? or LOWER (aliases) LIKE ?',


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1712

This extra array had been left in from previous debugging. Although Scott was seeing extended load times for it, I was only seeing a fraction of a second, so I didn't notice that it was still in place.