### PR TITLE
Environment cleanup for dev/stage

### DIFF
--- a/lib/stash/indexer/solr_indexer.rb
+++ b/lib/stash/indexer/solr_indexer.rb
@@ -10,7 +10,7 @@ module Stash
 
       def initialize(solr_url:)
         # rsolr gives lots of other config options, but this is probably all we need for now
-        @solr = RSolr.connect(url: solr_url, retry_503: 3, retry_after_limit: 1, read_timeout: 20, open_timeout: 20)
+        @solr = RSolr.connect(url: solr_url, retry_503: 3, retry_after_limit: 1, timeout: 20)
       end
 
       def index_document(solr_hash:)

--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -252,7 +252,7 @@ namespace :dev_ops do
         # delete this dataset with no useful files
         puts '  Deleting from SOLR'
         solr = RSolr.connect url: Blacklight.connection_config[:url]
-        solr.delete_by_query("uuid:\"#{ident.to_s}\"")
+        solr.delete_by_query("uuid:\"#{ident}\"")
         solr.commit
 
         puts '  Removing from the database'

--- a/lib/tasks/rsolr.rake
+++ b/lib/tasks/rsolr.rake
@@ -6,6 +6,7 @@ namespace :rsolr do
     ids = StashEngine::Identifier.all.publicly_viewable
     ids.each_with_index do |identifier, idx|
       puts "#{idx + 1}/#{ids.count} processed" if ((idx + 1) % 500) == 0 # only output progress occasionally, but good to know it's working
+      next if identifier.resources.submitted&.by_version_desc&.first.nil?
       identifier.latest_resource_with_public_metadata&.submit_to_solr
     end
     p 'Complete'

--- a/lib/tasks/rsolr.rake
+++ b/lib/tasks/rsolr.rake
@@ -7,6 +7,7 @@ namespace :rsolr do
     ids.each_with_index do |identifier, idx|
       puts "#{idx + 1}/#{ids.count} processed" if ((idx + 1) % 500) == 0 # only output progress occasionally, but good to know it's working
       next if identifier.resources.submitted&.by_version_desc&.first.nil?
+
       identifier.latest_resource_with_public_metadata&.submit_to_solr
     end
     p 'Complete'

--- a/script/clear_data.rb
+++ b/script/clear_data.rb
@@ -1,3 +1,4 @@
+require 'rsolr'
 module ClearData
 
   def self.clear_data
@@ -12,18 +13,22 @@ module ClearData
     end
   end
 
+  # this now gives "stream Body id disabled"
   def self.clear_solr
-    clear_solr_url = "#{Blacklight.connection_config[:url]}/update?stream.body" +
-        '=<delete><query>*:*</query></delete>&commit=true'
+    # clear_solr_url = "#{Blacklight.connection_config[:url]}/update?stream.body" +
+    #    '=<delete><query>*:*</query></delete>&commit=true'
 
-    puts "Clearing solr with #{clear_solr_url}"
+    puts "Clearing solr data"
 
+    solr = RSolr.connect url: Blacklight.connection_config[:url]
+    solr.delete_by_query("*:*")
+    solr.commit
     # the following, commented out, is a query test to see if SOLR blacklight is accessible
     #response = HTTParty.get("#{Blacklight.connection_config[:url]}/select?q=*%3A*&wt=json&indent=true")
     #puts response
 
     # this one will actually clear things out
-    response = HTTParty.get(clear_solr_url)
+    # response = HTTParty.get(clear_solr_url)
   end
 
 end


### PR DESCRIPTION
I tested this on development and removed extra crap.  It will not run on production (exits early if tried).

- The rake task `dev_ops:clean_datasets` deletes published datasets that do not have a corresponding file in Merritt (tests a single file from each dataset).
- Afterward, run the updated script `ClearData.clear_solr` which I needed to change since the old method no longer worked.  It clears all records from SOLR.
- Then run the rake task `rsolr:reindex` to repopulate the records for search.

This should make the things in the public UI work and get rid of most of the test data that didn't actually have files uploaded.

Some instructions from previous pull request should go away if other branch merged first.  I accidentally started my branch off that one instead of main.