### PR TITLE
Frictionless report api access at /api/v2/files/<id>/frictionlessReport

### DIFF
--- a/app/controllers/stash_api/frictionless_reports_controller.rb
+++ b/app/controllers/stash_api/frictionless_reports_controller.rb
@@ -1,0 +1,48 @@
+
+# This class is only for internal use and is not exposed to the public since it may include reports for
+# files that we don't own (at Zenodo) and would only be used by our Frictionless checker or perhas a view
+# and limited to roles that can access
+
+# expect URLs to look like /api/v2/files/<file-id>/frictionlessReport
+# and do only bare output of data for our own use.  Only enable PUT and GET
+module StashApi
+  class FrictionlessReportsController < ApiApplicationController
+
+    before_action :require_json_headers
+    before_action :force_json_content_type
+    before_action :require_file # this is different for this than for files
+    before_action :doorkeeper_authorize!, only: %i[update]
+    before_action :require_api_user, only: %i[update]
+    before_action :optional_api_user, only: %i[show]
+    before_action :require_viewable_report, only: %i[show]
+    before_action :require_permission, only: %i[update]
+
+    # GET
+    def show
+      @api_report = StashApi::FrictionlessReport.new(file_obj: @stash_file, fric_obj: @report)
+      respond_to do |format|
+        format.any { render json: @api_report.metadata }
+      end
+    end
+
+    # PUT
+    def update
+      # only json for report and status will be updated, the rest is automatically updated
+      byebug
+    end
+
+    def require_file
+      @stash_file = StashEngine::GenericFile.where(id: params[:file_id]).first
+      render json: { error: 'not-found' }.to_json, status: 404 if @stash_file.nil?
+      @resource = @stash_file.resource # for require_permission to use
+    end
+
+    def require_viewable_report
+      @report = @stash_file&.frictionless_report
+      render json: { error: 'not-found' }.to_json, status: 404 if @report.nil? ||
+        !@stash_file.resource.may_view?(ui_user: @user)
+    end
+
+
+  end
+end

--- a/app/controllers/stash_api/frictionless_reports_controller.rb
+++ b/app/controllers/stash_api/frictionless_reports_controller.rb
@@ -1,4 +1,3 @@
-
 # This class is only for internal use and is not exposed to the public since it may include reports for
 # files that we don't own (at Zenodo) and would only be used by our Frictionless checker or perhas a view
 # and limited to roles that can access
@@ -51,9 +50,9 @@ module StashApi
     end
 
     def require_correct_status
-      unless StashEngine::FrictionlessReport.statuses.keys.include?(params[:status])
-        render json: { error: 'incorrect status set' }.to_json, status: 400
-      end
+      return if StashEngine::FrictionlessReport.statuses.keys.include?(params[:status])
+
+      render json: { error: 'incorrect status set' }.to_json, status: 400
     end
 
   end

