### PR TITLE
Only show 5 lines of csv if it's not very wide

### DIFF
--- a/app/controllers/stash_engine/downloads_controller.rb
+++ b/app/controllers/stash_engine/downloads_controller.rb
@@ -128,6 +128,9 @@ module StashEngine
     def preview_csv
       @data_file = DataFile.find(params[:file_id])
       @preview = (@data_file.preview_file if @data_file&.resource&.may_download?(ui_user: current_user))
+
+      # limit to only 5 lines at most and make unix line endings
+      @preview = @preview.split(/$/).map(&:strip)[0..5].join("\n") if @preview.class == String
     end
 
     private

--- a/app/views/stash_engine/downloads/_preview_csv.html.erb
+++ b/app/views/stash_engine/downloads/_preview_csv.html.erb
@@ -3,7 +3,8 @@
 <h1 class="c-modal-h1">CSV preview of <%= file.upload_file_name %></h1>
 
 <% if preview %>
-  <pre id='preview_csv'><%= preview.strip -%> ...</pre><br/>
+  <pre id='preview_csv'><%= preview.strip %>
+...</pre><br/>
   <button id='copy_csv' class="o-banner__button">
     <i class="fa fa-clipboard"></i> Copy preview text to clipboard
   </button>


### PR DESCRIPTION
Only show 5 lines of the csv.  This uses a regex for end of line so we don't have to know if it's unix or windows line endings.  Splits and reconstitutes the preview lines as Unix file endings.