### PR TITLE
Don't let crossref set dataset publication date

### DIFF
--- a/lib/stash/import/crossref.rb
+++ b/lib/stash/import/crossref.rb
@@ -81,7 +81,6 @@ module Stash
         populate_authors
         populate_related_doi
         populate_funders
-        populate_publication_date
         populate_publication_issn
         populate_publication_name
         populate_title

--- a/spec/lib/stash_datacite/crossref_spec.rb
+++ b/spec/lib/stash_datacite/crossref_spec.rb
@@ -382,7 +382,6 @@ module Stash
           expect(@resource.identifier.internal_data.select { |id| id.data_type == 'publicationName' }.first.value).to eql(PUBLISHER)
           doi = @resource.related_identifiers.select { |id| id.related_identifier_type == 'doi' && id.relation_type == 'iscitedby' }
           expect(doi.first&.related_identifier).to end_with(DOI)
-          expect(@resource.publication_date.strftime('%Y-%m-%d')).to eql(@cr.send(:date_parts_to_date, PAST_PUBLICATION_DATE).to_s)
         end
       end
 


### PR DESCRIPTION
I think this will prevent the issue described in https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1753

The mechanism for importing CrossRef metadata had been setting the publication_date on the resource, but the date it was receiving was the publication date for an article, which would not necessarily be the same.