### PR TITLE
fix: ORCID link stuff not showing up for curators

### DIFF
--- a/app/javascript/react/components/MetadataEntry/OrcidInfo.js
+++ b/app/javascript/react/components/MetadataEntry/OrcidInfo.js
@@ -27,11 +27,11 @@ export default function OrcidInfo({
           &nbsp;&nbsp;Corresponding Author
         </div>
       )}
-      {(curator && dryadAuthor.orcid_invite_path
+      {(curator && !orcidInfo && dryadAuthor.orcid_invite_path
         ? (
-          <div className="c-orcid__div">
-            Associate &nbsp;<span className="c-orcid__icon" />&nbsp;at {dryadAuthor.orcid_invite_path}
-          </div>
+           <div className="c-orcid__div">
+             Associate &nbsp;<span className="c-orcid__icon" />&nbsp;at {dryadAuthor.orcid_invite_path}
+            </div>
         ) : '')}
     </div>
   );

--- a/app/javascript/react/components/MetadataEntry/OrcidInfo.js
+++ b/app/javascript/react/components/MetadataEntry/OrcidInfo.js
@@ -29,9 +29,9 @@ export default function OrcidInfo({
       )}
       {(curator && !orcidInfo && dryadAuthor.orcid_invite_path
         ? (
-           <div className="c-orcid__div">
-             Associate &nbsp;<span className="c-orcid__icon" />&nbsp;at {dryadAuthor.orcid_invite_path}
-            </div>
+          <div className="c-orcid__div">
+            Associate &nbsp;<span className="c-orcid__icon" />&nbsp;at {dryadAuthor.orcid_invite_path}
+          </div>
         ) : '')}
     </div>
   );

--- a/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
+++ b/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
@@ -30,9 +30,7 @@
       <%= react_component('components/MetadataEntry/Authors', { resource: @resource,
           dryadAuthors: @resource.authors.includes(:affiliations).map{|auth| auth.as_json.merge(
               affiliation: auth.affiliation.as_json,
-              orcid_invite_path:
-                  (auth.author_orcid.blank? && auth.author_email.present? && auth.resource.identifier.pub_state == 'published' ?
-                       auth.orcid_invite_path : nil ))},
+              orcid_invite_path: auth&.orcid_invite_path)},
               curator: current_user&.curator?, icon: '/images/fa-barfs.svg', # because the asset pipeline not working right on stage
               correspondingAuthorId: @resource.owner_author&.id
       } ) %>


### PR DESCRIPTION
Previously the special links only showed on published datasets for curators to give people invite links.

This gets passed through and now shows for curators on any that don't already have an ORCID and whatever state the dataset is in.  Turned out to be a simple change but just needed to trace few a few UI levels to figure out.