### PR TITLE
Fix submission queue page

### DIFF
--- a/app/views/stash_engine/submission_queue/_status_table.html.erb
+++ b/app/views/stash_engine/submission_queue/_status_table.html.erb
@@ -24,25 +24,27 @@
 </div>
 
 <table class="c-lined-table">
-    <tr class="c-lined-table__head">
-	<th class="<%= sort_display('resource_id') %>">
-	    <%= sortable_column_head sort_field: 'resource_id', title: 'Resource' %>	  
-	</th>
-	<th>
-	    DOI
-	</th>
-	<th class="<%= sort_display('state') %>">
-	    <%= sortable_column_head sort_field: 'state', title: 'State' %>
-	</th>
-	<th class="<%= sort_display('hostname') %>">
-	    <%= sortable_column_head sort_field: 'hostname', title: 'Hostname' %>
-	</th>
-	<th class="<%= sort_display('updated_at') %>">
-	    <%= sortable_column_head sort_field: 'updated_at', title: 'Updated at' %>
-	</th>
-    </tr>
+	<tr class="c-lined-table__head">
+		<th>&check;</th>
+		<th class="<%= sort_display('resource_id') %>">
+				<%= sortable_column_head sort_field: 'resource_id', title: 'Resource' %>
+		</th>
+		<th>
+				DOI
+		</th>
+		<th class="<%= sort_display('state') %>">
+				<%= sortable_column_head sort_field: 'state', title: 'State' %>
+		</th>
+		<th class="<%= sort_display('hostname') %>">
+				<%= sortable_column_head sort_field: 'hostname', title: 'Hostname' %>
+		</th>
+		<th class="<%= sort_display('updated_at') %>">
+				<%= sortable_column_head sort_field: 'updated_at', title: 'Updated at' %>
+		</th>
+	</tr>
     <% @queue_rows.each do |qr| %>
     <tr class="c-lined-table__row">
+			<td><%= check_box_tag(qr.resource_id) %></td>
       <td><%= qr.resource_id %></td>
       <td><%= StashEngine::Resource.find(qr.resource_id).identifier.to_s %></td>
       <td><%= qr.state %></td>

--- a/app/views/stash_engine/submission_queue/action_taken.html.erb
+++ b/app/views/stash_engine/submission_queue/action_taken.html.erb
@@ -1,18 +1,5 @@
-<% if params[:action] == 'graceful_shutdown' %>
-  <h2>Now shutting down gracefully</h2>
+  <h2>Now resending submissions for these items</h2>
 
-  <p>Please monitor the queue from the previous page to see when all <strong>processing</strong> and <strong>enqueued</strong>
-  states clear for this server.</p>
-<% elsif params[:action] == 'graceful_start' %>
-  <h2>Now starting up from a graceful shutdown</h2>
+  <p>Re-enqueued these resource_ids for re-submission to Merritt: <%= params[:ids] %></p>
 
-  <p>You may monitor the states from the previous screen to see items get re-queued and processed on this server.</p>
-<% else %>
-  <h2>Now starting up from an un-graceful shutdown</h2>
-
-  <p>You may monitor the states from the previous screen to see items get re-queued and processed on this server.</p>
-<% end %>
-
-
-
-<%= link_to 'go back to viewing queue updates', stash_url_helpers.submission_queue_path %> (updates automatically every 30 seconds)
+<%= link_to 'go back to viewing queue updates', stash_url_helpers.submission_queue_path %> (updates automatically every 2 minutes)

--- a/app/views/stash_engine/submission_queue/index.html.erb
+++ b/app/views/stash_engine/submission_queue/index.html.erb
@@ -7,56 +7,37 @@
 
 <h2>Actions you can take</h2>
 
-<h3>Graceful shutdown of submissions</h3>
+<h3>To shut down and hold submissions</h3>
 <p>
