### PR TITLE
Lockout simultaneous submit

### DIFF
--- a/app/controllers/stash_datacite/resources_controller.rb
+++ b/app/controllers/stash_datacite/resources_controller.rb
@@ -64,7 +64,7 @@ module StashDatacite
       resource = StashEngine::Resource.find(resource_id)
       resource.identifier.update_search_words!
 
-      ``      return if processing?(resource) # return here if it already has resource_state of processing in any version
+      return if processing?(resource) # return here if it already has resource_state of processing in any version
 
       # set current merritt state to processing right away to prevent another submission while something might be
       # waiting in the queue.  The repo_queue_states are more fine grained for queueing and used in Merritt class.

--- a/app/controllers/stash_datacite/resources_controller.rb
+++ b/app/controllers/stash_datacite/resources_controller.rb
@@ -64,7 +64,11 @@ module StashDatacite
       resource = StashEngine::Resource.find(resource_id)
       resource.identifier.update_search_words!
 
-      return if processing?(resource)
+      ``      return if processing?(resource) # return here if it already has resource_state of processing in any version
+
+      # set current merritt state to processing right away to prevent another submission while something might be
+      # waiting in the queue.  The repo_queue_states are more fine grained for queueing and used in Merritt class.
+      resource.current_state = 'processing'
 
       update_submission_resource_info(resource)
 

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -7,7 +7,6 @@
 defaults: &DEFAULTS
   google_analytics_id: null
   shared_resource_model: StashEngine::Resource
-  repository: Stash::Merritt::Repository
   stash_mount: /stash
   ezid:
     host: ezid.cdlib.org

--- a/config/initializers/repository.rb
+++ b/config/initializers/repository.rb
@@ -3,16 +3,12 @@ require 'stash/repo'
 module StashEngine
   def self.repository
     @repository ||= begin
-      repository_class_name = APP_CONFIG.repository
-      Rails.logger.debug("APP_CONFIG.repository = #{repository_class_name}")
-
-      repository_class = repository_class_name.constantize
       url_helpers = Rails.application.routes.url_helpers
 
-      Rails.logger.debug("Initializing new instance of repository #{repository_class}")
-      repository_instance = repository_class.new(url_helpers: url_helpers, threads: APP_CONFIG.merritt_max_submission_threads)
+      Rails.logger.debug("Initializing new instance of repository Stash::Merritt::Repository")
+      repository_instance = Stash::Merritt::Repository.new(url_helpers: url_helpers, threads: APP_CONFIG.merritt_max_submission_threads)
       unless repository_instance.respond_to?(:submit)
-        raise ArgumentError, "Repository #{repository_instance.class} does not appear to be a #{Stash::Repo::Repository}"
+        raise ArgumentError, "Repository Stash::Merritt::Repository does not appear to be a #{Stash::Repo::Repository}"
       end
 
       repository_instance

--- a/dryad-config-example/app_config.yml
+++ b/dryad-config-example/app_config.yml
@@ -1,6 +1,5 @@
 defaults: &DEFAULTS
   shared_resource_model: StashEngine::Resource
-  repository: Stash::Merritt::Repository
   stash_mount: /stash
   max_review_days: 180
   ezid:

--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -282,8 +282,9 @@ RSpec.feature 'Admin', type: :feature do
         click_button('Merge')
         expect(page).to have_text('Manage Users')
 
-        # user_2 should be removed
-        expect(StashEngine::User.where(id: user2_id).size).to eq(0)
+        sleep 1 # since it takes some time for async action to reflect in db
+        # user_2 should be removed, modified check because of some weird caching or something
+        expect(StashEngine::User.all.map(&:id)).not_to include(user2_id)
 
         # user should be updated with new values
         user_after = StashEngine::User.find(user_id)


### PR DESCRIPTION
See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1820 about why this change and how someone was able to submit two versions (waiting on queue to set one of the states).

I also removed Merritt from the configuration file and hard coded it into the startup instead.  Seems kind of dumb to make it configurable like we're going to be switching between more than one storage repository frequently when we've never changed it in like 6 years.

PS. I attempted a bunch of updates to see if I could move github ubuntu version to 20.04, but it caused mysql problems and I reset my attempts and it will need to be a separate ticket that might take a while.