### PR TITLE
This enables a feature for tenant with IP Address verification

### DIFF
--- a/app/controllers/stash_datacite/publications_controller.rb
+++ b/app/controllers/stash_datacite/publications_controller.rb
@@ -5,6 +5,8 @@ require 'stash/import/dryad_manuscript'
 require 'stash/link_out/pubmed_sequence_service'
 require 'stash/link_out/pubmed_service'
 require 'cgi'
+
+# rubocop:disable Metrics/ClassLength
 module StashDatacite
   class PublicationsController < ApplicationController
     def update
@@ -259,3 +261,4 @@ module StashDatacite
 
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/views/stash_engine/pages/ip_error.html.erb
+++ b/app/views/stash_engine/pages/ip_error.html.erb
@@ -1,0 +1,17 @@
+<% @page_title = "Login Error" %>
+
+<h1 class="o-heading__level2">Unable to log in to your organization's Dryad account</h1>
+
+<p>Please <%= link_to 'try logging in again', stash_url_helpers.choose_login_path %> while using
+  your organization's network or VPN in order to validate your membership in Dryad.</p>
+
+<p>
+  After successfully logging in for the first time you will no longer need to be on your organization's network
+  or VPN for subsequent logins.
+</p>
+
+<p>
+  Please email <a href="mailto:help@datadryad.org">help@datadryad.org</a> if the problem persists after trying from your
+  organization's network or VPN.
+</p>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,6 +259,7 @@ Rails.application.routes.draw do
     get '404', to: 'pages#app_404', as: 'app_404'
     get 'landing/metrics/:identifier_id', to: 'landing#metrics', as: 'show_metrics'
     get 'test', to: 'pages#test'
+    get 'ip_error', to: 'pages#ip_error'
     
     patch 'dataset/*id', to: 'landing#update', constraints: { id: /\S+/ }
     

--- a/config/tenants/dryad_iptest.yml
+++ b/config/tenants/dryad_iptest.yml
@@ -1,0 +1,80 @@
+default: &default
+  enabled: true
+  repository:
+    domain: https://merritt-stage.cdlib.org
+    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
+    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
+    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
+  abbreviation: "dryad_ip"
+  short_name: "Dryad IP Address Test"
+  long_name: "Dryad Digital Repository IP Address Test"
+  publisher_id: isni:0000000446638050
+  ror_ids:
+    - https://ror.org/dummy
+  tenant_id: dryad_ip
+  identifier_service:
+    provider: datacite
+    prefix: "10.7959"
+    account: <%= Rails.application.credentials[Rails.env.to_sym][:datacite_username] %>
+    password: <%= Rails.application.credentials[Rails.env.to_sym][:datacite_password] %>
+    sandbox: true
+  authentication:
+    strategy: ip_address
+    ranges: ["128.48.67.15/255.255.255.0", "127.0.0.1/255.255.255.0"]
+  default_license: cc0
+  campus_contacts: ["scott.fisher@ucop.edu"] # for testing
+  data_deposit_agreement: false
+  partner_display: true
+  covers_dpc: true
+
+development: &DEVELOPMENT
+  <<: *default
+  #Add any items that need to override the defaults here
+
+
+local_dev:
+  <<: *DEVELOPMENT
+
+aws_db:
+  <<: *default
+
+local:
+  <<: *default
+  #Add any items that need to override the defaults here
+
+stage:
+  <<: *default
+  #Add any items that need to override the defaults here
+  repository:
+    domain: https://merritt-stage.cdlib.org
+    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
+    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
+    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
+
+migration:
+  <<: *default
+  #Add any items that need to override the defaults here
+  repository:
+    domain: https://merritt.cdlib.org
+    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
+    username: <%= Rails.application.credentials[:production][:merritt_dryad_username] %>
+    password: <%= Rails.application.credentials[:production][:merritt_dryad_password] %>
+
+production:
+  <<: *default
+  #Add any items that need to override the defaults here
+  enabled: false
+  repository:
+    domain: https://merritt.cdlib.org
+    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
+    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
+    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
+  identifier_service:
+    provider: datacite
+    prefix: "10.5061"
+    account: <%= Rails.application.credentials[Rails.env.to_sym][:datacite_username] %>
+    password: <%= Rails.application.credentials[Rails.env.to_sym][:datacite_password] %>
+    sandbox: false
+  campus_contacts: ["Daniella.Lowenberg@ucop.edu"]
+
+

