### PR TITLE
This adds the content urls for the item if files are public

### DIFF
--- a/app/models/stash_datacite/resource/schema_dataset.rb
+++ b/app/models/stash_datacite/resource/schema_dataset.rb
@@ -99,7 +99,7 @@ module StashDatacite
       def content_urls
         return [] unless @resource.file_view
 
-        @resource.data_files.present_files.map {|f| Rails.application.routes.url_helpers.download_stream_url(f.id)}
+        @resource.data_files.present_files.map { |f| Rails.application.routes.url_helpers.download_stream_url(f.id) }
       end
 
       def doi_url

--- a/app/models/stash_datacite/resource/schema_dataset.rb
+++ b/app/models/stash_datacite/resource/schema_dataset.rb
@@ -14,6 +14,7 @@ module StashDatacite
         'name' => :names,
         'description' => :descriptions,
         'url' => :landing_url,
+        'contentUrl' => :content_urls,
         'identifier' => :doi_url,
         'version' => :version,
         'isAccessibleForFree' => :true_val,
@@ -85,6 +86,20 @@ module StashDatacite
       def landing_url
         target_id = CGI.escape(@resource.identifier&.to_s)
         Rails.application.routes.url_helpers.show_url(target_id)
+      end
+
+      # These are urls for the individual files for download.
+      # It's much more problematic to add the zip file since creating these zip files is an expensive and slow operation
+      # taken care of by Merritt (who doesn't really enjoy the extra load) and often results in queueing, javascript
+      # progress-bars and all kinds of gymnatics to avoid all the problems.
+      #
+      # It seems that full zip files aren't going away as a requirement but have their issues.  If we wanted to make them
+      # instantly available then we'd probably also want to increase our storage costs by a lot and make them available
+      # as instant downloads and store the zip files pre-created in S3 or elsewhere.
+      def content_urls
+        return [] unless @resource.file_view
+
+        @resource.data_files.present_files.map {|f| Rails.application.routes.url_helpers.download_stream_url(f.id)}
       end
 
       def doi_url

--- a/spec/models/stash_datacite/schema_dataset_spec.rb
+++ b/spec/models/stash_datacite/schema_dataset_spec.rb
@@ -7,9 +7,11 @@ module StashDatacite
                        email: 'lmuckenhaupt@example.edu',
                        tenant_id: 'dataone')
 
-        @resource = create(:resource, user: @user)
+        @resource = create(:resource, user: @user, file_view: 1)
         @resource.download_uri = "https://repo.example.edu/#{@resource.identifier_str}.zip"
         @resource.save
+
+        @data_files = [ create(:data_file, resource: @resource), create(:data_file, resource: @resource) ]
 
         schema_dataset = SchemaDataset.new(resource: @resource)
 
@@ -50,6 +52,11 @@ module StashDatacite
 
       it 'has the correct download link' do
         expect(@actual['distribution']['contentUrl']).to include('api/v2/datasets/doi')
+      end
+
+      it 'has URLs for file downloads (include the file id)' do
+        expect(@actual['contentUrl'].first).to include(@data_files.first.id.to_s)
+        expect(@actual['contentUrl'].second).to include(@data_files.second.id.to_s)
       end
     end
   end

--- a/spec/models/stash_datacite/schema_dataset_spec.rb
+++ b/spec/models/stash_datacite/schema_dataset_spec.rb
@@ -11,7 +11,7 @@ module StashDatacite
         @resource.download_uri = "https://repo.example.edu/#{@resource.identifier_str}.zip"
         @resource.save
 
-        @data_files = [ create(:data_file, resource: @resource), create(:data_file, resource: @resource) ]
+        @data_files = [create(:data_file, resource: @resource), create(:data_file, resource: @resource)]
 
         schema_dataset = SchemaDataset.new(resource: @resource)
 


### PR DESCRIPTION
Adds tests to be sure it's outputting url with the id in them for the data files.  Note: only outputs ContentUrls for datasets that have been published and have files available to download by everyone.

Also tested at https://search.google.com/test/rich-results to be sure the schema.org was being parsed and didn't have errors. Looks good.