### PR TITLE
Don't allow setting back to private for peer review after publishing

### DIFF
--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -285,6 +285,7 @@ module StashEngine
     end
 
     def allow_review?
+      return false if pub_state == 'published' # do not allow to go into peer review after already published
       return true if journal.blank?
       return true if last_submitted_resource&.current_curation_status == 'peer_review'
 

--- a/spec/models/stash_engine/identifier_spec.rb
+++ b/spec/models/stash_engine/identifier_spec.rb
@@ -555,6 +555,11 @@ module StashEngine
         expect(@identifier.allow_review?).to be(false)
       end
 
+      it 'disallows review if already published' do
+        @identifier.pub_state = 'published'
+        expect(@identifier.allow_review?).to be(false)
+      end
+
       it 'allows review when the curation status is review, regardless of journal settings' do
         Journal.create(issn: @fake_issn, allow_review_workflow: false)
         allow_any_instance_of(Resource).to receive(:current_curation_status).and_return('peer_review')


### PR DESCRIPTION
I guess some users were doing this after publishing and it doesn't really work right to do this, anyway, since the data will be out there on the internet about the dataset (in zenodo, in solr search, maybe in Google results and maybe referenced by other works).

Should avoid making something private or removing after being public unless good reason and not just at author's whim.