### PR TITLE
Require at least one funder

### DIFF
--- a/app/javascript/react/components/MetadataEntry/FunderAutocomplete.js
+++ b/app/javascript/react/components/MetadataEntry/FunderAutocomplete.js
@@ -53,10 +53,10 @@ export default function FunderAutocomplete({
           const similarity = stringSimilarity.compareTwoStrings(item.name, qt) + (item.name.startsWith(qt) ? 1 : 0);
           return {...item, similarity};
         });
-          list.sort((x, y) => ((x.similarity < y.similarity) ? 1 : -1));
-	  // Add 'N/A' to the top of the list in case there is no funder
-	  const na_item = { id: 0, name: 'N/A', uri: '0'} 
-	  list.unshift(na_item);
+        list.sort((x, y) => ((x.similarity < y.similarity) ? 1 : -1));
+        // Add 'N/A' to the top of the list in case there is no funder
+        const na_item = {id: 0, name: 'N/A', uri: '0'};
+        list.unshift(na_item);
         return list;
       });
   }

--- a/app/javascript/react/components/MetadataEntry/FunderAutocomplete.js
+++ b/app/javascript/react/components/MetadataEntry/FunderAutocomplete.js
@@ -53,7 +53,10 @@ export default function FunderAutocomplete({
           const similarity = stringSimilarity.compareTwoStrings(item.name, qt) + (item.name.startsWith(qt) ? 1 : 0);
           return {...item, similarity};
         });
-        list.sort((x, y) => ((x.similarity < y.similarity) ? 1 : -1));
+          list.sort((x, y) => ((x.similarity < y.similarity) ? 1 : -1));
+	  // Add 'N/A' to the top of the list in case there is no funder
+	  const na_item = { id: 0, name: 'N/A', uri: '0'} 
+	  list.unshift(na_item);
         return list;
       });
   }

--- a/app/javascript/react/components/MetadataEntry/FunderForm.js
+++ b/app/javascript/react/components/MetadataEntry/FunderForm.js
@@ -82,7 +82,7 @@ function FunderForm({
                                       {
                                         htmlId: `contrib_${contributor.id}`,
                                         labelText: 'Granting Organization',
-                                        isRequired: false,
+                                        isRequired: true,
                                       }
                                     }
             />

--- a/app/javascript/react/components/MetadataEntry/GenericNameIdAutocomplete.js
+++ b/app/javascript/react/components/MetadataEntry/GenericNameIdAutocomplete.js
@@ -115,7 +115,7 @@ export default function GenericNameIdAutocomplete(
           aria-labelledby={`label_${htmlId}`}
         />
         { !acID && isRequired
-          ? <span title={`${labelText} not found. Select the correct ${labelText} from the auto-complete list.`}>&#x2753;</span>
+          ? <span title={`${labelText} not found. Select the correct ${labelText} from the auto-complete list. If no $labelText} is not applicable, enter N/A.`}>&#x2753;</span>
           : ''}
         <ul
           {...getMenuProps()}

--- a/app/javascript/react/components/MetadataEntry/GenericNameIdAutocomplete.js
+++ b/app/javascript/react/components/MetadataEntry/GenericNameIdAutocomplete.js
@@ -116,8 +116,8 @@ export default function GenericNameIdAutocomplete(
         />
         { !acID && isRequired
           ? (
-            <span title={`${labelText} not found. Select the correct ${labelText} from the auto-complete list.
-                          If no $labelText} is not applicable, enter N/A.`}
+            <span title={`${labelText} not found. Select the correct ${labelText} from the auto-complete list. `
+                          + `If no ${labelText} is applicable, enter N/A.`}
             >&#x2753;
             </span>
           )

--- a/app/javascript/react/components/MetadataEntry/GenericNameIdAutocomplete.js
+++ b/app/javascript/react/components/MetadataEntry/GenericNameIdAutocomplete.js
@@ -115,7 +115,12 @@ export default function GenericNameIdAutocomplete(
           aria-labelledby={`label_${htmlId}`}
         />
         { !acID && isRequired
-          ? <span title={`${labelText} not found. Select the correct ${labelText} from the auto-complete list. If no $labelText} is not applicable, enter N/A.`}>&#x2753;</span>
+          ? (
+            <span title={`${labelText} not found. Select the correct ${labelText} from the auto-complete list.
+                          If no $labelText} is not applicable, enter N/A.`}
+            >&#x2753;
+            </span>
+          )
           : ''}
         <ul
           {...getMenuProps()}

--- a/app/models/stash_datacite/resource/dataset_validations.rb
+++ b/app/models/stash_datacite/resource/dataset_validations.rb
@@ -132,7 +132,8 @@ module StashDatacite
       def funder
         funder_require_date = '2022-04-13'
         if (@resource.contributors.blank? || @resource.contributors.first.contributor_name.blank?) &&
-           @resource.identifier.created_at > funder_require_date
+           @resource.identifier.created_at > funder_require_date &&
+           @resource.identifer.pub_state == 'unpublished'
           return ErrorItem.new(message: 'Fill in a {funder}. Use "N/A" if there is no funder associated with the dataset.',
                                page: metadata_page(@resource),
                                ids: ['funder_fieldset'])

--- a/app/models/stash_datacite/resource/dataset_validations.rb
+++ b/app/models/stash_datacite/resource/dataset_validations.rb
@@ -60,6 +60,7 @@ module StashDatacite
         err << title
         err << authors
         err << research_domain
+        err << funder
         err << abstract
 
         err << s3_error_uploads
@@ -124,6 +125,17 @@ module StashDatacite
           return ErrorItem.new(message: 'Fill in a {research domain}',
                                page: metadata_page(@resource),
                                ids: ["fos_subjects__#{@resource.id}"])
+        end
+        []
+      end
+
+      def funder
+        funder_require_date = '2022-04-13'
+        if (@resource.contributors.blank? || @resource.contributors.first.contributor_name.blank?) &&
+           @resource.identifier.created_at > funder_require_date
+          return ErrorItem.new(message: 'Fill in a {funder}. Use "N/A" if there is no funder associated with the dataset.',
+                               page: metadata_page(@resource),
+                               ids: ['funder_fieldset'])
         end
         []
       end

--- a/app/models/stash_datacite/resource/dataset_validations.rb
+++ b/app/models/stash_datacite/resource/dataset_validations.rb
@@ -130,7 +130,7 @@ module StashDatacite
       end
 
       def funder
-        funder_require_date = '2022-04-13'
+        funder_require_date = '2022-04-14'
         if (@resource.contributors.blank? || @resource.contributors.first.contributor_name.blank?) &&
            @resource.identifier.created_at > funder_require_date &&
            @resource.identifer.pub_state == 'unpublished'

--- a/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
+++ b/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
@@ -44,7 +44,7 @@
     </div>
   </div>
 
-  <fieldset class="c-fieldset">
+  <fieldset class="c-fieldset" id="funder_fieldset">
     <legend class="c-fieldset__legend">Funding</legend>
     <div className="js-contributors_form">
       <%= react_component('components/MetadataEntry/Funders',

--- a/stash/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -199,6 +199,8 @@ module StashEngine
     end
 
     def remove_placeholder_funders
+      return unless resource.present?
+
       resource.update(contributors: resource.contributors.reject { |funder| funder.contributor_name&.upcase == 'N/A' })
     end
 


### PR DESCRIPTION
https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1716

Require a funder to be entered. 

Since this changes the help text in GenericNameAutocomplete, the note about "N/A" is also shown in the help text for affiliations. This seemed cleaner than making it customized to the funder field, but I'm certainly open to feedback on this approach.