### PR TITLE
Disallow html uploads from URLs

### DIFF
--- a/app/javascript/react/components/FileUpload/FailedUrlList/Url/Url.js
+++ b/app/javascript/react/components/FileUpload/FailedUrlList/Url/Url.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import parse from 'html-react-parser';
+
 
 const url = (props) => (
   <div className="c-manifest__item">
     <div className="c-manifest__url">{props.url.url}</div>
-    <div className="c-manifest__error">{props.url.error_message}</div>
+    <div className="c-manifest__error">{parse(props.url.error_message)}</div>
     <div className="c-manifest__action">
       {/* <a href="#!">Edit</a> */}
       <a href="#!" onClick={props.click}>Remove</a>

--- a/app/javascript/react/components/FileUpload/FailedUrlList/Url/Url.js
+++ b/app/javascript/react/components/FileUpload/FailedUrlList/Url/Url.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import parse from 'html-react-parser';
 
-
 const url = (props) => (
   <div className="c-manifest__item">
     <div className="c-manifest__url">{props.url.url}</div>

--- a/app/javascript/react/containers/FileUpload/UploadFiles.js
+++ b/app/javascript/react/containers/FileUpload/UploadFiles.js
@@ -155,6 +155,8 @@ class UploadFiles extends React.Component {
                 return 'The server timed out waiting for the request to complete.';
             case 409:
                 return "You've already added this URL in this version.";
+            case 481:
+                return '<a href="/stash/web_crawling" target="_blank">Crawling of HTML files</a> isn\'t supported.';
             case 500: case 501: case 502: case 503: case 504: case 505: case 506:
             case 507: case 508: case 509: case 510: case 511:
                 return 'Encountered a remote server error while retrieving the request.';

--- a/app/models/stash_engine/url_validator.rb
+++ b/app/models/stash_engine/url_validator.rb
@@ -145,6 +145,11 @@ module StashEngine
                        response.status_code
                      end
       @mime_type = mime_type_from(response)
+
+      # Following is a made-up status code for our own use.  We're not a web crawler and don't accept URLs for HTML pages
+      # since we're not going to crawl them and they are usually an error on the user's part or will be missing components
+      # such as CSS or images. If they go in then they are probably not doing what the user hopes and they should be warned.
+      @status_code = 481 if @mime_type == 'text/html'
       @redirected = !response.previous.nil?
       @redirected_to = response.previous.header['Location'].first if @redirected
       @filename = filename_from(response, @redirected_to, @url)

--- a/app/views/stash_engine/pages/web_crawling.html.erb
+++ b/app/views/stash_engine/pages/web_crawling.html.erb
@@ -1,0 +1,44 @@
+<% @page_title = "Web crawling isn't supported" %>
+
+<h1 class="o-heading__level2">Why can't I add my HTML file?</h1>
+
+<p>
+  A HTML file by itself will not usually display or work correctly since it depends on many other files on the
+  web site or the internet to work (such as additional CSS, Javascript and image files).
+</p>
+
+<p>
+  In addition, we've found that HTML content is usually best added in another way or may indicate a problem.
+</p>
+
+<p>For example</p>
+
+<ul>
+  <li>
+    A publisher's web page for a paper or other related work is probably best added under the
+    <strong>Related Works</strong> section and by using the DOI or other permanent identifier rather than trying
+    to upload a live web page.
+  </li>
+  <li>
+    If you are trying to upload a file from a file sharing site and it returns HTML then it probably means that
+    site is presenting the file in a web page or with a warning rather than allowing direct retrieval of the file
+    you want to preserve.
+  </li>
+  <li>
+    The HTML file by itself isn't self-contained and may end up with missing dependencies which will change display and function.
+    If you need to add additional information files to your dataset, then consider formats such as text,
+    rich text or PDF that will be readable even after being moved and don't rely on additional external resources which may change.
+  </li>
+</ul>
+
+<p>
+  If you have a specialized case where you need to preserve a complete web page or web site, then web crawling tools such as
+  <a href="https://archive.org" target="_blank">the Internet Archive</a>, <a href="https://archive-it.org">Archive-It</a>
+  or <a href="https://www.httrack.com/">HTTrack</a> <em>may</em> preserve all the embedded dependencies and the context needed
+  for a web page to be usable later at a different internet location.
+</p>
+
+<p>
+  Web crawling and preservation tools are specialized and complex and fall outside Dryad's core uses for preserving datasets.
+</p>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,6 +252,7 @@ Rails.application.routes.draw do
     get 'search', to: 'searches#index'
     get 'terms', to: 'pages#terms'
     get 'editor', to: 'pages#editor'
+    get 'web_crawling', to: 'pages#web_crawling'
     get 'dataset/*id', to: 'landing#show', as: 'show', constraints: { id: /\S+/ }
     get 'landing/citations/:identifier_id', to: 'landing#citations', as: 'show_citations'
     get '404', to: 'pages#app_404', as: 'app_404'

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "gulp-sourcemaps": "^3.0.0",
     "gulp-useref": "^5.0.0",
     "gulp-w3cjs": "^1.3.2",
+    "html-react-parser": "^1.4.14",
     "identity-obj-proxy": "^3.0.0",
     "lodash": "^4.17.21",
     "match-sorter": "^6.3.1",

--- a/spec/models/stash_engine/url_validator_spec.rb
+++ b/spec/models/stash_engine/url_validator_spec.rb
@@ -20,7 +20,8 @@ module StashEngine
 
     it 'returns 481 (our own status) for text/html files and not success' do
       stub_request(:head, 'http://www.blahstackfood.com').to_return(
-        headers: { 'Content-Length' => 3, 'content-type' => 'text/html; charset=us-ascii' })
+        headers: { 'Content-Length' => 3, 'content-type' => 'text/html; charset=us-ascii' }
+      )
       resp = uv.validate
       # [ uv.mime_type, uv.size, uv.url, uv.status_code, uv.redirected_to, uv.timed_out?, uv.redirected?, uv.correctly_formatted_url? ]
       expect(resp).to eq(false)

--- a/spec/models/stash_engine/url_validator_spec.rb
+++ b/spec/models/stash_engine/url_validator_spec.rb
@@ -18,6 +18,15 @@ module StashEngine
       expect(uv.status_code).to eq(200)
     end
 
+    it 'returns 481 (our own status) for text/html files and not success' do
+      stub_request(:head, 'http://www.blahstackfood.com').to_return(
+        headers: { 'Content-Length' => 3, 'content-type' => 'text/html; charset=us-ascii' })
+      resp = uv.validate
+      # [ uv.mime_type, uv.size, uv.url, uv.status_code, uv.redirected_to, uv.timed_out?, uv.redirected?, uv.correctly_formatted_url? ]
+      expect(resp).to eq(false)
+      expect(uv.status_code).to eq(481)
+    end
+
     it 'sets a 411 for a url with no content-length' do
       stub_request(:head, 'http://www.blahstackfood.com')
       success = uv.validate

--- a/yarn.lock
+++ b/yarn.lock
@@ -4984,7 +4984,7 @@ domhandler@2.3:
   dependencies:
     domelementtype "1"
 
-domhandler@^4.2.0, domhandler@^4.3.1:
+domhandler@4.3.1, domhandler@^4.2.0, domhandler@^4.2.2, domhandler@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
   integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
@@ -5286,6 +5286,11 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+entities@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
+  integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
 
 entities@~2.1.0:
   version "2.1.0"
@@ -7229,6 +7234,14 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
+html-dom-parser@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/html-dom-parser/-/html-dom-parser-1.2.0.tgz#8f689b835982ffbf245eda99730e92b8462c111e"
+  integrity sha512-2HIpFMvvffsXHFUFjso0M9LqM+1Lm22BF+Df2ba+7QHJXjk63pWChEnI6YG27eaWqUdfnh5/Vy+OXrNTtepRsg==
+  dependencies:
+    domhandler "4.3.1"
+    htmlparser2 "7.2.0"
+
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
@@ -7246,6 +7259,16 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+html-react-parser@^1.4.14:
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-1.4.14.tgz#577b7a90be0c61eebbbc488d914ad08398c79ef5"
+  integrity sha512-pxhNWGie8Y+DGDpSh8cTa0k3g8PsDcwlfolA+XxYo1AGDeB6e2rdlyv4ptU9bOTiZ2i3fID+6kyqs86MN0FYZQ==
+  dependencies:
+    domhandler "4.3.1"
+    html-dom-parser "1.2.0"
+    react-property "2.0.0"
+    style-to-js "1.1.1"
+
 html-tags@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.2.0.tgz#dbb3518d20b726524e4dd43de397eb0a95726961"
@@ -7261,6 +7284,16 @@ htmlparser2@3.8.x:
     domutils "1.5"
     entities "1.0"
     readable-stream "1.1"
+
+htmlparser2@7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-7.2.0.tgz#8817cdea38bbc324392a90b1990908e81a65f5a5"
+  integrity sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.2.2"
+    domutils "^2.8.0"
+    entities "^3.0.1"
 
 http-cache-semantics@3.8.1:
   version "3.8.1"
@@ -7594,6 +7627,11 @@ ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
+inline-style-parser@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
+  integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
 
 internal-slot@^1.0.3:
   version "1.0.3"
@@ -11977,6 +12015,11 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-property@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.0.tgz#2156ba9d85fa4741faf1918b38efc1eae3c6a136"
+  integrity sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==
+
 react-shallow-renderer@^16.13.1:
   version "16.14.1"
   resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz#bf0d02df8a519a558fd9b8215442efa5c840e124"
@@ -13474,6 +13517,20 @@ style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
+
+style-to-js@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/style-to-js/-/style-to-js-1.1.1.tgz#417786986cda61d4525c80aed9d1123a6a7af9b8"
+  integrity sha512-RJ18Z9t2B02sYhZtfWKQq5uplVctgvjTfLWT7+Eb1zjUjIrWzX5SdlkwLGQozrqarTmEzJJ/YmdNJCUNI47elg==
+  dependencies:
+    style-to-object "0.3.0"
+
+style-to-object@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.3.0.tgz#b1b790d205991cc783801967214979ee19a76e46"
+  integrity sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==
+  dependencies:
+    inline-style-parser "0.1.1"
 
 stylehacks@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
The items coming back as 'text/html' are probably going to be missing dependencies and render poorly at best.  At worst and the most common case is that they are probably user errors (putting in a html page for their paper which should go in related works instead) or they are trying to use a file sharing service but they didn't put a good sharing URL or else the sharing service is giving us an HTML page that contains the file or is giving us a html page saying it couldn't scan the file for viruses because it is too big.