### PR TITLE
push people to datadryad.org from www.datadryad.org

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  match '(*any)', to: redirect(subdomain: ''), via: :all, constraints: {subdomain: 'www'}
+
   use_doorkeeper
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rails routes".


### PR DESCRIPTION
This will simplify our life and mean we don't have to check everything dependent on domain names to support the www domain name, also. (from https://stackoverflow.com/questions/22235977/ruby-on-rails-redirecting-www-to-non-www-version-of-site )