### PR TITLE
Rake task to update Zenodo metadata

### DIFF
--- a/lib/tasks/zenodo.rake
+++ b/lib/tasks/zenodo.rake
@@ -1,5 +1,6 @@
 require_relative 'zenodo/stats'
 require_relative 'zenodo/metadata'
+require 'byebug'
 
 namespace :zenodo do
   desc 'Queue feeder that keeps migration items going to the delayed job queue with sleep in between'
@@ -65,9 +66,48 @@ namespace :zenodo do
     puts "Optimistic completion date: #{(Time.new + time_remaining).strftime('%Y-%m-%d')}"
   end
 
-  # additional rake task will look something like this for each to update
-  # require_relative 'lib/tasks/zenodo/metadata'
-  # @zenodo_copy = StashEngine::ZenodoCopy.find(112)
-  # zm = Zenodo::Metadata.new(zenodo_copy: @zenodo_copy)
-  # zm.update_metadata
+  desc 'Update metadata at zenodo latest version for datasets'
+  task update_metadata: :environment do
+    $stdout.sync = true # keeps the output from buffering and delaying output
+
+    trap('SIGINT') do
+      puts 'Exiting metadata update'
+      exit
+    end
+
+    start_num = ARGV[1].to_i
+    identifiers = StashEngine::Identifier.joins(:zenodo_copies).distinct.order(:id).offset(start_num)
+
+    # rubocop:disable Style/BlockDelimiters
+    ARGV.each { |a| task a.to_sym do; end } # prevents rake from interpreting addional args as other rake tasks
+    # rubocop:enable Style/BlockDelimiters
+
+    puts "Updating zenodo metadata starting at record #{start_num}"
+
+    # this stops spamming of activerecord query logs in dev environment
+    ActiveRecord::Base.logger.silence do
+      identifiers.each_with_index do |identifier, idx|
+        data = identifier.zenodo_copies.where(state: 'finished').where('deposition_id IS NOT NULL')
+                         .where("copy_type like 'data%'").order(id: :desc).first
+        supp = identifier.zenodo_copies.where(state: 'finished').where('deposition_id IS NOT NULL')
+                         .where("copy_type like 'supp%'").order(id: :desc).first
+        sfw = identifier.zenodo_copies.where(state: 'finished').where('deposition_id IS NOT NULL')
+                         .where("copy_type like 'software%'").order(id: :desc).first
+
+        # Was going to output every 50th item so we can see it's still going without spamming every item to the output.
+        # However the updates to zenodo are slow enough that it probably makes sense to see each and write log to
+        # examine later.
+        puts "updating number #{idx + start_num} with identifier.id #{identifier.id}: #{identifier.identifier}" # if idx % 50 == 0
+
+        begin
+          Zenodo::Metadata.new(zenodo_copy: data).update_metadata if data.present?
+          Zenodo::Metadata.new(zenodo_copy: supp).update_metadata if supp.present?
+          Zenodo::Metadata.new(zenodo_copy: sfw).update_metadata if sfw.present?
+        rescue Stash::ZenodoReplicate::ZenodoError => e
+          puts "Error updating metadata:\n#{e.to_s}\n\n"
+        end
+        sleep 1
+      end
+    end
+  end
 end

--- a/lib/tasks/zenodo.rake
+++ b/lib/tasks/zenodo.rake
@@ -1,4 +1,5 @@
 require_relative 'zenodo/stats'
+require_relative 'zenodo/metadata'
 
 namespace :zenodo do
   desc 'Queue feeder that keeps migration items going to the delayed job queue with sleep in between'
@@ -63,4 +64,10 @@ namespace :zenodo do
 
     puts "Optimistic completion date: #{(Time.new + time_remaining).strftime('%Y-%m-%d')}"
   end
+
+  # additional rake task will look something like this for each to update
+  # require_relative 'lib/tasks/zenodo/metadata'
+  # @zenodo_copy = StashEngine::ZenodoCopy.find(112)
+  # zm = Zenodo::Metadata.new(zenodo_copy: @zenodo_copy)
+  # zm.update_metadata
 end

--- a/lib/tasks/zenodo/metadata.rb
+++ b/lib/tasks/zenodo/metadata.rb
@@ -1,0 +1,43 @@
+require 'byebug'
+require_relative '../../../lib/stash/zenodo_replicate/metadata_generator'
+require_relative '../../../lib/stash/zenodo_replicate/deposit'
+
+module Zenodo
+  class Metadata
+
+    def initialize(zenodo_copy:)
+      @zc = zenodo_copy
+      @resource = StashEngine::Resource.where(id: @zc.resource_id).first
+    end
+
+    def dataset_type
+      return :data if @zc.copy_type == 'data'
+
+      return :supp if @zc.copy_type&.start_with?('supp')
+
+      :software
+    end
+
+    def smart_doi
+      return nil if @zc.software_doi.blank?
+
+      @zc.software_doi
+    end
+
+    def update_metadata
+      return if @zc.deposition_id.blank? || @zc.state != 'finished' || @resource.nil? # it isn't update-able
+
+      deposit = Stash::ZenodoReplicate::Deposit.new(resource: @resource)
+      resp = deposit.get_by_deposition(deposition_id: @zc.deposition_id)
+
+      if resp[:state] == 'done'
+        deposit.reopen_for_editing
+        deposit.update_metadata(dataset_type: dataset_type, doi: smart_doi)
+        deposit.publish
+      else
+        deposit.update_metadata(dataset_type: dataset_type, doi: smart_doi)
+      end
+    end
+
+  end
+end

--- a/lib/tasks/zenodo/metadata.rb
+++ b/lib/tasks/zenodo/metadata.rb
@@ -18,6 +18,7 @@ module Zenodo
       :software
     end
 
+    # this may be a different doi than the main one for software/supplemental (zenodo generated one we save)
     def smart_doi
       return nil if @zc.software_doi.blank?
 


### PR DESCRIPTION
The basics:

- Does a join from stash_engine_identifiers to zenodo copies to get only items that have had something happen at Zenodo.
- Checks  & updates latest submission for identifier on finished items with a deposit id in the three categories of data/software/supplemental.
- sets submission type so relationships get set when generating metadata from zenodo libraries.
- For closed items (published) it re-opens, updates metadata and re-publishes to put them back to the published/closed state.
- For open items (not published), it just updates the metadata