-  A graceful shutdown will allow any processing submissions to finish and change enqueued items to a
-  <em>rejected_shutting_down</em> state so they do not begin processing.  A graceful shutdown allows all activity to stop before
-  a application or system restart and it can be resumed later.
-</p>
-<p>
-  This action adds a <em>hold-submissions.txt</em> file to the file system in the directory above the Rails.root.  You
-    will want to monitor the state above before actually shutting down a server and wait for active <em>processing</em> submissions to clear.</p>
+  Add a <em>hold-submissions.txt</em> file in the directory above the Rails.root. This would be
+  <em>~/apps/ui/releases/hold-submissions.txt</em> in our current directory structure.</p>
 
+<h3>Re-enqueue submissions for checked items</h3>
 <p>
-    <%= button_to 'Do a graceful shutdown of submissions',
-                  stash_url_helpers.graceful_shutdown_path, 
-                  { method: 'get', id: 'graceful_shutdown' } %>
-</p>
-
-<h3>Restart gracefully</h3>
-<p>
-  This restarts processing submissions on this server again.  It changes the <em>rejected_shutting_down</em> to
-  a <em>enqueued</em> state and re-inserts them into the internal processing queue which will begin sending them to the
-  storage repository again.  It also removes the hold-submissions.txt file from the file system if it exists.
+ This will re-send the items you check (by clearing the queue states and re-inserting them in the current server's queue).
 </p>
 
 <p>
-    <%= button_to 'Restart submissions which were shutdown gracefully',
-                  stash_url_helpers.graceful_start_path, 
-                  { method: 'get', id: 'graceful_start'} %>
-</p>
-
-
-<h3>Restart submissions not gracefully shut down</h3>
-<p>
-  This restarts items with the states of <em>enqueued</em> and <em>rejected_shutting_down</em> by inserting them into the internal
-  queue for the workers, which likely has nothing in it if the application wasn't shut down gracefully.
-</p>
-
-<p>
-  If an item is enqueued more than once, it will only be processed once since items already processed by the repository
-  are skipped when it is their turn to be processed.  It also removes the hold-submissions.txt file.
-</p>
-
-<p>
-    <%= button_to 'Restart submissions which were NOT shutdown gracefully',
-                  stash_url_helpers.ungraceful_start_path, 
-                  { method: 'get', id: 'ungraceful_start' } %>
+    <%= button_to 'Resend checked submissions',
+                  stash_url_helpers.graceful_start_path,
+                  { method: 'get',
+                    id: 'graceful_start',
+                    params: { ids: '' },
+                    onclick: "gatherChecked();",
+                    form_class: 'button_form'
+                  } %>
 </p>
 
 <script>
+
+  function gatherChecked() {
+      const checked = [...document.querySelectorAll("input[type=checkbox]:checked")].map((el) => el.id ).join();
+      document.querySelector('.button_form>input[name=ids]').value = checked;
+  }
+
+    //
     $(document).ready(function () {
-        setInterval(refreshPartial, 30000)
+        setInterval(refreshPartial, 120000) // refresh every 2 minutes
     });
 
     // calls action refreshing the partial

--- a/app/views/stash_engine/submission_queue/index.html.erb
+++ b/app/views/stash_engine/submission_queue/index.html.erb
@@ -21,7 +21,6 @@
     <%= button_to 'Resend checked submissions',
                   stash_url_helpers.graceful_start_path,
                   { method: 'get',
-                    id: 'graceful_start',
                     params: { ids: '' },
                     onclick: "gatherChecked();",
                     form_class: 'button_form'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -292,9 +292,7 @@ Rails.application.routes.draw do
     # routing for submission queue controller
     get 'submission_queue', to: 'submission_queue#index'
     get 'submission_queue/refresh_table', to: 'submission_queue#refresh_table'
-    get 'submission_queue/graceful_shutdown', to: 'submission_queue#graceful_shutdown', as: 'graceful_shutdown'
     get 'submission_queue/graceful_start', to: 'submission_queue#graceful_start', as: 'graceful_start'
-    get 'submission_queue/ungraceful_start', to: 'submission_queue#ungraceful_start', as: 'ungraceful_start'
     
     # routing for zenodo_queue
     get 'zenodo_queue', to: 'zenodo_queue#index', as: 'zenodo_queue'

--- a/spec/controllers/readme.txt
+++ b/spec/controllers/readme.txt
@@ -1,3 +1,3 @@
-Most controller tests for testing output will be in response testing.  (responses)
+Most controller tests for testing output will be in request spec testing.
 
-Or we can test controllers and views through capybara/selenium testing.
+Or we can test controllers and views through capybara/selenium feature testing.

--- a/spec/features/stash_engine/dataset_queuing_spec.rb
+++ b/spec/features/stash_engine/dataset_queuing_spec.rb
@@ -60,21 +60,5 @@ RSpec.feature 'DatasetQueuing', type: :feature do
       expect(page).to have_content(/[23] queued on this server/)
     end
 
-    it 'should pause transfers', js: true do
-      visit '/stash/submission_queue'
-      click_button 'graceful_shutdown'
-      click_link 'go back to viewing queue updates'
-      wait_for_ajax(15)
-      expect(page).to have_text('Submissions are being held for shutdown on this server')
-    end
-
-    it 'should re-enable transfers', js: true do
-      FileUtils.touch(HOLD_SUBMISSIONS_PATH)
-      visit '/stash/submission_queue'
-      click_button 'graceful_start'
-      click_link 'go back to viewing queue updates'
-      wait_for_ajax(15)
-      expect(page).to have_text('Normal submissions in effect on this server')
-    end
   end
 end

--- a/spec/requests/stash_engine/submission_queue_controller_spec.rb
+++ b/spec/requests/stash_engine/submission_queue_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+require 'byebug'
+
+# see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
+module StashEngine
+  RSpec.describe SubmissionQueueController, type: :request do
+    include GenericFilesHelper # this is a bit weird but has a method for creating user needed for UI
+
+    before(:each) do
+      generic_before # adds a superuser for use by the following mock
+      # HACK: in session because requests specs don't allow session in rails 4
+      allow_any_instance_of(SubmissionQueueController).to receive(:session).and_return({ user_id: @user.id }.to_ostruct)
+    end
+
+    describe '#graceful_start' do
+      before(:each) do
+        # @resource is already set up by generic_before
+        resource2 = create(:resource, user_id: @user.id)
+        resource2.current_resource_state.update(resource_state: 'submitted')
+        @resources = [@resource, resource2]
+
+        @resources.each do |res|
+          create(:repo_queue_state, resource: res, state: 'enqueued', hostname: 'test')
+          create(:repo_queue_state, resource: res, state: 'processing', hostname: 'test')
+          create(:repo_queue_state, resource: res, state: 'errored', hostname: 'test')
+        end
+      end
+
+      it 'takes a list of resource IDs, updates queue states and calls to re-enqueue them' do
+        @url = Rails.application.routes.url_helpers.graceful_start_path({ ids: @resources.map(&:id).join(',') })
+        allow_any_instance_of(SubmissionQueueController).to receive(:enqueue_submissions).and_return('')
+        response_code = get @url
+        expect(response_code).to eql(200)
+        @resources.each do |res|
+          res.reload
+          expect(res.repo_queue_states.length).to eq(1)
+          expect(res.repo_queue_states.first.state).to eq('rejected_shutting_down')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Gets rid of the option to pause acceptance of submissions and just gives instructions
- Adds a checkbox to each line in the list and allows checking items to reset/re-enqueue for submission
  - Javascript to gather ids
  - controller resets items and always re-sends them automatically from whatever the current server is

To test manually, you can do something like:
1. Create submission with a URL on the internet and validate it so that URL goes into the database as a file.
2. Go into the database for your resource and modify the file URL in the database so that it is bad and will fail in Merritt.
3. Submit it to Merritt and wait for it to fail.
4. Go back into the database and correct the URL so that it is good again.
5. Go to the submission queue page and check the failed item in the list and click the button to resend it.
6. It should go through merritt now.

I think this should make re-sending/starting items easier after either freezing submissions for a while or else if something goes wrong and we have lots of errors.  Just check the ones you want to resend and click submit.