### PR TITLE
Limit schema.org description length and strip html

### DIFF
--- a/app/models/stash_datacite/resource/schema_dataset.rb
+++ b/app/models/stash_datacite/resource/schema_dataset.rb
@@ -79,7 +79,10 @@ module StashDatacite
       def descriptions
         return [] unless @resource.descriptions
 
-        @resource.descriptions.map(&:description).compact
+        @resource.descriptions.map do |d|
+          str = ActionView::Base.full_sanitizer.sanitize(d.description || '')
+          ((str&.length || 0) > 1000 ? "#{str[0..1000]}..." : str )
+        end.compact
       end
 
       def landing_url

--- a/app/models/stash_datacite/resource/schema_dataset.rb
+++ b/app/models/stash_datacite/resource/schema_dataset.rb
@@ -81,7 +81,7 @@ module StashDatacite
 
         @resource.descriptions.map do |d|
           str = ActionView::Base.full_sanitizer.sanitize(d.description || '')
-          ((str&.length || 0) > 1000 ? "#{str[0..1000]}..." : str )
+          ((str&.length || 0) > 1000 ? "#{str[0..1000]}..." : str)
         end.compact
       end
 


### PR DESCRIPTION
This fixes the warnings that Google gives us from the page.

https://search.google.com/test/rich-results  (and then put in the url to test)

Before it gave us a warning because of the length and the html.  I deployed to dev and tested with https://dryad-dev.cdlib.org/stash/dataset/doi:10.5072/FK28P64B5G and it didn't show errors after the changes (but did before).
