### PR TITLE
Fixes encoding display issues

### DIFF
--- a/app/controllers/stash_engine/downloads_controller.rb
+++ b/app/controllers/stash_engine/downloads_controller.rb
@@ -2,6 +2,7 @@ require_dependency 'stash_engine/application_controller'
 require 'stash/download/file_presigned'
 require 'stash/download/version_presigned'
 require 'http'
+
 module StashEngine
   class DownloadsController < ApplicationController
     include ActionView::Helpers::DateHelper
@@ -130,7 +131,11 @@ module StashEngine
       @preview = (@data_file.preview_file if @data_file&.resource&.may_download?(ui_user: current_user))
 
       # limit to only 5 lines at most and make unix line endings
-      @preview = @preview.split(/$/).map(&:strip)[0..5].join("\n") if @preview.class == String
+      if @preview.class == String
+        @preview = @preview.encode("UTF-8", :invalid => :replace, :undef => :replace, :replace => "?") # replace bad chars
+        @preview = @preview.split(/[\r\n|\r|\n]+/).map(&:strip)[0..5].join("\n") # only 5 lines, please
+      end
+
     end
 
     private

--- a/app/controllers/stash_engine/downloads_controller.rb
+++ b/app/controllers/stash_engine/downloads_controller.rb
@@ -131,11 +131,10 @@ module StashEngine
       @preview = (@data_file.preview_file if @data_file&.resource&.may_download?(ui_user: current_user))
 
       # limit to only 5 lines at most and make unix line endings
-      if @preview.class == String
-        @preview = @preview.encode("UTF-8", :invalid => :replace, :undef => :replace, :replace => "?") # replace bad chars
-        @preview = @preview.split(/[\r\n|\r|\n]+/).map(&:strip)[0..5].join("\n") # only 5 lines, please
-      end
+      return unless @preview.class == String
 
+      @preview = @preview.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?') # replace bad chars
+      @preview = @preview.split(/[\r\n|\r|\n]+/).map(&:strip)[0..5].join("\n") # only 5 lines, please
     end
 
     private


### PR DESCRIPTION
This fixes the encoding issues by stripping out bad things that will cause rails to barf.

At first I tried a character detection library to convert more cleanly, but it just caused more issues than it fixed.

This also fixes a problem where some previews not limited to 5 lines with `/$/` regex.

I have a dataset on dev called "Testing lots of bad CSVs" which has about 20 csvs that the semrush crawler found and errored on.  They all work now.

It's a tiny PR but took a long time to find the right thing to do to make it reliable.