### PR TITLE
Track new DataCite counter stats

### DIFF
--- a/app/views/layouts/stash_engine/_landing_head.html.erb
+++ b/app/views/layouts/stash_engine/_landing_head.html.erb
@@ -1,0 +1,8 @@
+<% if Rails.env == 'production' %>
+  <!-- Track View for counter -->
+  <!-- We don't need to include doi since in schema.org, but if not the data-doi attribute is what we'd use -->
+  <script defer
+        data-repoid="datadryad.org"
+        data-metric="view"
+        src="https://cdn.jsdelivr.net/npm/@datacite/datacite-tracker"></script>
+<% end %>

--- a/app/views/layouts/stash_engine/_standard_head.html.erb
+++ b/app/views/layouts/stash_engine/_standard_head.html.erb
@@ -11,11 +11,6 @@
 
 <%= render 'layouts/stash_engine/google_analytics' %>
 
-<% if Rails.env == 'production' %>
-  <!-- for experimental tracking of Counter Code of Practice stats on production -->
-  <script async defer data-domain="datadryad.org" src="https://plausible.io/js/plausible.js"></script>
-<% end %>
-
 <%= csrf_meta_tags %>
 
 <%= favicon_link_tag 'favicon.ico' %>

--- a/app/views/layouts/stash_engine/application.html.erb
+++ b/app/views/layouts/stash_engine/application.html.erb
@@ -3,6 +3,9 @@
 <head>
   <%= render 'layouts/stash_engine/standard_head' %>
   <%= render 'layouts/stash_engine/stash_head' %>
+  <% if controller_name == 'landing' && action_name == 'show' %>
+    <%= render 'layouts/stash_engine/landing_head' %>
+  <% end %>
 </head>
 <body class='<%= "#{controller_name}_#{action_name}" %>'>
   <%= render 'layouts/stash_engine/top_area' %>


### PR DESCRIPTION
Adding a special header to only the landing page on production and include their tracking code.