### PR TITLE
Took out the YUI dependency

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,2 @@
 module ApplicationHelper
-
 end

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
-  config.assets.css_compressor = :yui
+  config.assets.css_compressor = :uglifier
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/development.rb.stagelike
+++ b/config/environments/development.rb.stagelike
@@ -27,7 +27,7 @@ Rails.application.configure do
     
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
-  config.assets.css_compressor = :yui
+  config.assets.css_compressor = :uglifier
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/migration.rb
+++ b/config/environments/migration.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
-  config.assets.css_compressor = :yui
+  config.assets.css_compressor = :uglifier
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = Uglifier.new(harmony: true)
-  config.assets.css_compressor = :yui
+  config.assets.css_compressor = :uglifier
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = Uglifier.new(harmony: true)
-  config.assets.css_compressor = :yui
+  config.assets.css_compressor = :uglifier
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
YUI (Yahoo UI) css minifier isn't the rails default.  We originally switched to it like a decade ago because the uglifier css minifier had a bug where it didn't correctly encode something when minifying and caused errors.

The time we did that was probably around 7 or more years ago, so I'm really hoping any bugs in Uglifier encoding and minification have been fixed by now.

I'd rather get rid of the extra dependencies that we don't really need when we can.  I already took YUI out of our Gemfile but forgot to change up the css minification in some environments.