### PR TITLE
Hide help text 

### DIFF
--- a/app/javascript/react/components/MetadataEntry/Authors.js
+++ b/app/javascript/react/components/MetadataEntry/Authors.js
@@ -202,10 +202,10 @@ export default function Authors({
 
   return (
     <section>
-      <p id="global-help">
+      <p id="global-help" className="offscreen">
         Activate the reorder button and use the arrow keys to reorder the list or use your mouse to
         drag/reorder. Press escape to cancel the reordering.
-        <span className="offscreen">Ensure screen reader is in focus mode.</span>
+        <span>Ensure screen reader is in focus mode.</span>
       </p>
       <ul className="dragon-drop-list" aria-labelledby="authors-head" ref={dragonRef}>
         {authors

--- a/app/javascript/react/components/MetadataEntry/Title.js
+++ b/app/javascript/react/components/MetadataEntry/Title.js
@@ -46,10 +46,7 @@ function Title({resource, path}) {
     >
       {(formik) => (
         <Form className="c-input">
-          <strong>
-            <label className="required c-input__label" htmlFor={`title__${resource.id}`}>Dataset Title</label>
-          </strong>
-          <br />
+          <label className="required c-input__label" htmlFor={`title__${resource.id}`}>Dataset Title</label>
           <Field
             name="title"
             type="text"


### PR DESCRIPTION
so people with screen readers can still access it the display. was disliked and the default message there from Dragon Drop might be useful to screen readers.

Also unbolded the title since it was the only one that was bold and none of the other labels.