--- a/app/models/stash_api/frictionless_report.rb
+++ b/app/models/stash_api/frictionless_report.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative 'presenter'
+module StashApi
+  class FrictionlessReport
+    include Presenter
+
+    def initialize(file_obj:, fric_obj:)
+      @se_data_file = file_obj
+      @resource = @se_data_file.resource
+      @se_frictionless = fric_obj
+    end
+
+    def metadata
+      { '_links': links }.merge(report: @se_frictionless.report,
+                                createdAt: @se_frictionless.created_at,
+                                updatedAt: @se_frictionless.updated_at,
+                                status: @se_frictionless.status).recursive_compact
+    end
+
+    def links
+      basic_links.compact.merge(stash_curie)
+    end
+
+    def parent_version
+      @version ||= Version.new(resource_id: @se_data_file.resource_id)
+    end
+
+    private
+
+    def basic_links
+      {
+        self: { href: api_url_helper.file_frictionless_report_path(@se_data_file.id) },
+        'stash:dataset': { href: parent_version.parent_dataset.self_path },
+        'stash:version': { href: parent_version.self_path },
+        'stash:files': { href: parent_version.files_path }
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,7 @@ Rails.application.routes.draw do
         get 'download', on: :member
         resources :files, shallow: true, path: '/files' do
           get :download, on: :member
+          resource :frictionless_report, path: '/frictionlessReport'
         end
       end
             

--- a/spec/requests/stash_api/frictionless_reports_controller_spec.rb
+++ b/spec/requests/stash_api/frictionless_reports_controller_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+require 'uri'
+require_relative 'helpers'
+require 'fixtures/stash_api/metadata'
+require 'fixtures/stash_api/curation_metadata'
+require 'cgi'
+# see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
+module StashApi
+  RSpec.describe FrictionlessReportsController, type: :request do
+
+    include Mocks::CurationActivity
+    include Mocks::Repository
+    include Mocks::Tenant
+
+    # set up some versions with different curation statuses (visibility)
+    before(:each) do
+      @user = create(:user, role: 'superuser')
+      @doorkeeper_application = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
+                                       owner_id: @user.id, owner_type: 'StashEngine::User')
+      setup_access_token(doorkeeper_application: @doorkeeper_application)
+
+      neuter_curation_callbacks!
+      mock_tenant!
+
+      @tenant_ids = StashEngine::Tenant.all.map(&:tenant_id)
+
+      @user1 = create(:user, tenant_id: @tenant_ids.first, role: 'user')
+
+      @identifier = create(:identifier)
+      @resource = create(:resource, user_id: @user1.id, tenant_id: @user1.tenant_id, identifier_id: @identifier.id)
+
+      create(:curation_activity, resource: @resource, status: 'in_progress')
+
+      @resource.current_resource_state.update(resource_state: 'in_progress')
+      # be sure versions are set correctly, because creating them manually like this doesn't ensure it
+      @resource.stash_version.update(version: 1)
+      @generic_file = create(:generic_file, resource: @resource)
+    end
+
+    describe '#show' do
+      before(:each) do
+        @frict_report = create(:frictionless_report, generic_file: @generic_file)
+        @path = Rails.application.routes.url_helpers.file_frictionless_report_path(@generic_file.id)
+      end
+
+      it 'shows the frictionless report info for a file that exists and has report (superuser)' do
+        response_code = get @path, headers: default_authenticated_headers
+        expect(response_code).to eq(200)
+        hsh = response_body_hash
+        expect(hsh['_links']['self']['href']).to eq(@path)
+        expect(hsh['status']).to eq(@frict_report.status)
+        expect(hsh['report']).to eq(@frict_report.report)
+      end
+
+      it "doesn't show a report for an item the user doesn't have permission for" do
+        @user.update(role: 'user')
+        response_code = get @path, headers: default_authenticated_headers
+        expect(response_code).to eq(404)
+        expect(response_body_hash).to eq({"error"=>"not-found"})
+      end
+
+    end
+
+  end
+end

--- a/spec/requests/stash_api/frictionless_reports_controller_spec.rb
+++ b/spec/requests/stash_api/frictionless_reports_controller_spec.rb
@@ -16,7 +16,7 @@ module StashApi
     before(:each) do
       @user = create(:user, role: 'superuser')
       @doorkeeper_application = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-                                       owner_id: @user.id, owner_type: 'StashEngine::User')
+                                                                owner_id: @user.id, owner_type: 'StashEngine::User')
       setup_access_token(doorkeeper_application: @doorkeeper_application)
 
       neuter_curation_callbacks!
@@ -56,7 +56,7 @@ module StashApi
         @user.update(role: 'user')
         response_code = get @path, headers: default_authenticated_headers
         expect(response_code).to eq(404)
-        expect(response_body_hash).to eq({"error"=>"not-found"})
+        expect(response_body_hash).to eq({ 'error' => 'not-found' })
       end
 
       it "returns 404 if report doesn't exist" do
@@ -75,7 +75,7 @@ module StashApi
 
       it "adds a report that doesn't exist yet" do
         response_code = put @path,
-                            params: {status: 'noissues', report: @frict_report2.report}.to_json, # same as report2 json
+                            params: { status: 'noissues', report: @frict_report2.report }.to_json, # same as report2 json
                             headers: default_authenticated_headers
         expect(response_code).to eq(200)
         hsh = response_body_hash
@@ -83,11 +83,11 @@ module StashApi
         expect(hsh['report']).to eq(@frict_report2.report)
       end
 
-      it "updates a report that does exist" do
+      it 'updates a report that does exist' do
         @frict_report = create(:frictionless_report, generic_file: @generic_file)
         report_id = @frict_report.id
         response_code = put @path,
-                            params: {status: 'noissues', report: @frict_report2.report}.to_json, # same as report2 json
+                            params: { status: 'noissues', report: @frict_report2.report }.to_json, # same as report2 json
                             headers: default_authenticated_headers
         expect(response_code).to eq(200)
         hsh = response_body_hash
@@ -99,7 +99,7 @@ module StashApi
       it "doesn't allow updating without the correct permissions" do
         @user.update(role: 'user')
         response_code = put @path,
-                            params: {status: 'noissues', report: @frict_report2.report}.to_json, # same as report2 json
+                            params: { status: 'noissues', report: @frict_report2.report }.to_json, # same as report2 json
                             headers: default_authenticated_headers
         expect(response_code).to eq(401)
         hsh = response_body_hash
