### PR TITLE
Fix blacklight intercepting landing page renders for some kinds of identifiers

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,22 +143,6 @@ Rails.application.routes.draw do
   # Endpoint for LinkOut
   get :discover, to: 'catalog#discover'
 
-  # the ones below coming from new routing for geoblacklight
-  #--------------------------------------------------------
-  mount Geoblacklight::Engine => 'geoblacklight'
-  mount Blacklight::Engine => '/'
-
-  get '/search', to: 'catalog#index'
-
-  concern :searchable, Blacklight::Routes::Searchable.new
-
-  resource :catalog, only: [:index], as: 'catalog', path: '/search', controller: 'catalog' do
-    concerns :searchable
-  end
-
-  # this is kind of hacky, but it directs our search results to open links to the landing pages
-  resources :solr_documents, only: [:show], path: '/stash/dataset', controller: 'catalog'
-
   ########################## StashEngine support ######################################
 
   scope module: 'stash_engine', path: '/stash' do    
@@ -329,6 +313,22 @@ Rails.application.routes.draw do
     get 'journals', to: 'journals#index'
     
   end
+
+  # the ones below coming from new routing for geoblacklight
+  #--------------------------------------------------------
+  mount Geoblacklight::Engine => 'geoblacklight'
+  mount Blacklight::Engine => '/'
+
+  get '/search', to: 'catalog#index'
+
+  concern :searchable, Blacklight::Routes::Searchable.new
+
+  resource :catalog, only: [:index], as: 'catalog', path: '/search', controller: 'catalog' do
+    concerns :searchable
+  end
+
+  # this is kind of hacky, but it directs our search results to open links to the landing pages
+  resources :solr_documents, only: [:show], path: '/stash/dataset', controller: 'catalog'
   
   ########################## StashDatacite support ######################################
 


### PR DESCRIPTION
DOIs that had just one dot in them and an encoded slash seemed like they were being intercepted by blacklight instead of our dataset landing page.  I believe it was interpreting everything after the dot as a file extension to indicate a file type to render (which is garbage).  Maybe when the slash was in there it decided it wasn't the end of the URL so didn't interpret things that way.

```
Processing by CatalogController#show as
  Parameters: {"id"=>"doi:10"}
```

It seems like geoblacklight was now being loaded earlier in the routes and so takes precedence for some specific ids/urls.

I moved the geoblacklight routes down below the (former) stash engine ones so that stash_engine gets priority over geoblacklight and landing URLs don't get intercepted.

We have a lot of garbage in there, but a URL like http://localhost:3000/stash/dataset/doi:10.5072%2FFK2B56NP8K exposed the problem on my local machine.  Also a search like http://localhost:3000/search?q=-%22data+from%22 gives (mostly) good URLs and a maybe 30% to 50% had this problem.