--- a/documentation/tenants.md
+++ b/documentation/tenants.md
@@ -101,6 +101,12 @@ authentication:
 - A strategy of `author_match` allows login by that institution without
   shibboleth validation, but requires an author to be from the same tenant
   (an author ROR institution should match).
+- A strategy of `ip_address` allows validating membership by requiring that
+  the user logs in from their organization network the first time.  The organization
+  supplies the network ranges that are allowed and we put in an array under the
+  key `ranges`.  The format is those accepted by ipaddr.rb which could be in
+  CIDR (ie "192.168.1.0/24") or network mask formats like "192.168.1.0/255.255.255.0"
+  (see their docs).  It also supports IPv6 (which we're not currently using).
 
 `default_license` is either cc0 or cc_by right now but might be set to
 other licenses configured at the application-level with some text and

--- a/spec/mocks/tenant.rb
+++ b/spec/mocks/tenant.rb
@@ -22,6 +22,37 @@ module Mocks
         password: 'bogus_password'
       }
 
+      setup_submocks(tenant: tenant, auth_params: auth_params, id_params: id_params, repo_params: repo_params,
+                     covers_dpc: covers_dpc)
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    def mock_ip_tenant!(ip_string:, covers_dpc: true)
+      tenant = double(StashEngine::Tenant)
+
+      auth_params = {
+        strategy: 'ip_address',
+        ranges: [ip_string]
+      }
+      id_params = {
+        provider: 'datacite',
+        prefix: '10.5072',
+        account: 'stash',
+        password: '3cc9d3fbd9788148c6a32a1415fa673a',
+        sandbox: true
+      }
+      repo_params = {
+        domain: 'https://merritt-stage.cdlib.org',
+        endpoint: 'http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev',
+        username: 'some_fake_user',
+        password: 'bogus_password'
+      }
+
+      setup_submocks(tenant: tenant, auth_params: auth_params, id_params: id_params, repo_params: repo_params,
+                     covers_dpc: covers_dpc)
+    end
+
+    def setup_submocks(tenant:, auth_params:, id_params:, repo_params:, covers_dpc:)
       allow(tenant).to receive(:abbreviation).and_return('mock_tenant')
       allow(tenant).to receive(:authentication).and_return(OpenStruct.new(auth_params))
       allow(tenant).to receive(:campus_contacts).and_return(['contact@someuniversity.edu'])
@@ -45,8 +76,6 @@ module Mocks
       allow_any_instance_of(StashEngine::Resource).to receive(:tenant).and_return(tenant)
       allow(StashEngine::Tenant).to receive(:find).and_return(tenant)
     end
-    # rubocop:enable Metrics/AbcSize
-
   end
 
 end

--- a/spec/mocks/tenant.rb
+++ b/spec/mocks/tenant.rb
@@ -1,7 +1,6 @@
+# rubocop:disable Metrics/AbcSize
 module Mocks
   module Tenant
-
-    # rubocop:disable Metrics/AbcSize
     def mock_tenant!(covers_dpc: false)
       tenant = double(StashEngine::Tenant)
 
@@ -25,7 +24,6 @@ module Mocks
       setup_submocks(tenant: tenant, auth_params: auth_params, id_params: id_params, repo_params: repo_params,
                      covers_dpc: covers_dpc)
     end
-    # rubocop:enable Metrics/AbcSize
 
     def mock_ip_tenant!(ip_string:, covers_dpc: true)
       tenant = double(StashEngine::Tenant)
