### PR TITLE
Ignore bad curators in sorting on curation page

### DIFF
--- a/app/helpers/stash_engine/admin_datasets_helper.rb
+++ b/app/helpers/stash_engine/admin_datasets_helper.rb
@@ -29,7 +29,7 @@ module StashEngine
 
     def editor_select
       curators = StashEngine::User.curators
-      curators.sort { |a, b| "#{a.last_name}" <=> "#{b.last_name}" }.map do |c|
+      curators.sort { |a, b| a.last_name.to_s <=> b.last_name.to_s }.map do |c|
         [c.name_last_first, c.id]
       end
     end

--- a/app/helpers/stash_engine/admin_datasets_helper.rb
+++ b/app/helpers/stash_engine/admin_datasets_helper.rb
@@ -29,7 +29,7 @@ module StashEngine
 
     def editor_select
       curators = StashEngine::User.curators
-      curators.sort { |a, b| a.last_name <=> b.last_name }.map do |c|
+      curators.sort { |a, b| "#{a.last_name}" <=> "#{b.last_name}" }.map do |c|
         [c.name_last_first, c.id]
       end
     end


### PR DESCRIPTION
Curators were set for "Ambika" and "silverfish-stage".  In general a last name is usually required.  convert to string if no last name so that sort works properly.