### PR TITLE
Add filtering by journal sponsor/publisher

### DIFF
--- a/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -16,6 +16,8 @@ module StashEngine
     # the admin datasets main page showing users and stats, but slightly different in scope for curators vs tenant admins
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def index
+      # These limits are imposed by the user's permissions
+      # Limits due to the current search/filter settings are handled within CurationTableRow
       my_tenant_id = (%w[admin tenant_curator].include?(current_user.role) ? current_user.tenant_id : nil)
       tenant_limit = (%w[admin tenant_curator].include?(current_user.role) ? current_user.tenant : nil)
       journal_limit = (if current_user.role != 'superuser' &&

--- a/app/helpers/stash_engine/admin_datasets_helper.rb
+++ b/app/helpers/stash_engine/admin_datasets_helper.rb
@@ -7,6 +7,10 @@ module StashEngine
       StashEngine::Tenant.all.map { |item| [item.short_name, item.tenant_id] }
     end
 
+    def sponsor_select
+      StashEngine::JournalOrganization.all.map { |item| [item.name, item.id] }
+    end
+
     def status_select(statuses = [])
       statuses = StashEngine::CurationActivity.statuses if statuses.empty?
       statuses.sort { |a, b| a <=> b }.map do |status|

--- a/app/helpers/stash_engine/sortable_table_helper.rb
+++ b/app/helpers/stash_engine/sortable_table_helper.rb
@@ -49,7 +49,8 @@ module StashEngine
     # Passthrough for query parameters that are allowed on pages with sortable tables
     def sortable_table_params
       params.permit(:q, :sort, :direction, :page, :page_size, :show_all,
-                    :tenant, :editor_id, :curation_status, :publication_name, :all_advanced)
+                    :tenant, :editor_id, :curation_status, :publication_name, :sponsor_org,
+                    :all_advanced)
     end
 
     # Generate a string for ordering ActiveRecord selections. If no sort order

--- a/app/views/stash_engine/admin_datasets/_filter.html.erb
+++ b/app/views/stash_engine/admin_datasets/_filter.html.erb
@@ -21,10 +21,18 @@
       <%= text_field_tag(:publication_name, params[:publication_name], class: 'c-horizontal-form__input--search', id: 'publication_name') %>
   <% end %>
   </p>
+  <p>
+  <% if current_user.curator? %>
+    <label for="sponsor_org">Sponsoring Org:</label>
+    <%= select_tag(:sponsor_org, options_for_select( [['Sponsoring Org', '']] + sponsor_select, params[:sponsor_org]),
+                   class: 'c-horizontal-form__input', onchange: "this.form.submit();") %>
+
+  <% end %>
+  </p>
  
   <a href="#" class="c-horizontal-form__input" id="filter_resetter">Reset all filters</a>
 
-  <% params.except(:controller, :action, :tenant, :curation_status, :editor_id,
+  <% params.except(:controller, :action, :tenant, :curation_status, :sponsor_org, :editor_id,
 		   :commit, :page, :page_size, :show_all, :publication_name).each_pair do |k,v| %>
     <%= hidden_field_tag k, v, id: "filter_#{k}" %>
   <% end %>
@@ -38,6 +46,7 @@
     $("#editor_id option[value='']").prop('selected',true);
     $("#curation_status option[value='']").prop('selected',true);
     $('#publication_name[type="text"]').val('');
+    $("#sponsor_org option[value='']").prop('selected',true);
     $("#filter_form").submit();
   });
 


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1721

On the Admin Dashboard page, add a filtering option for the Sponsoring Organization. 

All of these filters are starting to occupy a lot of vertical space, but it's kind of unavoidable if we want to retain the full width of the input fields to display the names of journals and organizations. Any great ideas on how to make it more compact?