@@ -77,5 +75,5 @@ module Mocks
       allow(StashEngine::Tenant).to receive(:find).and_return(tenant)
     end
   end
-
 end
+# rubocop:enable Metrics/AbcSize

--- a/spec/requests/stash_engine/sessions_controller_spec.rb
+++ b/spec/requests/stash_engine/sessions_controller_spec.rb
@@ -1,0 +1,27 @@
+module StashEngine
+  RSpec.describe SessionsController, type: :request do
+    include Mocks::Tenant
+
+    describe '#sso-ip_address' do
+      it 'allows user in with allowed IP address' do
+        mock_ip_tenant!(ip_string: "127.0.0.1/255.255.255.0")
+        @user = create(:user, role: 'user')
+        allow_any_instance_of(SessionsController).to receive(:session).and_return({ user_id: @user.id }.to_ostruct)
+
+        response_code = post "/stash/sessions/sso", params: { 'tenant_id' => nil } # tenant mock means not needed
+        expect(response_code).to eql(302) # redirect
+        expect(response.headers['Location']).to include('/stash/dashboard')
+      end
+
+      it 'blocks user from non-allowed IP address' do
+        mock_ip_tenant!(ip_string: "192.168.1.0/255.255.255.0")
+        @user = create(:user, role: 'user')
+        allow_any_instance_of(SessionsController).to receive(:session).and_return({ user_id: @user.id }.to_ostruct)
+
+        response_code = post "/stash/sessions/sso", params: { 'tenant_id' => nil } # tenant mock means not needed
+        expect(response_code).to eql(302) # redirect
+        expect(response.headers['Location']).to include('/stash/ip_error')
+      end
+    end
+  end
+end

--- a/spec/requests/stash_engine/sessions_controller_spec.rb
+++ b/spec/requests/stash_engine/sessions_controller_spec.rb
@@ -4,21 +4,21 @@ module StashEngine
 
     describe '#sso-ip_address' do
       it 'allows user in with allowed IP address' do
-        mock_ip_tenant!(ip_string: "127.0.0.1/255.255.255.0")
+        mock_ip_tenant!(ip_string: '127.0.0.1/255.255.255.0')
         @user = create(:user, role: 'user')
         allow_any_instance_of(SessionsController).to receive(:session).and_return({ user_id: @user.id }.to_ostruct)
 
-        response_code = post "/stash/sessions/sso", params: { 'tenant_id' => nil } # tenant mock means not needed
+        response_code = post '/stash/sessions/sso', params: { 'tenant_id' => nil } # tenant mock means not needed
         expect(response_code).to eql(302) # redirect
         expect(response.headers['Location']).to include('/stash/dashboard')
       end
 
       it 'blocks user from non-allowed IP address' do
-        mock_ip_tenant!(ip_string: "192.168.1.0/255.255.255.0")
+        mock_ip_tenant!(ip_string: '192.168.1.0/255.255.255.0')
         @user = create(:user, role: 'user')
         allow_any_instance_of(SessionsController).to receive(:session).and_return({ user_id: @user.id }.to_ostruct)
 
-        response_code = post "/stash/sessions/sso", params: { 'tenant_id' => nil } # tenant mock means not needed
+        response_code = post '/stash/sessions/sso', params: { 'tenant_id' => nil } # tenant mock means not needed
         expect(response_code).to eql(302) # redirect
         expect(response.headers['Location']).to include('/stash/ip_error')
       end


### PR DESCRIPTION
Added a tenant dryad_ip for testing (non-production) that uses ip_address validation, if strategy 'ip_address' is given, it looks like below:

```
  authentication:
    strategy: ip_address
    ranges: ["128.48.67.15/255.255.255.0", "127.0.0.1/255.255.255.0"]
```

This test allows testing on certain IP addresses if the user tenant is reset.  If on a certain VPN then lets in, but it not then displays information and doesn't allow continuing login.