### PR TITLE
Allow curators to have HTML code editing

### DIFF
--- a/app/javascript/react/components/MetadataEntry/Description.js
+++ b/app/javascript/react/components/MetadataEntry/Description.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import {showSavedMsg, showSavingMsg} from '../../../lib/utils';
 
 export default function Description({
-  dcsDescription, path, mceKey, mceLabel, isCurator
+  dcsDescription, path, mceKey, mceLabel, isCurator,
 }) {
   const csrf = document.querySelector("meta[name='csrf-token']")?.getAttribute('content');
 
@@ -77,5 +77,5 @@ Description.propTypes = {
   path: PropTypes.string.isRequired,
   mceKey: PropTypes.string.isRequired,
   mceLabel: PropTypes.object.isRequired,
-  isCurator: PropTypes.bool.isRequired
+  isCurator: PropTypes.bool.isRequired,
 };

--- a/app/javascript/react/components/MetadataEntry/Description.js
+++ b/app/javascript/react/components/MetadataEntry/Description.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import {showSavedMsg, showSavingMsg} from '../../../lib/utils';
 
 export default function Description({
-  dcsDescription, path, mceKey, mceLabel,
+  dcsDescription, path, mceKey, mceLabel, isCurator
 }) {
   const csrf = document.querySelector("meta[name='csrf-token']")?.getAttribute('content');
 
@@ -58,7 +58,8 @@ export default function Description({
           toolbar: 'help | formatselect | '
                   + 'bold italic strikethrough forecolor backcolor removeformat | alignleft aligncenter '
                   + 'alignright | bullist numlist outdent indent | '
-                  + 'table link hr blockquote | superscript subscript charmap | undo redo | fontsizeselect | ltr rtl ',
+                  + 'table link hr blockquote | superscript subscript charmap | undo redo | fontsizeselect | ltr rtl '
+                  + `${(isCurator ? 'code' : '')}`,
           table_toolbar: 'tableprops tabledelete | tableinsertrowbefore tableinsertrowafter tabledeleterow | '
                   + 'tableinsertcolbefore tableinsertcolafter tabledeletecol',
           content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:14px }',
@@ -76,4 +77,5 @@ Description.propTypes = {
   path: PropTypes.string.isRequired,
   mceKey: PropTypes.string.isRequired,
   mceLabel: PropTypes.object.isRequired,
+  isCurator: PropTypes.bool.isRequired
 };

--- a/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
+++ b/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
@@ -69,7 +69,8 @@
                         dcsDescription: @metadata_entry.abstract,
                         path: descriptions_update_path,
                         mceKey: APP_CONFIG[:mce_key],
-                        mceLabel: {label: 'Abstract', required: true, describe: ''}) %>
+                        mceLabel: {label: 'Abstract', required: true, describe: ''},
+                        isCurator: current_user&.curator?) %>
 
     <h2 class="o-heading__page-span">Data Description</h2>
 
@@ -89,7 +90,8 @@
                     dcsDescription: @metadata_entry.methods,
                     path: descriptions_update_path,
                     mceKey: APP_CONFIG[:mce_key],
-                    mceLabel: {label: 'Methods:', required: false, describe: ' How was this dataset collected? How has it been processed?'}) %>
+                    mceLabel: {label: 'Methods:', required: false, describe: ' How was this dataset collected? How has it been processed?'},
+                    isCurator: current_user&.curator?) %>
 
     <%= react_component('components/MetadataEntry/Description',
                     dcsDescription: @metadata_entry.other,
@@ -98,7 +100,8 @@
                     mceLabel: {label: 'Usage Notes:', required: false,
                                describe: ' What else would someone need to know to use this dataset?' +
                                    ' Are there any missing values? Please upload any files necessary for re-use ' +
-                                   '(i.e. ReadMe files) and note them.'}) %>
+                                   '(i.e. ReadMe files) and note them.'},
+                    isCurator: current_user&.curator?) %>
 
     <h2 class="o-heading__page-span">Related Works</h2>
 


### PR DESCRIPTION
It's last on the toolbar under the ... icon to expand.  Only curators and above get it and uses the built in tinyMCE option for this.

I didn't allow it for normal people since allowing to edit all code may make malformed HTML (which the plugin seems to eliminate) and also allows people to do things like insert images or other functionality which we may not want.

We once had someone who made an entire paper to post for free in the old Dash system by editing code, encoding photos inline and the rest.  It had photos of churches and other things. Allowing things like photos is a can of worms since then we also need to host them, encode them inline or be afraid that externally supplied photos will go dead and break the rendering.

So I think maybe it's best to keep normal users from having HTML editing.

PS.  Javascript is stripped from the html when things are saved.