### PR TITLE
Windows in blank tab rather than named tab

### DIFF
--- a/app/views/stash_engine/admin_datasets/_datasets_row.html.erb
+++ b/app/views/stash_engine/admin_datasets/_datasets_row.html.erb
@@ -3,7 +3,7 @@
   <!-- Title -->
   <td class="c-admin-hide-border-right">
     <% if dataset&.qualified_identifier %>
-      <%= link_to dataset.title, stash_url_helpers.show_path(id: dataset.qualified_identifier), target: :blank %>
+      <%= link_to dataset.title, stash_url_helpers.show_path(id: dataset.qualified_identifier), target: '_blank' %>
     <% else %>
       <%= dataset.title %>
     <% end %>

--- a/app/views/stash_engine/admin_datasets/activity_log.html.erb
+++ b/app/views/stash_engine/admin_datasets/activity_log.html.erb
@@ -70,7 +70,7 @@
 		    <% sf_links.each do |sf_link| %>
 			<tr class="c-lined-table__row">
 			    <td>				
-				<%= link_to sf_link.title, sf_link.path, target: :blank %>
+				<%= link_to sf_link.title, sf_link.path, target: '_blank' %>
 			    </td>
 			    <td>
 				<%= sf_link.status %>

--- a/app/views/stash_engine/publication_updater/_current_metadata.html.erb
+++ b/app/views/stash_engine/publication_updater/_current_metadata.html.erb
@@ -1,6 +1,6 @@
 <td>
   <strong>Dateset:</strong>
-  <%= link_to resource.title, show_path(id: resource.identifier.to_s), target: :blank %>
+  <%= link_to resource.title, show_path(id: resource.identifier.to_s), target: '_blank' %>
 </td>
 <td class="c-proposed-change-table__column-centered"><strong>Current Metadata</strong></td>
 <td><%= existing_pubname %></td>

--- a/app/views/stash_engine/publication_updater/_proposed_metadata.html.erb
+++ b/app/views/stash_engine/publication_updater/_proposed_metadata.html.erb
@@ -1,6 +1,6 @@
 <td>
   <strong>Publication:</strong>
-  <%= link_to proposed_change.title, proposed_change.url, target: :blank %>
+  <%= link_to proposed_change.title, proposed_change.url, target: '_blank' %>
 </td>
 <td class="c-proposed-change-table__column-centered">
   <strong>Changes</strong>


### PR DESCRIPTION
Jess had commented that tabs were being reused when being opened.

In some cases it was using a named tab instead of the special new tab syntax "_blank" (not :blank or 'blank').