### PR TITLE
Improve automatic workflow actions caused by journal API calls

### DIFF
--- a/app/controllers/stash_api/datasets_controller.rb
+++ b/app/controllers/stash_api/datasets_controller.rb
@@ -475,8 +475,13 @@ module StashApi
       note = 'status updated via API call'
 
       # DON'T go backwards in workflow,
-      # that is, don't change a status other than submitted or peer_review
+      # don't change a status other than submitted or peer_review
       unless %w[submitted peer_review].include?(@resource.current_curation_status)
+        note = "received API request to change status to #{new_status}, but retaining current curation status due to workflow rules"
+        new_status = @resource.current_curation_status
+      end
+      # and certainly don't withdraw something that was previously published
+      if (new_status == 'withdrawn') && @resource.previously_public?
         note = "received API request to change status to #{new_status}, but retaining current curation status due to workflow rules"
         new_status = @resource.current_curation_status
       end

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -920,9 +920,6 @@ module StashEngine
     end
 
     def auto_assign_curator(target_status:)
-      curation_activities << StashEngine::CurationActivity.create(user_id: 0, status: target_status,
-                                                                  note: 'System auto-assigned curator')
-
       target_curator = identifier.most_recent_curator
       if target_curator.nil? || !target_curator.curator?
         # if the previous curator does not exist, or is no longer a curator,
@@ -931,7 +928,11 @@ module StashEngine
         target_curator = cur_list[rand(cur_list.length)]
       end
 
-      update(current_editor_id: target_curator.id) if target_curator
+      return unless target_curator
+
+      update(current_editor_id: target_curator.id)
+      curation_activities << StashEngine::CurationActivity.create(user_id: 0, status: target_status,
+                                                                  note: "System auto-assigned curator #{target_curator&.name}")
     end
   end
 end


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1842

Fixing a couple of issues arising from interactions of the journal API and our automation:
- Always provide the name of an auto-assigned curator, so that if they don't pick it up immediately, we can still determine who was assigned.
- Don't allow journal API calls to withdraw a dataset that had been previously published.