### PR TITLE
Fixes validation for primary article doi in some cases

### DIFF
--- a/app/controllers/stash_datacite/publications_controller.rb
+++ b/app/controllers/stash_datacite/publications_controller.rb
@@ -89,7 +89,8 @@ module StashDatacite
         standard_doi = RelatedIdentifier.standardize_doi(bare_form_doi)
 
         # user is expanding on a DOI that we already have; update it in the DB (and change the work_type if needed)
-        rd.update(related_identifier: standard_doi, work_type: 'primary_article', hidden: false)
+        rd.update(related_identifier: standard_doi, related_identifier_type: 'doi', work_type: 'primary_article',
+                  hidden: false)
         rd.update(verified: rd.live_url_valid?) # do this separately since we need the doi in standard format in object to check
         return nil
       end

--- a/app/models/stash_datacite/resource/dataset_validations.rb
+++ b/app/models/stash_datacite/resource/dataset_validations.rb
@@ -155,9 +155,16 @@ module StashDatacite
           @resource.identifier.manuscript_number.blank? &&
           @resource.identifier.publication_article_doi.blank?
 
-        ErrorItem.new(message: "Fill in a {manuscript number or DOI} for the article from #{@resource.identifier.publication_name}",
-                      page: metadata_page(@resource),
-                      ids: %w[msid primary_article_doi])
+        if @resource.related_identifiers.where(work_type: 'primary_article').count.positive? # has primary, but not doi
+          ErrorItem.new(message: "Fill in {a correctly formatted DOI} for your article from #{@resource.identifier
+                                                                                          .publication_name}",
+                        page: metadata_page(@resource),
+                        ids: %w[primary_article_doi])
+        else
+          ErrorItem.new(message: "Fill in a {manuscript number or DOI} for the article from #{@resource.identifier.publication_name}",
+                        page: metadata_page(@resource),
+                        ids: %w[msid primary_article_doi])
+        end
       end
 
       def s3_error_uploads

--- a/spec/models/stash_datacite/dataset_validations_spec.rb
+++ b/spec/models/stash_datacite/dataset_validations_spec.rb
@@ -108,6 +108,19 @@ module StashDatacite
           expect(error.ids).to eq(%w[msid primary_article_doi])
         end
 
+        it 'gives a formatting error when someone puts in a URL instead of a DOI' do
+          StashEngine::InternalDatum.create(data_type: 'publicationName',
+                                            value: 'Barrel of Monkeys: the Primate Journal',
+                                            identifier_id: @resource.identifier_id)
+          create(:related_identifier, resource_id: @resource.id, related_identifier_type: 'url', work_type:
+            'primary_article')
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.article_id
+
+          expect(error.message).to include('formatted DOI')
+          expect(error.ids).to eq(%w[primary_article_doi])
+        end
+
         it "doesn't give error if manuscript filled" do
           StashEngine::InternalDatum.create(data_type: 'publicationName',
                                             value: 'Barrel of Monkeys: the Primate Journal',


### PR DESCRIPTION
There were a couple problems that were tricky to troubleshoot since they only came up in some cases.

- Primary articles should be DOIs, but we allow putting in other things in related works and try to magically detect the type among many different types.  Some types of DOI urls seem to be ambiguous in some way so they are were classified as URLs even in the "primary article" slot at the top which is also a related work.  Forced this to hard code as DOI rather than autodetecting.
- If a primary article is another type in the data then it gave a generic message that the identifier wasn't filled, which was incorrect.  The problem was that a primary article needs a DOI and not a URL.  Change the validation to detect this case and supply a better error message that is more specific.