### PR TITLE
Fix automatch for affiliations

### DIFF
--- a/spec/features/stash_datacite/new_dataset_spec.rb
+++ b/spec/features/stash_datacite/new_dataset_spec.rb
@@ -137,21 +137,11 @@ RSpec.feature 'NewDataset', type: :feature do
       # ##############################
       # Author w/ affiliation in specific university
       fill_in_author
-
       fill_in_research_domain
-
-      # have to do this directly since the fields are no longer directly exposed and rors come from list
-      # affil = StashDatacite::Affiliation.create(long_name: waiver_university, ror_id: ror_org.ror_id)
-      author = StashEngine::Author.first
-      # author.affiliations.destroy_all
-      #  author.affiliations << affil
-      author.affiliation.update(long_name: waiver_university, ror_id: ror_org.ror_id)
-
-      # page.execute_script("document.getElementsByClassName('js-affil-longname')[0].value = '#{waiver_university}'")
-      # a little bit hacky, but the following fills in the ROR expected of a fee waiver institution's country
-      # page.execute_script("document.getElementsByClassName('js-affil-id')[0].value = '#{ror_org.ror_id}'")
-
       navigate_to_review
+
+      # Need to set the affiliation directly in the backend, because it's a pain to interact with the autocomplete component
+      author = StashEngine::Author.first
       author.affiliation.update(long_name: waiver_university, ror_id: ror_org.ror_id)
       navigate_to_review
 
@@ -186,11 +176,13 @@ RSpec.feature 'NewDataset', type: :feature do
       # ##############################
       # Author w/ affiliation in specific university
       fill_in_author
-      page.execute_script("document.getElementsByClassName('js-affil-longname')[0].value = '#{non_waiver_university}'")
-      # a litlte big hacky, but the following fills in the ROR expected of a fee waiver institution's country
-      page.execute_script("document.getElementsByClassName('js-affil-id')[0].value = '#{ror_org.ror_id}'")
-
       navigate_to_review
+
+      # Need to set the affiliation directly in the backend, because it's a pain to interact with the autocomplete component
+      author = StashEngine::Author.first
+      author.affiliation.update(long_name: non_waiver_university, ror_id: ror_org.ror_id)
+      navigate_to_review
+
       expect(page).to have_text('you will receive an invoice')
     end
 


### PR DESCRIPTION
https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1688

- Match affiliation to a ROR entry whenever possible, even if the user does not click on the autocomplete list. 
- Correct tests that were trying to use non-existent class names and not actually testing the correct functionality.

