### PR TITLE
Update to prevent possible sql injection

### DIFF
--- a/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -196,7 +196,8 @@ module StashEngine
     def activity_log
       @identifier = Identifier.find(params[:id])
       resource_ids = @identifier.resources.collect(&:id)
-      @curation_activities = CurationActivity.where(resource_id: resource_ids).order(helpers.sortable_table_order, id: :asc)
+      ord = helpers.sortable_table_order(whitelist: %w[created_at])
+      @curation_activities = CurationActivity.where(resource_id: resource_ids).order(ord, id: :asc)
       @internal_data = InternalDatum.where(identifier_id: @identifier.id)
     rescue ActiveRecord::RecordNotFound
       admin_path = stash_url_helpers.url_for(controller: 'stash_engine/admin_datasets', action: 'index', only_path: true)

--- a/app/controllers/stash_engine/journals_controller.rb
+++ b/app/controllers/stash_engine/journals_controller.rb
@@ -6,8 +6,6 @@ module StashEngine
     include SharedSecurityController
     helper SortableTableHelper
 
-    before_action :require_curator
-
     def index
       params.permit(:q)
       params[:sort] = 'title' if params[:sort].blank?

--- a/app/controllers/stash_engine/journals_controller.rb
+++ b/app/controllers/stash_engine/journals_controller.rb
@@ -19,7 +19,8 @@ module StashEngine
       sponsoring_journals = Journal.where.not(payment_plan_type: [nil, '']).map(&:id)
       display_journals = metadata_journals | sponsoring_journals
 
-      @journals = Journal.joins(:sponsor).where(id: display_journals).order(helpers.sortable_table_order, title: :asc)
+      ord = helpers.sortable_table_order(whitelist: %w[title issn allow_blackout payment_plan_type name])
+      @journals = Journal.joins(:sponsor).where(id: display_journals).order(ord, title: :asc)
 
       respond_to do |format|
         format.html

--- a/app/controllers/stash_engine/journals_controller.rb
+++ b/app/controllers/stash_engine/journals_controller.rb
@@ -6,6 +6,8 @@ module StashEngine
     include SharedSecurityController
     helper SortableTableHelper
 
+    before_action :require_curator
+
     def index
       params.permit(:q)
       params[:sort] = 'title' if params[:sort].blank?

--- a/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/app/controllers/stash_engine/publication_updater_controller.rb
@@ -15,7 +15,11 @@ module StashEngine
         .joins(identifier: :resources).where(approved: false, rejected: false)
       params[:sort] = 'score' if params[:sort].blank?
       params[:direction] = 'desc' if params[:direction].blank?
-      @proposed_changes = proposed_changes.order(helpers.sortable_table_order).page(@page).per(@page_size)
+
+      ord = helpers.sortable_table_order(whitelist:
+         %w[stash_engine_proposed_changes.title publication_name publication_issn publication_doi
+            stash_engine_proposed_changes.publication_date authors score])
+      @proposed_changes = proposed_changes.order(ord).page(@page).per(@page_size)
       return unless @proposed_changes.present?
 
       @resources = StashEngine::Resource.latest_per_dataset.where(identifier_id: @proposed_changes&.map(&:identifier_id))

--- a/app/controllers/stash_engine/submission_queue_controller.rb
+++ b/app/controllers/stash_engine/submission_queue_controller.rb
@@ -20,7 +20,9 @@ module StashEngine
     # rubocop:disable Metrics/AbcSize
     def refresh_table
       params[:sort] = 'updated_at' if params[:sort].blank?
-      @queue_rows = RepoQueueState.latest_per_resource.where.not(state: 'completed').order(helpers.sortable_table_order)
+      ord = helpers.sortable_table_order(whitelist:
+                                           %w[resource_id state hostname updated_at])
+      @queue_rows = RepoQueueState.latest_per_resource.where.not(state: 'completed').order(ord)
       @queued_count = RepoQueueState.latest_per_resource.where(state: 'enqueued').count
       @server_held_count = RepoQueueState.latest_per_resource.where(state: 'rejected_shutting_down')
         .where(hostname: StashEngine.repository.class.hostname).count

--- a/app/controllers/stash_engine/user_admin_controller.rb
+++ b/app/controllers/stash_engine/user_admin_controller.rb
@@ -33,9 +33,11 @@ module StashEngine
           @users = @users.or(User.where('first_name LIKE ? and last_name LIKE ?', "%#{splitname.first}%", "%#{splitname.second}%"))
         end
 
-        @users = @users.order(helpers.sortable_table_order)
+        ord = helpers.sortable_table_order(whitelist: %w[last_name email tenant_id role last_login])
+        @users = @users.order(ord)
       else
-        @users = User.all.order(helpers.sortable_table_order)
+        ord = helpers.sortable_table_order(whitelist: %w[last_name email tenant_id role last_login])
+        @users = User.all.order(ord)
       end
 
       add_institution_filter! # if they chose a facet or are only an admin

--- a/app/helpers/stash_engine/sortable_table_helper.rb
+++ b/app/helpers/stash_engine/sortable_table_helper.rb
@@ -58,6 +58,7 @@ module StashEngine
     def sortable_table_order
       params[:sort] = 'created_at' if params[:sort].blank?
       params[:direction] = 'asc' if params[:direction].blank?
+      params[:direction] = 'asc' unless %w[asc desc].include?(params[:direction]) # limit to only these two values
       "#{params[:sort]} #{params[:direction]}"
     end
 

--- a/app/helpers/stash_engine/sortable_table_helper.rb
+++ b/app/helpers/stash_engine/sortable_table_helper.rb
@@ -55,10 +55,15 @@ module StashEngine
 
     # Generate a string for ordering ActiveRecord selections. If no sort order
     # has been set, defaults to sorting records by the `created_at` date.
-    def sortable_table_order
+    # ONLY allow the whitelist of fields and the two orders to prevent SQL injection
+    def sortable_table_order(whitelist: [])
       params[:sort] = 'created_at' if params[:sort].blank?
       params[:direction] = 'asc' if params[:direction].blank?
-      params[:direction] = 'asc' unless %w[asc desc].include?(params[:direction]) # limit to only these two values
+      params[:direction] = 'asc' unless %w[asc desc].include?(params[:direction]) # limit to only these two sort orders
+      params[:sort] = whitelist.first unless whitelist.include?(params[:sort]) # limit to whitelisted field names
+
+      return '' if params[:sort].blank? || params[:direction].blank?
+
       "#{params[:sort]} #{params[:direction]}"
     end
 


### PR DESCRIPTION
Only allow whitelisted fields and the two orders into ORDER clauses.

https://stackoverflow.com/questions/17859880/is-activerecords-order-method-vulnerable-to-sql-injection

Also didn't seem like there was a user permissions scope applied to the journal list.