### PR TITLE
This changes the identifier relationships to DataCite (and others)

### DIFF
--- a/app/controllers/stash_datacite/publications_controller.rb
+++ b/app/controllers/stash_datacite/publications_controller.rb
@@ -99,7 +99,7 @@ module StashDatacite
       ri = RelatedIdentifier.create(resource_id: @resource.id,
                                     related_identifier: standard_doi,
                                     related_identifier_type: 'doi',
-                                    relation_type: 'cites', # based on what Daniella defined for auto-added articles from elsewhere
+                                    relation_type: 'iscitedby',
                                     work_type: 'primary_article',
                                     hidden: false)
       ri.update(verified: ri.live_url_valid?) # do this separately since we need the doi in standard format in object to check

--- a/app/controllers/stash_engine/widgets_controller.rb
+++ b/app/controllers/stash_engine/widgets_controller.rb
@@ -39,7 +39,7 @@ module StashEngine
 
     def require_id_exists
       pmid = InternalDatum.find_by(data_type: 'pubmedID', value: @pmid)
-      doi = StashDatacite::RelatedIdentifier.find_by(related_identifier_type: 'doi', relation_type: 'cites',
+      doi = StashDatacite::RelatedIdentifier.find_by(related_identifier_type: 'doi', relation_type: 'isCitedBy',
                                                      related_identifier: @doi)
       @stash_id = pmid.stash_identifier unless pmid.blank?
       @stash_id = doi.resource.identifier if @stash_id.blank? && doi.present?

--- a/app/models/stash_datacite/related_identifier.rb
+++ b/app/models/stash_datacite/related_identifier.rb
@@ -36,7 +36,7 @@ module StashDatacite
                              'is source of': 'issourceof' }.freeze
     # rubocop:enable Naming/ConstantName
 
