### PR TITLE
Update email validation regex

### DIFF
--- a/app/models/stash_engine/author.rb
+++ b/app/models/stash_engine/author.rb
@@ -11,9 +11,7 @@ module StashEngine
 
     accepts_nested_attributes_for :affiliations
 
-    EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i.freeze
-
-    validates :author_email, format: EMAIL_REGEX, allow_blank: true
+    validates :author_email, format: URI::MailTo::EMAIL_REGEXP, allow_blank: true
 
     before_save :strip_whitespace
 


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1708

We already had email validation in place, so the issue described in the ticket must have not been processed by the UI (e.g., updated directly in the DB or migrated from the v1 system).

But I think it's useful to use the "official" email validation regex instead of our own.