### PR TITLE
Tracks state when changing "tabs" in preliminary info

### DIFF
--- a/app/javascript/react/components/MetadataEntry/PrelimArticle.js
+++ b/app/javascript/react/components/MetadataEntry/PrelimArticle.js
@@ -154,7 +154,10 @@ export default PrelimArticle;
 PrelimArticle.propTypes = {
   resourceId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   identifierId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  publication_name: PropTypes.object.isRequired,
-  publication_issn: PropTypes.object.isRequired,
-  related_identifier: PropTypes.string.isRequired,
+  acText: PropTypes.string.isRequired,
+  setAcText: PropTypes.func.isRequired,
+  acID: PropTypes.string.isRequired,
+  setAcID: PropTypes.func.isRequired,
+  relatedIdentifier: PropTypes.string.isRequired,
+  setRelatedIdentifier: PropTypes.func.isRequired
 };

--- a/app/javascript/react/components/MetadataEntry/PrelimArticle.js
+++ b/app/javascript/react/components/MetadataEntry/PrelimArticle.js
@@ -8,15 +8,16 @@ import PrelimAutocomplete from './PrelimAutocomplete';
 function PrelimArticle({
   resourceId,
   identifierId,
-  publication_name,
-  publication_issn,
-  related_identifier,
+  acText,
+  setAcText,
+  acID,
+  setAcID,
+  relatedIdentifier,
+  setRelatedIdentifier,
 }) {
   const formRef = useRef();
 
   // the follow autocomplete items are lifted up state that is normally just part of the form, but doesn't work with Formik
-  const [acText, setAcText] = useState(publication_name.value);
-  const [acID, setAcID] = useState(publication_issn.value);
   const [importError, setImportError] = useState('');
 
   const submitForm = (values) => {
@@ -36,6 +37,8 @@ function PrelimArticle({
       primary_article_doi: values.primary_article_doi,
       do_import: values.isImport,
     };
+
+    setRelatedIdentifier(values.primary_article_doi);
 
     // submit by json
     return axios.patch(
@@ -69,7 +72,7 @@ function PrelimArticle({
     <Formik
       initialValues={
             {
-              primary_article_doi: related_identifier,
+              primary_article_doi: relatedIdentifier,
               isImport: false,
             }
           }

--- a/app/javascript/react/components/MetadataEntry/PrelimArticle.js
+++ b/app/javascript/react/components/MetadataEntry/PrelimArticle.js
@@ -159,5 +159,5 @@ PrelimArticle.propTypes = {
   acID: PropTypes.string.isRequired,
   setAcID: PropTypes.func.isRequired,
   relatedIdentifier: PropTypes.string.isRequired,
-  setRelatedIdentifier: PropTypes.func.isRequired
+  setRelatedIdentifier: PropTypes.func.isRequired,
 };

--- a/app/javascript/react/components/MetadataEntry/PrelimInfo.js
+++ b/app/javascript/react/components/MetadataEntry/PrelimInfo.js
@@ -18,7 +18,7 @@ function PrelimInfo(
   const [acID, setAcID] = useState(publication_issn?.value || '');
   const [msId, setMsId] = useState(msid?.value || '');
   const [importType, setImportType] = useState(importInfo);
-  const [relatedIdentifier, setRelatedIdentifier] = related_identifier;
+  const [relatedIdentifier, setRelatedIdentifier] = useState(related_identifier);
   console.log('related_identifier', related_identifier);
 
   const optionChange = (choice) => {
@@ -109,9 +109,12 @@ function PrelimInfo(
               <PrelimArticle
                 resourceId={resourceId}
                 identifierId={identifierId}
-                publication_name={publication_name}
-                publication_issn={publication_issn}
-                related_identifier={related_identifier}
+                acText={acText}
+                setAcText={setAcText}
+                acID={acID}
+                setAcID={setAcID}
+                relatedIdentifier={relatedIdentifier}
+                setRelatedIdentifier={setRelatedIdentifier}
               />
             );
           default:

--- a/app/javascript/react/components/MetadataEntry/PrelimInfo.js
+++ b/app/javascript/react/components/MetadataEntry/PrelimInfo.js
@@ -14,10 +14,20 @@ function PrelimInfo(
 ) {
   const csrf = document.querySelector("meta[name='csrf-token']")?.getAttribute('content');
 
+  let tempVal;
+  if (msid?.value){
+    tempVal = 'manuscript';
+  }else if (related_identifier){
+    tempVal = 'published';
+  }else{
+    tempVal = importInfo;
+  }
+
+
   const [acText, setAcText] = useState(publication_name?.value || '');
   const [acID, setAcID] = useState(publication_issn?.value || '');
   const [msId, setMsId] = useState(msid?.value || '');
-  const [importType, setImportType] = useState(importInfo);
+  const [importType, setImportType] = useState(tempVal);
   const [relatedIdentifier, setRelatedIdentifier] = useState(related_identifier);
 
   const optionChange = (choice) => {

--- a/app/javascript/react/components/MetadataEntry/PrelimInfo.js
+++ b/app/javascript/react/components/MetadataEntry/PrelimInfo.js
@@ -14,7 +14,12 @@ function PrelimInfo(
 ) {
   const csrf = document.querySelector("meta[name='csrf-token']")?.getAttribute('content');
 
+  const [acText, setAcText] = useState(publication_name?.value || '');
+  const [acID, setAcID] = useState(publication_issn?.value || '');
+  const [msId, setMsId] = useState(msid?.value || '');
   const [importType, setImportType] = useState(importInfo);
+  const [relatedIdentifier, setRelatedIdentifier] = related_identifier;
+  console.log('related_identifier', related_identifier);
 
   const optionChange = (choice) => {
     setImportType(choice);
@@ -91,9 +96,12 @@ function PrelimInfo(
               <PrelimManu
                 resourceId={resourceId}
                 identifierId={identifierId}
-                publication_name={publication_name}
-                publication_issn={publication_issn}
-                msid={msid}
+                acText={acText}
+                setAcText={setAcText}
+                acID={acID}
+                setAcID={setAcID}
+                msId={msId}
+                setMsId={setMsId}
               />
             );
           case 'published':

--- a/app/javascript/react/components/MetadataEntry/PrelimInfo.js
+++ b/app/javascript/react/components/MetadataEntry/PrelimInfo.js
@@ -19,7 +19,6 @@ function PrelimInfo(
   const [msId, setMsId] = useState(msid?.value || '');
   const [importType, setImportType] = useState(importInfo);
   const [relatedIdentifier, setRelatedIdentifier] = useState(related_identifier);
-  console.log('related_identifier', related_identifier);
 
   const optionChange = (choice) => {
     setImportType(choice);

--- a/app/javascript/react/components/MetadataEntry/PrelimInfo.js
+++ b/app/javascript/react/components/MetadataEntry/PrelimInfo.js
@@ -15,14 +15,13 @@ function PrelimInfo(
   const csrf = document.querySelector("meta[name='csrf-token']")?.getAttribute('content');
 
   let tempVal;
-  if (msid?.value){
+  if (msid?.value) {
     tempVal = 'manuscript';
-  }else if (related_identifier){
+  } else if (related_identifier) {
     tempVal = 'published';
-  }else{
+  } else {
     tempVal = importInfo;
   }
-
 
   const [acText, setAcText] = useState(publication_name?.value || '');
   const [acID, setAcID] = useState(publication_issn?.value || '');

--- a/app/javascript/react/components/MetadataEntry/PrelimManu.js
+++ b/app/javascript/react/components/MetadataEntry/PrelimManu.js
@@ -154,7 +154,10 @@ export default PrelimManu;
 PrelimManu.propTypes = {
   resourceId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   identifierId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  publication_name: PropTypes.object.isRequired,
-  publication_issn: PropTypes.object.isRequired,
-  msid: PropTypes.object.isRequired,
+  acText: PropTypes.string.isRequired,
+  setAcText: PropTypes.func.isRequired,
+  acID: PropTypes.string.isRequired,
+  setAcID: PropTypes.func.isRequired,
+  msId: PropTypes.string.isRequired,
+  setMsId: PropTypes.func.isRequired,
 };

--- a/app/javascript/react/components/MetadataEntry/PrelimManu.js
+++ b/app/javascript/react/components/MetadataEntry/PrelimManu.js
@@ -8,15 +8,16 @@ import PrelimAutocomplete from './PrelimAutocomplete';
 function PrelimManu({
   resourceId,
   identifierId,
-  publication_name,
-  publication_issn,
-  msid,
+  acText,
+  setAcText,
+  acID,
+  setAcID,
+  msId,
+  setMsId,
 }) {
   const formRef = useRef();
 
   // the follow autocomplete items are lifted up state that is normally just part of the form, but doesn't work with Formik
-  const [acText, setAcText] = useState(publication_name?.value || '');
-  const [acID, setAcID] = useState(publication_issn?.value || '');
   const [importError, setImportError] = useState('');
 
   const submitForm = (values) => {
@@ -33,9 +34,11 @@ function PrelimManu({
       identifier_id: identifierId,
       resource_id: resourceId,
       publication_issn: acID,
-      msid: values.msid,
+      msid: values.msId,
       do_import: values.isImport,
     };
+
+    setMsId(values.msId);
 
     // submit by json
     return axios.patch(
@@ -69,7 +72,7 @@ function PrelimManu({
     <Formik
       initialValues={
             {
-              msid: msid.value || '',
+              msId: msId || '',
               isImport: false,
             }
           }
@@ -104,15 +107,15 @@ function PrelimManu({
               </div>
               <div className="c-input">
                 {/* eslint-disable jsx-a11y/label-has-associated-control */}
-                <label className="c-input__label required" htmlFor="msid">
+                <label className="c-input__label required" htmlFor="msId">
                   Manuscript Number
                 </label>
                 <Field
                   className="c-input__text"
                   placeholder="APPS-D-17-00113"
                   type="text"
-                  name="msid"
-                  id="msid"
+                  name="msId"
+                  id="msId"
                   onBlur={() => { // defaults to formik.handleBlur
                     formRef.current.values.isImport = false;
                     formik.handleSubmit();
@@ -131,7 +134,7 @@ function PrelimManu({
                   formRef.current.values.isImport = true;
                   formik.handleSubmit();
                 }}
-                disabled={(acText === '' || acID === '' || formRef?.current?.values.msid === '')}
+                disabled={(acText === '' || acID === '' || formRef?.current?.values.msId === '')}
               >
                 Import Manuscript Metadata
               </button>

--- a/spec/javascript/react/components/MetadataEntry/PrelimArticle.test.js
+++ b/spec/javascript/react/components/MetadataEntry/PrelimArticle.test.js
@@ -9,7 +9,8 @@ jest.mock('axios');
 
 describe('PrelimArticle', () => {
 
-  let resourceId, identifierId, publication_name, publication_issn, related_identifier;
+  let resourceId, identifierId, publication_name, publication_issn, related_identifier, acText, setAcText,
+      acID, setAcID, relatedIdentifier, setRelatedIdentifier;
 
   beforeEach(() => {
     resourceId = faker.datatype.number();
@@ -27,6 +28,15 @@ describe('PrelimArticle', () => {
       "value": `${faker.datatype.number({min:1000, max:9999})}-${faker.datatype.number({min:1000, max:9999})}`
     };
     related_identifier = faker.internet.url();
+
+    acText = publication_name.value;
+    setAcText = jest.fn();
+
+    acID = publication_issn.value;
+    setAcID = jest.fn();
+
+    relatedIdentifier = related_identifier;
+    setRelatedIdentifier = jest.fn();
   });
 
 
@@ -34,9 +44,12 @@ describe('PrelimArticle', () => {
     render(<PrelimArticle
         resourceId={resourceId}
         identifierId={identifierId}
-        publication_name={publication_name}
-        publication_issn={publication_issn}
-        related_identifier={related_identifier} />);
+        acText={acText}
+        setAcText={setAcText}
+        acID={acID}
+        setAcID={setAcID}
+        relatedIdentifier={relatedIdentifier}
+        setRelatedIdentifier={setRelatedIdentifier} />);
 
     const labeledElements = screen.getAllByLabelText('Journal Name', { exact: false });
     expect(labeledElements.length).toBe(2);
@@ -56,9 +69,12 @@ describe('PrelimArticle', () => {
     render(<PrelimArticle
         resourceId={resourceId}
         identifierId={identifierId}
-        publication_name={publication_name}
-        publication_issn={publication_issn}
-        related_identifier={related_identifier} />);
+        acText={acText}
+        setAcText={setAcText}
+        acID={acID}
+        setAcID={setAcID}
+        relatedIdentifier={relatedIdentifier}
+        setRelatedIdentifier={setRelatedIdentifier} />);
 
     userEvent.clear(screen.getByLabelText('DOI'));
     userEvent.type(screen.getByLabelText('DOI'), '12345.dryad/fa387gek');

--- a/spec/javascript/react/components/MetadataEntry/PrelimInfo.test.js
+++ b/spec/javascript/react/components/MetadataEntry/PrelimInfo.test.js
@@ -31,9 +31,9 @@ describe('PrelimInfo', () => {
       "id": faker.datatype.number(),
       "identifier_id": identifierId,
       "data_type": "manuscriptNumber",
-      "value": `CROM-${faker.datatype.number({min:1000, max:9999})}-${faker.datatype.number({min:1000, max:9999})}`
+      "value": ''
     }
-    related_identifier = faker.internet.url();
+    related_identifier = '';
   });
 
   it("renders the preliminary information section", () => {

--- a/spec/javascript/react/components/MetadataEntry/PrelimManu.test.js
+++ b/spec/javascript/react/components/MetadataEntry/PrelimManu.test.js
@@ -9,7 +9,8 @@ jest.mock('axios');
 
 describe('PrelimManu', () => {
 
-  let resourceId, identifierId, publication_name, publication_issn, msid;
+  let resourceId, identifierId, publication_name, publication_issn, msid, acText, setAcText,
+      acID, setAcID, msId, setMsId;
 
   beforeEach(() => {
     resourceId = faker.datatype.number();
@@ -32,15 +33,27 @@ describe('PrelimManu', () => {
       "data_type": "manuscriptNumber",
       "value": `CROM-${faker.datatype.number({min:1000, max:9999})}-${faker.datatype.number({min:1000, max:9999})}`
     }
+
+    acText = publication_name.value;
+    setAcText = jest.fn();
+
+    acID = publication_issn.value;
+    setAcID = jest.fn();
+
+    msId = msid.value;
+    setMsId = jest.fn();
   });
 
   it("renders the basic article and manuscript id form", () => {
     render(<PrelimManu
         resourceId={resourceId}
         identifierId={identifierId}
-        publication_name={publication_name}
-        publication_issn={publication_issn}
-        msid={msid} />);
+        acText={acText}
+        setAcText={setAcText}
+        acID={acID}
+        setAcID={setAcID}
+        msId={msId}
+        setMsId={setMsId} />);
 
     const labeledElements = screen.getAllByLabelText('Journal Name', { exact: false });
     expect(labeledElements.length).toBe(2);
@@ -60,9 +73,12 @@ describe('PrelimManu', () => {
     render(<PrelimManu
         resourceId={resourceId}
         identifierId={identifierId}
-        publication_name={publication_name}
-        publication_issn={publication_issn}
-        msid={msid} />);
+        acText={acText}
+        setAcText={setAcText}
+        acID={acID}
+        setAcID={setAcID}
+        msId={msId}
+        setMsId={setMsId} />);
 
     userEvent.clear(screen.getByLabelText('Manuscript Number'));
     userEvent.type(screen.getByLabelText('Manuscript Number'), 'GUD-MS-387-555');


### PR DESCRIPTION
See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1770

- Added code for tracking state across the "Preliminary info" "tabs."
- If people have added identifiers for manuscript or published article then default to that "tab" first.

To test that it retains settings for radio buttons:
- Start new dataset.
- Choose a different radio button choice.
- Navigate out and then re-enter dataset from "My Datasets" page and see that previously selected choice is still selected.

To test that it forces to the "tab" where an identifier is entered:
- Start a new dataset.
- Choose either of the two first choices and type in something for the identifier (MSID or DOI).
- Navigate back to "Other or not applicable"
- navigate out to the "my Datasets page" and then re-enter.
- Note that it forces to the first "tab" where you entered an identifier, even though you chose the last tab before.

To test that it now remembers the updated identifier you typed in after switching tabs.  (Before it would revert to showing the page-loaded value if you switched tabs, but saved correctly and it would show correctly if reloading the page)
- Start dataset
- Go to the first tab and enter a manuscript ID of your choice.
- Go to the second tab and enter a doi of your choice.
- Switch back to the first tab and note that it didn't revert the ID in the display and still has what you typed in.
- Switch to second tab and observe the same.

To test that the population still works correctly and I didn't break stuff you can try these items on development for auto-populating:

```
manuscript example:
Journal: Ecological Applications
MS number: 20-0939

DOI Article examples:
Journal of Ecology
10.1111/1365-2745.13903
```