-    enum work_type: { undefined: 0, article: 1, dataset: 2, preprint:3, software: 4, supplemental_information: 5,
+    enum work_type: { undefined: 0, article: 1, dataset: 2, preprint: 3, software: 4, supplemental_information: 5,
                       primary_article: 6, data_management_plan: 7 } # changing to make the enum index more explicit
 
     enum added_by: { default: 0, zenodo: 1 }

--- a/app/models/stash_datacite/related_identifier.rb
+++ b/app/models/stash_datacite/related_identifier.rb
@@ -162,7 +162,7 @@ module StashDatacite
       doi = standardize_doi(supp_copy.software_doi)
       create(related_identifier: doi,
              related_identifier_type: 'doi',
-             relation_type: 'issupplementto',
+             relation_type: 'issourceof',
              work_type: 'supplemental_information',
              verified: true,
              resource_id: resource.id,

--- a/app/models/stash_datacite/related_identifier.rb
+++ b/app/models/stash_datacite/related_identifier.rb
@@ -36,7 +36,8 @@ module StashDatacite
                              'is source of': 'issourceof' }.freeze
     # rubocop:enable Naming/ConstantName
 
-    enum work_type: %i[undefined article dataset preprint software supplemental_information primary_article data_management_plan]
+    enum work_type: { undefined: 0, article: 1, dataset: 2, preprint:3, software: 4, supplemental_information: 5,
+                      primary_article: 6, data_management_plan: 7 } # changing to make the enum index more explicit
 
     enum added_by: { default: 0, zenodo: 1 }
 
@@ -48,8 +49,12 @@ module StashDatacite
     WORK_TYPE_CHOICES_PLURAL = { article: 'Articles', dataset: 'Datasets', preprint: 'Preprints', software: 'Software',
                                  supplemental_information: 'Supplemental Information' }.with_indifferent_access
 
-    WORK_TYPES_TO_RELATION_TYPE = { article: 'cites', dataset: 'issupplementto', preprint: 'cites', software: 'isderivedfrom',
-                                    supplemental_information: 'ispartof', primary_article: 'cites',
+    WORK_TYPES_TO_RELATION_TYPE = { article: 'iscitedby',
+                                    dataset: 'issupplementto',
+                                    preprint: 'iscitedby',
+                                    software: 'isderivedfrom',
+                                    supplemental_information: 'ispartof',
+                                    primary_article: 'iscitedby',
                                     data_management_plan: 'isdocumentedby' }.with_indifferent_access
 
     # these keys will be case-insensitive matches

--- a/app/models/stash_datacite/related_identifier.rb
+++ b/app/models/stash_datacite/related_identifier.rb
@@ -50,10 +50,10 @@ module StashDatacite
                                  supplemental_information: 'Supplemental Information' }.with_indifferent_access
 
     WORK_TYPES_TO_RELATION_TYPE = { article: 'iscitedby',
-                                    dataset: 'issupplementto',
+                                    dataset: 'issupplementedby',
                                     preprint: 'iscitedby',
                                     software: 'isderivedfrom',
-                                    supplemental_information: 'ispartof',
+                                    supplemental_information: 'issourceof',
                                     primary_article: 'iscitedby',
                                     data_management_plan: 'isdocumentedby' }.with_indifferent_access
 

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -694,6 +694,12 @@ module StashEngine
       all.submitted.with_visibility(states: %w[embargoed]).where('stash_engine_resources.publication_date < ?', Time.now)
     end
 
+    # returns boolean indicating if a version before the current resource has been made public (metadata view set to true)
+    def previously_public?
+      prev = self.class.where(identifier_id: identifier_id).where('created_at < ?', created_at).where(meta_view: true)
+      prev.count.positive?
+    end
+
     # -----------------------------------------------------------
     # editor
 

--- a/documentation/sql_queries/updates_to_relationships.md
+++ b/documentation/sql_queries/updates_to_relationships.md
@@ -1,0 +1,52 @@
+# May 2022, updates to relationships for certain work types
+
+This is some documentation and sql queries to change what work types use which relationships as of May 2022
+with corrections at DataCite.
+
+The changes are the following:
+
+- Article changed from `cites` to `iscitedby`
+- Dataset changed from `issupplementto` to `issupplementedby`
+- Preprint changed from `cites` to `iscitedby`
+- Software stayed the same as `isderivedfrom`
+- Supplemental Information changed from `ispartof` to `issourceof`
+- Primary Article changed from `cites` to `iscitedby`
+- Data Management Plan stayed the same `isdocumentedby`
+
+You can read these relationships as "Our dataset `is<SomethingedBy>` the `<externalItemType>`".
+
+The rails database enum is the following (the info is needed for direct SQL updates):
+
+```ruby
+{ undefined: 0,
+  article: 1,
+  dataset: 2,
+  preprint: 3,
+  software: 4,
+  supplemental_information: 5,
+  primary_article: 6,
+  data_management_plan: 7 }
+```
+
+Our database can be corrected with these three queries.
+
+```sql
+/* update the relationship for articles, preprints and primary articles */
+UPDATE dcs_related_identifiers
+SET relation_type = 'iscitedby'
+WHERE work_type IN (1, 3, 6);
+```
+
+```sql
+/* update the relation for other datasets */
+UPDATE dcs_related_identifiers
+SET relation_type = 'issupplementedby'
+WHERE work_type = 2;
+```
+
+```sql
+/* update the relation for supplemental information */
+UPDATE dcs_related_identifiers
+SET relation_type = 'issourceof'
+WHERE work_type = 5;
+```

--- a/lib/stash/import/crossref.rb
+++ b/lib/stash/import/crossref.rb
@@ -277,7 +277,7 @@ module Stash
         related.assign_attributes({
                                     related_identifier: StashDatacite::RelatedIdentifier.standardize_doi(my_related),
                                     related_identifier_type: 'doi',
-                                    relation_type: 'cites', # based on what Daniella defined for auto-added articles from elsewhere
+                                    relation_type: 'iscitedby',
                                     work_type: 'primary_article',
                                     verified: true,
                                     hidden: false

--- a/lib/stash/zenodo_replicate/metadata_generator.rb
+++ b/lib/stash/zenodo_replicate/metadata_generator.rb
@@ -112,29 +112,34 @@ module Stash
         end
       end
 
+      # this only gets called for data deposits and is basically the same metadata as our dataset
       def related_data
         @resource.related_identifiers.where(verified: true).where(hidden: false).map do |ri|
           { relation: ri.relation_type_friendly&.camelize(:lower), identifier: ri.related_identifier }
         end || []
       end
 
+      # this only gets called for zenodo software deposits, we have to add link back to our dataset from their software
       def related_software
         related = @resource.related_identifiers.where(verified: true).where(hidden: false).where.not(added_by: 'zenodo').map do |ri|
           { relation: ri.relation_type_friendly&.camelize(:lower), identifier: ri.related_identifier }
         end
 
+        # their software is source of our data
         related.push(relation: 'isSourceOf',
                      identifier: StashDatacite::RelatedIdentifier.standardize_doi(@resource.identifier.identifier),
                      scheme: 'doi')
         related || []
       end
 
+      # this only gets called for zenodo supplemental deposits,  we have to add link back to our dataset from their supplemental
       def related_supp
         related = @resource.related_identifiers.where(verified: true).where(hidden: false).where.not(added_by: 'zenodo').map do |ri|
           { relation: ri.relation_type_friendly&.camelize(:lower), identifier: ri.related_identifier }
         end
 
-        related.push(relation: 'isSupplementTo',
+        # their supplemental information isDerivedFrom our dataset
+        related.push(relation: 'isDerivedFrom',
                      identifier: StashDatacite::RelatedIdentifier.standardize_doi(@resource.identifier.identifier),
                      scheme: 'doi')
         related || []

--- a/spec/factories/stash_datacite/related_identifiers.rb
+++ b/spec/factories/stash_datacite/related_identifiers.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     trait :publication_doi do
       related_identifier      { Faker::Pid.doi }
       related_identifier_type { 'doi' }
-      relation_type           { 'cites' }
+      relation_type           { 'iscitedby' }
       work_type { 'article' }
       verified { true }
     end

--- a/spec/lib/stash/zenodo_replicate/metadata_generator_spec.rb
+++ b/spec/lib/stash/zenodo_replicate/metadata_generator_spec.rb
@@ -153,7 +153,7 @@ module Stash
           expect(ids).not_to include(@related_id.related_identifier) # zenodo id for this shouldn't exist
         end
 
-        it 'adds isSupplementTo to the Zenodo software to reference the Dryad dataset' do
+        it 'adds isSourceOf to the Zenodo software to reference the Dryad dataset' do
           ids = @mg.related_identifiers.map { |i| i[:identifier] }
           expect(ids).to include(StashDatacite::RelatedIdentifier.standardize_doi(@resource.identifier.identifier))
         end
@@ -165,7 +165,7 @@ module Stash
 
           test_doi = "https://doi.org/#{rand.to_s[2..3]}.#{rand.to_s[2..5]}/zenodo.#{rand.to_s[2..11]}"
           @related_id = create(:related_identifier, related_identifier: test_doi, related_identifier_type: 'doi',
-                                                    relation_type: 'issupplementto', resource_id: @resource.id,
+                                                    relation_type: 'issourceof', resource_id: @resource.id,
                                                     verified: true, hidden: false, added_by: 'zenodo')
 
           @related_id2 = create(:related_identifier, resource_id: @resource.id, verified: true, hidden: false)
@@ -183,7 +183,8 @@ module Stash
           expect(ids).not_to include(@related_id.related_identifier) # zenodo id for this shouldn't exist
         end
 
-        it 'adds isSupplementTo to the Zenodo software to reference the Dryad dataset' do
+        # the software is the source of the data
+        it 'adds isSourceOf to the Zenodo software to reference the Dryad dataset' do
           ids = @mg.related_identifiers.map { |i| i[:identifier] }
           expect(ids).to include(StashDatacite::RelatedIdentifier.standardize_doi(@resource.identifier.identifier))
         end

--- a/spec/lib/stash_datacite/crossref_spec.rb
+++ b/spec/lib/stash_datacite/crossref_spec.rb
@@ -380,7 +380,7 @@ module Stash
           expect(@resource.contributors.length).to eql(11)
           expect(@resource.related_identifiers.first.related_identifier).to eql(StashDatacite::RelatedIdentifier.standardize_doi(URL))
           expect(@resource.identifier.internal_data.select { |id| id.data_type == 'publicationName' }.first.value).to eql(PUBLISHER)
-          doi = @resource.related_identifiers.select { |id| id.related_identifier_type == 'doi' && id.relation_type == 'cites' }
+          doi = @resource.related_identifiers.select { |id| id.related_identifier_type == 'doi' && id.relation_type == 'iscitedby' }
           expect(doi.first&.related_identifier).to end_with(DOI)
           expect(@resource.publication_date.strftime('%Y-%m-%d')).to eql(@cr.send(:date_parts_to_date, PAST_PUBLICATION_DATE).to_s)
         end
@@ -619,7 +619,7 @@ module Stash
           resource = cr.populate_resource!
           expect(resource.title).to eql(@params[:title])
           expect(resource.identifier.internal_data.select { |id| id.data_type == 'publicationName' }.first.value).to eql(@params[:publication_name])
-          doi = resource.related_identifiers.select { |id| id.related_identifier_type == 'doi' && id.relation_type == 'cites' }
+          doi = resource.related_identifiers.select { |id| id.related_identifier_type == 'doi' && id.relation_type == 'iscitedby' }
           expect(doi.first&.related_identifier).to eql(StashDatacite::RelatedIdentifier.standardize_doi(@params[:publication_doi]))
         end
       end

--- a/spec/lib/stash_datacite/indexing_resource_spec.rb
+++ b/spec/lib/stash_datacite/indexing_resource_spec.rb
@@ -54,7 +54,7 @@ module Stash
         @resource = create(:resource, identifier_id: @identifier.id, user_id: @user.id)
         @resource_state = create(:resource_state, resource_id: @resource.id)
         @resource.update(current_resource_state_id: @resource_state.id)
-        create(:related_identifier, resource_id: @resource.id, related_identifier_type: 'doi', relation_type: 'cites',
+        create(:related_identifier, resource_id: @resource.id, related_identifier_type: 'doi', relation_type: 'iscitedby',
                                     related_identifier: 'doi123', work_type: 'primary_article')
         @version = create(:version, resource_id: @resource.id)
         @affil1 = create(:affiliation, long_name: 'Lafayette Tech', ror_id: 'https://ror.example.org/16xx22bs')

--- a/spec/models/stash_datacite/completions_spec.rb
+++ b/spec/models/stash_datacite/completions_spec.rb
@@ -45,7 +45,7 @@ module StashDatacite
       describe :related_works do
         before(:each) do
           create(:related_identifier, resource: @resource, related_identifier: Faker::Pid.doi,
-                                      related_identifier_type: 'doi', relation_type: 'cites',
+                                      related_identifier_type: 'doi', relation_type: 'iscitedby',
                                       work_type: 'article', verified: true)
         end
 

--- a/spec/models/stash_datacite/related_identifier_spec.rb
+++ b/spec/models/stash_datacite/related_identifier_spec.rb
@@ -116,7 +116,7 @@ module StashDatacite
         expect(@resource.related_identifiers.count).to eq(1)
         re = @resource.related_identifiers.first
         expect(re.related_identifier).to eq(@test_doi)
-        expect(re.relation_type).to eq('issupplementto')
+        expect(re.relation_type).to eq('issourceof') # our dataset is the source of the supplemental files
         expect(re.work_type).to eq('supplemental_information')
         expect(re.verified).to be(true)
         expect(re.added_by).to eq('zenodo')

--- a/spec/models/stash_engine/curation_activity_spec.rb
+++ b/spec/models/stash_engine/curation_activity_spec.rb
@@ -54,7 +54,7 @@ module StashEngine
         @curation_activity1 = create(:curation_activity, resource: @resource)
       end
 
-      xit 'does submit when Published is set' do
+      it 'does submit when Published is set' do
         create(:curation_activity, resource_id: @resource.id, status: 'published')
         expect(@mock_idgen).to have_received(:update_identifier_metadata!)
       end
@@ -64,7 +64,7 @@ module StashEngine
         expect(@mock_idgen).to_not have_received(:update_identifier_metadata!)
       end
 
-      xit "doesn't submit when status isn't changed" do
+      it "doesn't submit when status isn't changed" do
         @curation_activity2 = create(:curation_activity, resource: @resource, status: 'published')
         expect(@mock_idgen).to have_received(:update_identifier_metadata!).once
         CurationActivity.create(resource_id: @resource.id, status: 'published')
@@ -108,7 +108,7 @@ module StashEngine
         allow_any_instance_of(ActionMailer::MessageDelivery).to receive(:deliver_now)
       end
 
-      xit 'catches errors and emails the admins' do
+      it 'catches errors and emails the admins' do
         dc_error = Stash::Doi::IdGenError.new('Testing errors')
         allow(Stash::Doi::IdGen).to receive(:make_instance).with(any_args).and_raise(dc_error)
 

--- a/spec/models/stash_engine/identifier_spec.rb
+++ b/spec/models/stash_engine/identifier_spec.rb
@@ -512,7 +512,7 @@ module StashEngine
         @fake_article_doi = 'http://doi.org/10.1234/bogus-doi'
         allow_any_instance_of(Resource).to receive(:related_identifiers).and_return([OpenStruct.new(related_identifier: @fake_article_doi,
                                                                                                     related_identifier_type: 'doi',
-                                                                                                    relation_type: 'cites',
+                                                                                                    relation_type: 'iscitedby',
                                                                                                     work_type: 'primary_article')])
         expect(@identifier.publication_article_doi).to eql(@fake_article_doi)
       end

--- a/spec/models/stash_engine/proposed_change_spec.rb
+++ b/spec/models/stash_engine/proposed_change_spec.rb
@@ -95,7 +95,7 @@ module StashEngine
         expect(@resource.title).to eql(old_title)
         expect(@resource.identifier.internal_data.select { |id| id.data_type == 'publicationName' }.first.value).to eql(@params[:publication_name])
         expect(@resource.related_identifiers.select do |id|
-          id.related_identifier_type == 'doi' && id.relation_type == 'cites'
+          id.related_identifier_type == 'doi' && id.relation_type == 'iscitedby'
         end.first&.related_identifier).to eql(StashDatacite::RelatedIdentifier.standardize_doi(@params[:publication_doi]))
 
         @proposed_change.reload

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -580,6 +580,28 @@ module StashEngine
       end
     end
 
+    describe '#previously_public?' do
+      before(:each) do
+        @identifier = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI', pub_state: nil)
+      end
+
+      it 'returns true if a previous resource had metadata view set to true' do
+        @resource1 = Resource.create(user_id: user.id, created_at: '2020-01-03', identifier_id: @identifier.id, meta_view: true, file_view: false)
+        @resource2 = Resource.create(user_id: user.id, identifier_id: @identifier.id, meta_view: false, file_view: false)
+        # resource for different identifier, below
+        Resource.create(user_id: user.id, meta_view: true, created_at: '2020-01-03', file_view: false)
+        expect(@resource2.previously_public?).to eq(true)
+      end
+
+      it 'returns false if a previous resource had no metadata view exposed' do
+        @resource1 = Resource.create(user_id: user.id, created_at: '2020-01-03', identifier_id: @identifier.id, meta_view: false, file_view: false)
+        @resource2 = Resource.create(user_id: user.id, identifier_id: @identifier.id, meta_view: false, file_view: false)
+        # resource for different identifier, below
+        Resource.create(user_id: user.id, created_at: '2020-01-03', meta_view: true, file_view: false)
+        expect(@resource2.previously_public?).to eq(false)
+      end
+    end
+
     describe '#zenodo_published?' do
       before(:each) do
         @resource = create(:resource, identifier: create(:identifier))

--- a/spec/support/helpers/tinymce_helper.rb
+++ b/spec/support/helpers/tinymce_helper.rb
@@ -12,6 +12,9 @@ module TinymceHelper
     # binding.remote_pry
 
     # https://github.com/tinymce/tinymce/issues/3782
+    #
+    # Also see this page in case it helps.  TinyMCE seems unreliable to load in any specific time especially with multiple
+    # on the page.
 
     counter = 0
 
@@ -32,9 +35,10 @@ module TinymceHelper
       sleep 0.5
       counter += 1
     end
+    sleep 0.5
 
     script_text = <<-SCRIPT
-        var myEditor = tinyMCE.editors.filter(x => x.id === '#{field}')[0]
+        var myEditor = tinyMCE.editors.filter(x => x.id === '#{field}')[0];
         myEditor.setContent("#{content}");
         myEditor.focus();
     SCRIPT

--- a/stash/stash-merritt/lib/datacite/mapping/datacite_xml_factory.rb
+++ b/stash/stash-merritt/lib/datacite/mapping/datacite_xml_factory.rb
@@ -60,7 +60,7 @@ module Datacite
         add_contributors(dcs_resource, datacite_3: datacite_3)
         add_dates(dcs_resource)
         add_alt_ids(dcs_resource)
-        # add_related_ids(dcs_resource)
+        add_related_ids(dcs_resource)
         add_rights(dcs_resource)
         add_descriptions(dcs_resource)
         add_locations(dcs_resource)


### PR DESCRIPTION
This is for tickets #1750 and #1752 .  However not all the zenodo batch metadata update resubmission code is ready yet (moving to another ticket).

See the markdown file [documentation/sql_queries/updates_to_relationships.md](https://github.com/CDL-Dryad/dryad-app/compare/reverse-identifier-relationships?expand=1#diff-bbd1e07a2305861826412510fc091dbd45f07b3d071a3ef43329795286f0d724) which documents the final changes based on the emails and other tickets entered here.  The file also has three SQL queries that can be run when we're ready to update legacy data.  These database updates are fairly simple.

I searched through all code for these and took into account context to carefully update the values and the text.  The relationship for us adding things to zenodo changed according to #1752 (supplemental and software) and also the inverse relationships for them linking back to us which we submit the metadata to them.

It's not an extreme number of code changes, but took a while to be confident I'd found them all and had things right.  See also their https://support.datacite.org/docs/relationtype_for_citation and emails.

