### PR TITLE
Fixes issues with subjects (keywords) entered in the Field of Science box

### DIFF
--- a/app/controllers/stash_datacite/fos_subjects_controller.rb
+++ b/app/controllers/stash_datacite/fos_subjects_controller.rb
@@ -10,7 +10,9 @@ module StashDatacite
       respond_to do |format|
         format.json do
           # this removes the current associated fos subjects, but doesn't delete subject entries from subjects table
-          resource.subjects.permissive_fos.each { |subj| resource.subjects.delete(subj) }
+          resource.subjects.permissive_fos.each do |subj|
+            ResourcesSubjects.where(resource_id: resource, subject_id: subj).destroy_all
+          end
           resource.subjects << make_or_get_subject(params[:fos_subjects]) unless params[:fos_subjects].blank?
           render json: resource.subjects.permissive_fos
         end

--- a/app/controllers/stash_datacite/subjects_controller.rb
+++ b/app/controllers/stash_datacite/subjects_controller.rb
@@ -26,8 +26,10 @@ module StashDatacite
 
     # DELETE /subjects/1
     def delete
-      @subjects = resource.subjects.non_fos
-      resource.subjects.non_fos.delete(@subject)
+      # the following is the correct way to remove the join association between resource and subject
+      # without deleting the other items entirely.  Deleting the subject will leave orphans in the join table.
+      # If you have dependent destroy, it might destroy other associations to the same subject.
+      ResourcesSubjects.where(resource_id: @resource, subject_id: @subject).destroy_all
       respond_to do |format|
         format.js
         format.json { render json: @subject }
@@ -61,7 +63,7 @@ module StashDatacite
     end
 
     def find_or_create_subject(subject)
-      existing = Subject.where('subject LIKE ?', subject).first
+      existing = Subject.where('subject LIKE ?', subject).non_fos.first
       return existing if existing
 
       Subject.create(subject: subject)

--- a/app/models/stash_datacite/subject.rb
+++ b/app/models/stash_datacite/subject.rb
@@ -6,6 +6,10 @@ module StashDatacite
     has_and_belongs_to_many :resources, class_name: StashEngine::Resource.to_s,
                                         through: 'StashDatacite::ResourceSubject'
 
+    # non_fos isn't a field of science
+    # fos is a field of science, but only standard ones
+    # permissive_fos is a field of science entry but could be good or a free-form one
+    # bad_fos is a non-standard field entry that someone typed in
     scope :non_fos, -> { where("subject_scheme IS NULL OR subject_scheme NOT IN ('fos', 'bad_fos')") }
     scope :fos, -> { where("subject_scheme = 'fos'") }
     scope :permissive_fos, -> { where("subject_scheme IN ('fos', 'bad_fos')") }

--- a/app/models/stash_datacite/subject.rb
+++ b/app/models/stash_datacite/subject.rb
@@ -8,8 +8,10 @@ module StashDatacite
 
     # non_fos isn't a field of science
     # fos is a field of science, but only standard ones
-    # permissive_fos is a field of science entry but could be good or a free-form one
-    # bad_fos is a non-standard field entry that someone typed in
+    # permissive_fos is a field of science entry but could be good or a non-standard thing someone entered
+    # bad_fos is a non-standard field of science entry that someone typed in and isn't really right.
+    # TODO: We should add JS or other way to prevent these bad_fox and only allow good items in the list.
+
     scope :non_fos, -> { where("subject_scheme IS NULL OR subject_scheme NOT IN ('fos', 'bad_fos')") }
     scope :fos, -> { where("subject_scheme = 'fos'") }
     scope :permissive_fos, -> { where("subject_scheme IN ('fos', 'bad_fos')") }


### PR DESCRIPTION
This fixes some weird keywords that could have been entered as free text in the field of science (fos) subject box.

In most cases, changing the field of science deletes previous ones, but for the non-standard ones that people typed by free association they become a custom subject that then couldn't be deleted easily.

There were also some problems when subjects were deleted leaving orphans in the join table between resource/subjects (though these didn't show or cause practical problems because of the inner join).

We can correct these orphans after we deploy with

```
DELETE sub_res.* FROM dcs_subjects_stash_engine_resources sub_res
LEFT JOIN dcs_subjects subj
ON sub_res.`subject_id` = subj.id
WHERE subj.id IS NULL;
```

This correctly removes the association to a subject rather than removing the subject (which can be available for more joins or autocompletes in the future).