### PR TITLE
Allows an individual API item to show the general catalog of what changed

### DIFF
--- a/app/controllers/stash_api/datasets_controller.rb
+++ b/app/controllers/stash_api/datasets_controller.rb
@@ -27,7 +27,7 @@ module StashApi
 
     # get /datasets/<id>
     def show
-      ds = Dataset.new(identifier: @stash_identifier.to_s, user: @user)
+      ds = Dataset.new(identifier: @stash_identifier.to_s, user: @user, item_view: true)
       respond_to do |format|
         format.any { render json: ds.metadata }
         res = @stash_identifier.latest_viewable_resource(user: @user)

--- a/app/controllers/stash_api/versions_controller.rb
+++ b/app/controllers/stash_api/versions_controller.rb
@@ -15,7 +15,7 @@ module StashApi
 
     # get /versions/<id>
     def show
-      v = Version.new(resource_id: params[:id])
+      v = Version.new(resource_id: params[:id], item_view: true)
       respond_to do |format|
         format.any { render json: v.metadata_with_links }
         res = @stash_resources.first

--- a/app/models/stash_api/dataset.rb
+++ b/app/models/stash_api/dataset.rb
@@ -7,11 +7,12 @@ module StashApi
   class Dataset
     include Presenter
 
-    def initialize(identifier:, user: nil)
+    def initialize(identifier:, user: nil, item_view: false) # item view means not in list and may show more info for individual record
       id_type, iden = identifier.split(':', 2)
       @identifier_s = identifier
       @se_identifier = StashEngine::Identifier.where(identifier_type: id_type, identifier: iden).first
       @user = user
+      @item_view = item_view
     end
 
     def last_se_resource
@@ -22,7 +23,7 @@ module StashApi
       res = last_se_resource
       return nil unless res
 
-      Version.new(resource_id: res.id)
+      Version.new(resource_id: res.id, item_view: @item_view)
     end
 
     def metadata

--- a/app/models/stash_api/version.rb
+++ b/app/models/stash_api/version.rb
@@ -5,12 +5,13 @@ module StashApi
     include Presenter
 
     attr_reader :resource
-    def initialize(resource_id:)
+    def initialize(resource_id:, item_view: false) # the item_view may present additional information if it's not generating a list
       @resource = StashEngine::Resource.find(resource_id)
+      @item_view = item_view
     end
 
     def metadata
-      m = Metadata.new(resource: @resource)
+      m = Metadata.new(resource: @resource, item_view: @item_view)
       m.value.delete_if { |_k, v| v.blank? && v != false }
     end
 

--- a/spec/requests/stash_api/datasets_controller_spec.rb
+++ b/spec/requests/stash_api/datasets_controller_spec.rb
@@ -488,6 +488,14 @@ module StashApi
         end
       end
 
+      describe 'list display is different than single item display' do
+        it "doesn't show changedFields for every item in long list with expensive operation to compare versions" do
+          get '/api/v2/datasets', headers: default_authenticated_headers
+          output = response_body_hash
+          expect(output['_embedded']['stash:datasets'][0]['changedFields']).to be_nil
+        end
+      end
+
       describe 'shows appropriate latest resource metadata under identifier based on user' do
         before(:each) do
           # versions not getting set correctly for these two resources for some reason

--- a/spec/requests/stash_api/versions_controller_spec.rb
+++ b/spec/requests/stash_api/versions_controller_spec.rb
@@ -204,6 +204,21 @@ module StashApi
         expect(h['sharingLink']).to match(/http/)
       end
 
+      it 'shows what fields changed for v2 when both have been published' do
+        create(:curation_activity, resource: @resources[1], status: 'published', user_id: @user1.id)
+        response_code = get "/api/v2/versions/#{@resources[1].id}", headers: default_json_headers
+        expect(response_code).to eq(200)
+        h = response_body_hash
+        expect(h[:changedFields]).to eq(%w[title authors abstract subjects funders])
+      end
+
+      it "wouldn't show changed fields for a first version" do
+        response_code = get "/api/v2/versions/#{@resources[0].id}", headers: default_json_headers
+        expect(response_code).to eq(200)
+        h = response_body_hash
+        expect(h[:changedFields]).to eq(%w[none])
+      end
+
       it 'shows stuff to admin from the same tenant' do
         @user2 = create(:user, tenant_id: @tenant_ids.first, role: 'admin')
         @doorkeeper_application2 = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',


### PR DESCRIPTION
This only outputs on items that have more than one embargoed/published version (the same way the UI does and compares those versions).

It doesn't show the changedFields for lists so that we don't have to load so many things in long lists and just the individual item view.

Some examples (using the dev database) that show the extra field:

http://localhost:3000/api/v2/datasets/doi:10.5072%2FFK28P64B5G
http://localhost:3000/api/v2/versions/3660

Some examples that are lists and don't:

http://localhost:3000/api/v2/datasets
http://localhost:3000/api/v2/datasets/doi:10.5072%2FFK28P64B5G/versions


