### PR TITLE
Detect if previously public and don't send doi if so

### DIFF
--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -694,6 +694,12 @@ module StashEngine
       all.submitted.with_visibility(states: %w[embargoed]).where('stash_engine_resources.publication_date < ?', Time.now)
     end
 
+    # returns boolean indicating if a version before the current resource has been made public (metadata view set to true)
+    def previously_public?
+      prev = self.class.where(identifier_id: identifier_id).where('created_at < ?', created_at).where(meta_view: true)
+      prev.count.positive?
+    end
+
     # -----------------------------------------------------------
     # editor
 

--- a/lib/stash/doi/id_gen.rb
+++ b/lib/stash/doi/id_gen.rb
@@ -49,7 +49,7 @@ module Stash
         log_info("updating identifier landing page (#{landing_page_url}) and metadata for resource #{resource.id} (#{resource.identifier_str})")
         sp = Stash::Merritt::SubmissionPackage.new(resource: resource, packaging: nil)
         dc4_xml = sp.dc4_builder.contents
-        update_metadata(dc4_xml: dc4_xml, landing_page_url: landing_page_url) unless resource.skip_datacite_update
+        update_metadata(dc4_xml: dc4_xml, landing_page_url: landing_page_url) unless resource.skip_datacite_update || resource.previously_public?
       end
 
       def landing_page_url

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -580,6 +580,30 @@ module StashEngine
       end
     end
 
+    describe '#previously_public?' do
+      before(:each) do
+        @identifier = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI', pub_state: nil)
+      end
+
+      it 'returns true if a previous resource had metadata view set to true' do
+        @resource1 = Resource.create(user_id: user.id, identifier_id: @identifier.id, meta_view: true, file_view: false)
+        sleep 1 # so timestamps are separated
+        @resource2 = Resource.create(user_id: user.id, identifier_id: @identifier.id, meta_view: false, file_view: false)
+        # resource for different identifier, below
+        Resource.create(user_id: user.id, meta_view: true, file_view: false)
+        expect(@resource2.previously_public?).to eq(true)
+      end
+
+      it 'returns false if a previous resource had no metadata view exposed' do
+        @resource1 = Resource.create(user_id: user.id, identifier_id: @identifier.id, meta_view: false, file_view: false)
+        sleep 1 # so timestamps are separated
+        @resource2 = Resource.create(user_id: user.id, identifier_id: @identifier.id, meta_view: false, file_view: false)
+        # resource for different identifier, below
+        Resource.create(user_id: user.id, meta_view: true, file_view: false)
+        expect(@resource2.previously_public?).to eq(false)
+      end
+    end
+
     describe '#zenodo_published?' do
       before(:each) do
         @resource = create(:resource, identifier: create(:identifier))

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -586,20 +586,18 @@ module StashEngine
       end
 
       it 'returns true if a previous resource had metadata view set to true' do
-        @resource1 = Resource.create(user_id: user.id, identifier_id: @identifier.id, meta_view: true, file_view: false)
-        sleep 1 # so timestamps are separated
+        @resource1 = Resource.create(user_id: user.id, created_at: '2020-01-03', identifier_id: @identifier.id, meta_view: true, file_view: false)
         @resource2 = Resource.create(user_id: user.id, identifier_id: @identifier.id, meta_view: false, file_view: false)
         # resource for different identifier, below
-        Resource.create(user_id: user.id, meta_view: true, file_view: false)
+        Resource.create(user_id: user.id, meta_view: true, created_at: '2020-01-03', file_view: false)
         expect(@resource2.previously_public?).to eq(true)
       end
 
       it 'returns false if a previous resource had no metadata view exposed' do
-        @resource1 = Resource.create(user_id: user.id, identifier_id: @identifier.id, meta_view: false, file_view: false)
-        sleep 1 # so timestamps are separated
+        @resource1 = Resource.create(user_id: user.id, created_at: '2020-01-03', identifier_id: @identifier.id, meta_view: false, file_view: false)
         @resource2 = Resource.create(user_id: user.id, identifier_id: @identifier.id, meta_view: false, file_view: false)
         # resource for different identifier, below
-        Resource.create(user_id: user.id, meta_view: true, file_view: false)
+        Resource.create(user_id: user.id, created_at: '2020-01-03', meta_view: true, file_view: false)
         expect(@resource2.previously_public?).to eq(false)
       end
     end


### PR DESCRIPTION
PS.  You may not want to merge this into the main branch.  I can probably just deploy from this branch temporarily and if it's not merged into main for our next full release then you don't have to take it back out.

Adds a function to resource to detect if one was previously public.

Adds logic to skip updating doi if it was previously public.