@@ -108,14 +108,14 @@ module StashApi
 
       it "doesn't allow updating unless logged in" do
         response_code = put @path,
-                            params: {status: 'noissues', report: @frict_report2.report}.to_json, # same as report2 json
+                            params: { status: 'noissues', report: @frict_report2.report }.to_json, # same as report2 json
                             headers: default_json_headers
         expect(response_code).to eq(401)
       end
 
       it "doesn't allow updating unless a status is correct from the list" do
         response_code = put @path,
-                            params: {status: 'squid_cats', report: @frict_report2.report}.to_json,
+                            params: { status: 'squid_cats', report: @frict_report2.report }.to_json,
                             headers: default_authenticated_headers
         expect(response_code).to eq(400)
         hsh = response_body_hash

--- a/spec/requests/stash_api/frictionless_reports_controller_spec.rb
+++ b/spec/requests/stash_api/frictionless_reports_controller_spec.rb
@@ -58,8 +58,63 @@ module StashApi
         expect(response_code).to eq(404)
         expect(response_body_hash).to eq({"error"=>"not-found"})
       end
-
     end
 
+    describe '#update' do
+      before(:each) do
+        @generic_file2 = create(:generic_file, resource: @resource)
+        @frict_report2 = create(:frictionless_report, generic_file: @generic_file2)
+        @path = Rails.application.routes.url_helpers.file_frictionless_report_path(@generic_file.id)
+      end
+
+      it "adds a report that doesn't exist yet" do
+        response_code = put @path,
+                            params: {status: 'noissues', report: @frict_report2.report}.to_json, # same as report2 json
+                            headers: default_authenticated_headers
+        expect(response_code).to eq(200)
+        hsh = response_body_hash
+        expect(hsh['status']).to eq('noissues')
+        expect(hsh['report']).to eq(@frict_report2.report)
+      end
+
+      it "updates a report that does exist" do
+        @frict_report = create(:frictionless_report, generic_file: @generic_file)
+        report_id = @frict_report.id
+        response_code = put @path,
+                            params: {status: 'noissues', report: @frict_report2.report}.to_json, # same as report2 json
+                            headers: default_authenticated_headers
+        expect(response_code).to eq(200)
+        hsh = response_body_hash
+        expect(hsh['status']).to eq('noissues')
+        expect(hsh['report']).to eq(@frict_report2.report)
+        expect(StashEngine::FrictionlessReport.find(report_id).report).to eq(@frict_report2.report) # the id is the same
+      end
+
+      it "doesn't allow updating without the correct permissions" do
+        @user.update(role: 'user')
+        response_code = put @path,
+                            params: {status: 'noissues', report: @frict_report2.report}.to_json, # same as report2 json
+                            headers: default_authenticated_headers
+        expect(response_code).to eq(401)
+        hsh = response_body_hash
+        expect(hsh['error']).to eq('unauthorized')
+      end
+
+      it "doesn't allow updating unless logged in" do
+        response_code = put @path,
+                            params: {status: 'noissues', report: @frict_report2.report}.to_json, # same as report2 json
+                            headers: default_json_headers
+        expect(response_code).to eq(401)
+      end
+
+      it "doesn't allow updating unless a status is correct from the list" do
+        response_code = put @path,
+                            params: {status: 'squid_cats', report: @frict_report2.report}.to_json,
+                            headers: default_authenticated_headers
+        expect(response_code).to eq(400)
+        hsh = response_body_hash
+        expect(hsh['error']).to eq('incorrect status set')
+      end
+    end
   end
 end

--- a/spec/requests/stash_api/frictionless_reports_controller_spec.rb
+++ b/spec/requests/stash_api/frictionless_reports_controller_spec.rb
@@ -58,6 +58,12 @@ module StashApi
         expect(response_code).to eq(404)
         expect(response_body_hash).to eq({"error"=>"not-found"})
       end
+
+      it "returns 404 if report doesn't exist" do
+        @frict_report.destroy!
+        response_code = get @path, headers: default_authenticated_headers
+        expect(response_code).to eq(404)
+      end
     end
 
     describe '#update' do


### PR DESCRIPTION
This allows a frictionless report to be viewed and set in the API for a file.

This is really for our own use since we likely won't have people setting Frictionless reports besides us.  It is also a niche thing for people to view since only tabular files will have a report and is more of our validation than something most people are excited to see.

Also, frictionless reports may be available for all file types (including those uploaded to zenodo) which we do not expose the file objects for other people's files through our API and only expose our own files (but reports can be seen or set for any file).