### PR TITLE
Fix bug in calculation of invoiced dataset size

### DIFF
--- a/lib/stash/payments/invoicer.rb
+++ b/lib/stash/payments/invoicer.rb
@@ -47,7 +47,7 @@ module Stash
       def ds_size
         # Only charge based on the files present in the item at time of publication, even if
         # the Merritt history has larger files.
-        StashEngine::DataFile.where(resource_id: resource.id).sum(:upload_file_size)
+        StashEngine::DataFile.where(resource_id: resource.id).where(file_state: %w[created copied]).sum(:upload_file_size)
       end
 
       def overage_bytes


### PR DESCRIPTION
When calculating the "current" size of a dataset for invoicing, we were accidentally including the size of files whose `file_state` was `deleted`. In practice, this rarely affected anything, because the curator usually versioned the dataset in a final pass before publication. However, in the rare case where a dataset incurs overage charges AND the user replaces a very large file in the final version of the dataset, the overage charges could be quite large due to counting both the new and deleted versions of the large file.

This PR corrects the calculation by only including files that are `created` or `copied` in the version that is invoiced.