### PR TITLE
Fix PPR checkbox, update post-submission PPR rules

### DIFF
--- a/app/controllers/stash_datacite/peer_review_controller.rb
+++ b/app/controllers/stash_datacite/peer_review_controller.rb
@@ -25,7 +25,7 @@ module StashDatacite
     private
 
     def peer_review_params
-      params.require(:resource).permit(:id, :hold_for_peer_review)
+      params.require(:stash_engine_resource).permit(:id, :hold_for_peer_review)
     end
 
   end

--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -313,6 +313,15 @@ module StashEngine
       internal_data.find_by(data_type: 'manuscriptNumber')&.value&.strip
     end
 
+    # rubocop:disable Naming/PredicateName
+    def has_accepted_manuscript?
+      manu = StashEngine::Manuscript.where(manuscript_number: manuscript_number).last
+      return false unless manu
+
+      manu.accepted?
+    end
+    # rubocop:enable Naming/PredicateName
+
     def publication_article_doi
       doi = nil
       resources.each do |res|

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -857,7 +857,7 @@ module StashEngine
       prior_cur_act = StashEngine::CurationActivity.joins(:resource).where('stash_engine_resources.identifier_id = ?', identifier_id)
         .order(id: :desc).first
 
-      create_post_submission_status(prior_cur_act)
+      target_status = create_post_submission_status(prior_cur_act)
 
       # Warn curators if this is potentially a duplicate
       completions = StashDatacite::Resource::Completions.new(self)
@@ -910,6 +910,7 @@ module StashEngine
       # Generate the :submitted or :peer_review status
       # This will usually have the side effect of sending out notification emails to the author/journal
       curation_activities << StashEngine::CurationActivity.create(user_id: attribution, status: target_status, note: curation_note)
+      target_status
     end
 
     def auto_assign_curator(target_status:)

--- a/app/views/stash_datacite/peer_review/_review.html.erb
+++ b/app/views/stash_datacite/peer_review/_review.html.erb
@@ -8,7 +8,7 @@
   <div>
     <%= form_with model: @resource, url: peer_review_path, remote: true, authenticity_token: true do |f| %>
       <%= f.check_box :hold_for_peer_review %>
-      <label for="resource_hold_for_peer_review">Keep my dataset private while my related article is in peer review</label>
+      <label for="stash_engine_resource_hold_for_peer_review">Keep my dataset private while my related article is in peer review</label>
       <span class="c-input__error-message"><%= @error %></span>
       <%= f.hidden_field :id %>
     <% end %>
@@ -16,7 +16,7 @@
 </div>
 <br>
 <script type="text/javascript">
-  $('#resource_hold_for_peer_review').on('change', function(e) {
+ $('#stash_engine_resource_hold_for_peer_review').on('change', function(e) {
     $(this).closest('form').submit();
   });
 </script>

--- a/spec/models/stash_engine/identifier_spec.rb
+++ b/spec/models/stash_engine/identifier_spec.rb
@@ -507,6 +507,22 @@ module StashEngine
       end
     end
 
+    describe '#has_accepted_manuscript?' do
+      it 'is false when no matching manuscript exists' do
+        expect(@identifier.has_accepted_manuscript?).to be(false)
+      end
+
+      it 'is true when matching manuscript is accepted' do
+        create(:manuscript, manuscript_number: @fake_manuscript_number, status: 'accepted')
+        expect(@identifier.has_accepted_manuscript?).to be(true)
+      end
+
+      it 'is false when matching manuscript is submitted' do
+        create(:manuscript, manuscript_number: @fake_manuscript_number, status: 'submitted')
+        expect(@identifier.has_accepted_manuscript?).to be(false)
+      end
+    end
+
     describe '#publication_article_doi' do
       it 'gets publication_article_doi through convenience method' do
         @fake_article_doi = 'http://doi.org/10.1234/bogus-doi'


### PR DESCRIPTION
- Fixes the functionality of the PPR checkbox in the submission system, which had been malfunctioning due to the code rearrangements https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1778
- When a dataset's status is being updated after Merritt processing, does not allow the `peer_review` status if we know that an associated manuscript/article has been accepted https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1760