### PR TITLE
Withdrawn stats update

### DIFF
--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -547,11 +547,11 @@ module StashEngine
     end
 
     def curation_completed_date
-      return nil unless %w[action_required published embargoed].include?(pub_state)
+      return nil unless %w[action_required published embargoed withdrawn].include?(pub_state)
 
       found_cc_date = nil
       resources.map(&:curation_activities).flatten.each do |ca|
-        next unless %w[action_required published embargoed].include?(ca.status)
+        next unless %w[action_required published embargoed withdrawn].include?(ca.status)
 
         found_cc_date = ca.created_at
         break

--- a/app/views/stash_engine/curation_stats/index.html.erb
+++ b/app/views/stash_engine/curation_stats/index.html.erb
@@ -34,7 +34,7 @@
 	  class="c-admin-table">Datasets to Published</th>
       <th title="The number embargoed that day (status change from 'curation' to 'embargoed' per day)"
 	  class="c-admin-table">Datasets to Embargoed</th>
-      <th title="The number withdrawn that day (status change from 'curation' to 'withdrawn' per day)"
+      <th title="The number withdrawn that day (change from any status to 'withdrawn' per day)"
 	  class="c-admin-table">Datasets to Withdrawn</th>
       <th title="The number that come back to us after an Author Action Required that day (so they change status from 'action_required' to 'curation')"
 	  class="c-admin-table">Author Revised</th>

--- a/documentation/submission_flow.md
+++ b/documentation/submission_flow.md
@@ -67,7 +67,8 @@ Allowable values:
 - peer_review = the resource is availble for reviewers to view, but curators will ignore it
 - curation = a curator is working on the resource
 - action_required = a curator has returned the resource to submitter for revision
-- withdrawn = a previously-published resource has been removed from public view
+- withdrawn = a resource has been removed from public view, either manually by
+  the curator or automatically based on the journal's notification of a rejected article
 - embargoed = metadata for the resource is published, but data files are not publicly available
 - published = the resource is fully available to the public
 

--- a/spec/models/stash_engine/curation_stats_spec.rb
+++ b/spec/models/stash_engine/curation_stats_spec.rb
@@ -244,6 +244,7 @@ module StashEngine
         expect(stats.datasets_to_aar).to eq(0)
         expect(stats.datasets_to_embargoed).to eq(0)
         expect(stats.datasets_to_published).to eq(0)
+        expect(stats.datasets_to_withdrawn).to eq(0)
       end
 
       it 'counts correctly when there are some' do
@@ -290,6 +291,14 @@ module StashEngine
         stats.recalculate
         expect(stats.datasets_to_aar).to eq(2)
         expect(stats.datasets_to_published).to eq(1)
+
+        # YES, two withdrawn, from different statuses
+        @res[0].curation_activities << CurationActivity.create(status: 'curation', user: @curator, created_at: @day - 1.day)
+        @res[0].curation_activities << CurationActivity.create(status: 'withdrawn', user: @curator, created_at: @day)
+        @res[1].curation_activities << CurationActivity.create(status: 'peer_review', user: @curator, created_at: @day - 1.day)
+        @res[1].curation_activities << CurationActivity.create(status: 'withdrawn', user: @curator, created_at: @day)
+        stats.recalculate
+        expect(stats.datasets_to_withdrawn).to eq(2)
       end
     end
 


### PR DESCRIPTION
https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1786

Updates to statistics and reports that use the `withdrawn` status based on new shared understanding of the meaning.