### PR TITLE
Fixes the css compressor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'coffee-rails', '~> 5.0'
 gem 'jquery-rails', '~> 4.4.0'
 # gem 'libv8', '~> 3.16.1' # I think taken care of as dependency of mini_racer
 gem 'mini_racer'
-gem 'sass-rails', '~> 5.0'
+gem 'sassc-rails', '~> 2.1.2' # the default for newer rails, no need for yui and already used by bootstrap or something else
 # gem 'therubyracer', platforms: :ruby # this is very outdated and people say to use mini_racer instead if possible
 gem 'turbolinks'
 gem 'uglifier', '~> 4.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -628,17 +628,6 @@ GEM
     sanitize (6.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.1.0)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -853,7 +842,7 @@ DEPENDENCIES
   rspec-rails
   rubocop (~> 0.90.0)
   rubyzip (~> 2.3, >= 2.3.2)
-  sass-rails (~> 5.0)
+  sassc-rails (~> 2.1.2)
   selenium-webdriver
   serrano (~> 1.0)
   shoulda

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
-  config.assets.css_compressor = :uglifier
+  config.assets.css_compressor = :terser
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -25,9 +25,8 @@ Rails.application.configure do
 
   config.public_file_server.enabled = true					
 
-  # Compress JavaScripts and CSS.
+  # Compress JavaScripts and CSS, default is sassc without being specified for css
   config.assets.js_compressor = :uglifier
-  config.assets.css_compressor = :terser
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/development.rb.stagelike
+++ b/config/environments/development.rb.stagelike
@@ -27,7 +27,7 @@ Rails.application.configure do
     
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
-  config.assets.css_compressor = :uglifier
+  config.assets.css_compressor = :terser
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/development.rb.stagelike
+++ b/config/environments/development.rb.stagelike
@@ -25,9 +25,8 @@ Rails.application.configure do
   # config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?	
   config.public_file_server.enabled = true					
     
-  # Compress JavaScripts and CSS.
+  # Compress JavaScripts and CSS, default is sassc without being specified for css
   config.assets.js_compressor = :uglifier
-  config.assets.css_compressor = :terser
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/migration.rb
+++ b/config/environments/migration.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
-  config.assets.css_compressor = :uglifier
+  config.assets.css_compressor = :terser
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/migration.rb
+++ b/config/environments/migration.rb
@@ -28,9 +28,8 @@ Rails.application.configure do
   config.public_file_server.enabled = true
 
 
-  # Compress JavaScripts and CSS.
+  # Compress JavaScripts and CSS, default is sassc without being specified for css
   config.assets.js_compressor = :uglifier
-  config.assets.css_compressor = :terser
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,9 +32,8 @@ Rails.application.configure do
   # Allow serving files from the /public directory
   config.public_file_server.enabled = true
 
-  # Compress JavaScripts and CSS.
+  # Compress JavaScripts and CSS, default is sassc without being specified for css
   config.assets.js_compressor = Uglifier.new(harmony: true)
-  config.assets.css_compressor = :terser
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = Uglifier.new(harmony: true)
-  config.assets.css_compressor = :uglifier
+  config.assets.css_compressor = :terser
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -27,11 +27,10 @@ Rails.application.configure do
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   config.require_master_key = true
 
-  config.public_file_server.enabled = true					
+  config.public_file_server.enabled = true
 
-  # Compress JavaScripts and CSS.
+  # Compress JavaScripts and CSS, default is sassc without being specified for css
   config.assets.js_compressor = Uglifier.new(harmony: true)
-  config.assets.css_compressor = :terser
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
-  # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
+  # or in config/master.key. This key is used to decrypt credentials (and other encrypted files). x
   config.require_master_key = true
 
   config.public_file_server.enabled = true

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = Uglifier.new(harmony: true)
-  config.assets.css_compressor = :uglifier
+  config.assets.css_compressor = :terser
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/lib/stash_discovery/engine.rb
+++ b/lib/stash_discovery/engine.rb
@@ -8,7 +8,6 @@ require 'rsolr'
 # For undocumented reasons, sass-rails won't load without an explicit require
 require 'bootstrap'
 # require 'bootstrap-sass'
-require 'sass-rails'
 require 'twitter-typeahead-rails'
 
 module StashDiscovery

--- a/spec/javascript/react/components/MetadataEntry/Keywords.test.js
+++ b/spec/javascript/react/components/MetadataEntry/Keywords.test.js
@@ -57,7 +57,7 @@ describe('Keywords', () => {
     });
   })
 
-  xit("adds a keyword to the document", async () => {
+  it("adds a keyword to the document", async () => {
 
     const extraSubj = {
       id: faker.datatype.number(),

--- a/spec/javascript/react/components/MetadataEntry/Keywords.test.js
+++ b/spec/javascript/react/components/MetadataEntry/Keywords.test.js
@@ -57,7 +57,7 @@ describe('Keywords', () => {
     });
   })
 
-  it("adds a keyword to the document", async () => {
+  xit("adds a keyword to the document", async () => {
 
     const extraSubj = {
       id: faker.datatype.number(),


### PR DESCRIPTION
This only happens on stage/production, so I had a heck of a time getting it right.

We're already using sassc from a bootstrap dependency and it can compress assets.  It is faster and the default if present.  I removed the lines for this in the environments and got it to successfully deploy on stage after a bunch of attempts.