### PR TITLE
Zenodo logging to database

### DIFF
--- a/db/migrate/20220824235125_change_error_text_size_for_zenodo_copies.rb
+++ b/db/migrate/20220824235125_change_error_text_size_for_zenodo_copies.rb
@@ -1,0 +1,9 @@
+class ChangeErrorTextSizeForZenodoCopies < ActiveRecord::Migration[5.2]
+  def self.up
+    change_column :stash_engine_zenodo_copies, :error_info, :text, limit: 16.megabytes - 1
+  end
+
+  def self.down
+    change_column :stash_engine_zenodo_copies, :error_info, :text, limit: 64.kilobytes - 1
+  end
+end

--- a/lib/stash/zenodo_replicate/copier.rb
+++ b/lib/stash/zenodo_replicate/copier.rb
@@ -51,6 +51,7 @@ module Stash
         error_if_replicating
         error_if_out_of_order
 
+        @copy.reload
         @copy.update(state: 'replicating')
         @copy.increment!(:retries)
 
@@ -59,6 +60,7 @@ module Stash
 
         # get/create the deposit(ion) from zenodo
         get_or_create_deposition
+        @copy.reload
         @copy.update(deposition_id: @deposit.deposition_id)
 
         # update metadata and get response which has info links in it
@@ -71,9 +73,11 @@ module Stash
 
         # submit it, publishing will fail if there isn't at least one file
         @deposit.publish
+        @copy.reload
         @copy.update(state: 'finished', error_info: nil)
       rescue Stash::MerrittDownload::DownloadError, Stash::ZenodoReplicate::ZenodoError, HTTP::Error => e
         # log this in the database so we can track it
+        @copy.reload
         error_info = "#{Time.new} #{e.class}\n#{e}\n---\n#{@copy.error_info}" # append current error info first
         @copy.update(state: 'error', error_info: error_info)
       end

--- a/lib/stash/zenodo_replicate/copier.rb
+++ b/lib/stash/zenodo_replicate/copier.rb
@@ -55,7 +55,7 @@ module Stash
         @copy.increment!(:retries)
 
         # a zenodo deposit class for working with deposits
-        @deposit = Stash::ZenodoReplicate::Deposit.new(resource: @resource)
+        @deposit = Stash::ZenodoReplicate::Deposit.new(resource: @resource, zc_id: @copy.id)
 
         # get/create the deposit(ion) from zenodo
         get_or_create_deposition
@@ -65,8 +65,8 @@ module Stash
         @resp = @deposit.update_metadata
 
         # update files
-        file_change_list = FileChangeList.new(resource: @resource)
-        @file_collection = Stash::ZenodoSoftware::FileCollection.new(file_change_list_obj: file_change_list)
+        file_change_list = FileChangeList.new(resource: @resource, zc_id: @copy.id)
+        @file_collection = Stash::ZenodoSoftware::FileCollection.new(file_change_list_obj: file_change_list, zc_id: @copy.id)
         @file_collection.synchronize_to_zenodo(bucket_url: @resp[:links][:bucket])
 
         # submit it, publishing will fail if there isn't at least one file

--- a/lib/stash/zenodo_replicate/deposit.rb
+++ b/lib/stash/zenodo_replicate/deposit.rb
@@ -20,7 +20,7 @@ module Stash
         # mg = MetadataGenerator.new(resource: @resource)
         json = (pre_reserve_doi ? { metadata: { prereserve_doi: true } } : {})
         resp = ZC.standard_request(:post, "#{ZC.base_url}/api/deposit/depositions", json: json,
-                                   zc_id: @zc_id)
+                                                                                    zc_id: @zc_id)
 
         @deposition_id = resp[:id]
         @links = resp[:links]

--- a/lib/stash/zenodo_replicate/deposit.rb
+++ b/lib/stash/zenodo_replicate/deposit.rb
@@ -41,13 +41,13 @@ module Stash
                             json: { metadata: manual_metadata }, zc_id: @zc_id)
       end
 
-      def self.get_by_deposition(deposition_id:)
-        ZC.standard_request(:get, "#{ZC.base_url}/api/deposit/depositions/#{deposition_id}", zc_id: @zc_id)
+      def self.get_by_deposition(deposition_id:, zc_id:)
+        ZC.standard_request(:get, "#{ZC.base_url}/api/deposit/depositions/#{deposition_id}", zc_id: zc_id)
       end
 
       # GET /api/deposit/depositions/123
       def get_by_deposition(deposition_id:)
-        resp = Deposit.get_by_deposition(deposition_id: deposition_id)
+        resp = Deposit.get_by_deposition(deposition_id: deposition_id, zc_id: @zc_id)
 
         @deposition_id = resp[:id]
         @links = resp[:links]

--- a/lib/stash/zenodo_replicate/deposit.rb
+++ b/lib/stash/zenodo_replicate/deposit.rb
@@ -38,7 +38,7 @@ module Stash
         end
         manual_metadata[:doi] = doi unless doi.nil?
         ZC.standard_request(:put, "#{ZC.base_url}/api/deposit/depositions/#{@deposition_id}",
-                            json: { metadata: manual_metadata }, zd_id: @zc_id)
+                            json: { metadata: manual_metadata }, zc_id: @zc_id)
       end
 
       def self.get_by_deposition(deposition_id:)

--- a/lib/stash/zenodo_replicate/deposit.rb
+++ b/lib/stash/zenodo_replicate/deposit.rb
@@ -9,8 +9,9 @@ module Stash
 
       ZC = Stash::ZenodoReplicate::ZenodoConnection # keep code shorter with this
 
-      def initialize(resource:)
+      def initialize(resource:, zc_id:)
         @resource = resource
+        @zc_id = zc_id
       end
 
       # this creates a new deposit and returns the json response if successful
@@ -18,7 +19,8 @@ module Stash
       def new_deposition(pre_reserve_doi: false)
         # mg = MetadataGenerator.new(resource: @resource)
         json = (pre_reserve_doi ? { metadata: { prereserve_doi: true } } : {})
-        resp = ZC.standard_request(:post, "#{ZC.base_url}/api/deposit/depositions", json: json)
+        resp = ZC.standard_request(:post, "#{ZC.base_url}/api/deposit/depositions", json: json,
+                                   zc_id: @zc_id)
 
         @deposition_id = resp[:id]
         @links = resp[:links]
@@ -35,11 +37,12 @@ module Stash
           manual_metadata = mg.metadata
         end
         manual_metadata[:doi] = doi unless doi.nil?
-        ZC.standard_request(:put, "#{ZC.base_url}/api/deposit/depositions/#{@deposition_id}", json: { metadata: manual_metadata })
+        ZC.standard_request(:put, "#{ZC.base_url}/api/deposit/depositions/#{@deposition_id}",
+                            json: { metadata: manual_metadata }, zd_id: @zc_id)
       end
 
       def self.get_by_deposition(deposition_id:)
-        ZC.standard_request(:get, "#{ZC.base_url}/api/deposit/depositions/#{deposition_id}")
+        ZC.standard_request(:get, "#{ZC.base_url}/api/deposit/depositions/#{deposition_id}", zc_id: @zc_id)
       end
 
       # GET /api/deposit/depositions/123
@@ -54,9 +57,10 @@ module Stash
 
       def new_version(deposition_id:)
         # a two-step process according to the notes -- newversion and then get the latest draft link out and get that item for editing
-        resp = ZC.standard_request(:post, "#{ZC.base_url}/api/deposit/depositions/#{deposition_id}/actions/newversion")
+        resp = ZC.standard_request(:post, "#{ZC.base_url}/api/deposit/depositions/#{deposition_id}/actions/newversion",
+                                   zc_id: @zc_id)
 
-        resp2 = ZC.standard_request(:get, resp[:links][:latest_draft])
+        resp2 = ZC.standard_request(:get, resp[:links][:latest_draft], zc_id: @zc_id)
 
         @deposition_id = resp2[:id]
         @links = resp2[:links]
@@ -66,13 +70,13 @@ module Stash
 
       # POST /api/deposit/depositions/123/actions/edit
       def reopen_for_editing
-        ZC.standard_request(:post, @links[:edit])
+        ZC.standard_request(:post, @links[:edit], zc_id: @zc_id)
       end
 
       # POST /api/deposit/depositions/456/actions/publish
       # Need to have gotten or created the deposition for this to work
       def publish
-        ZC.standard_request(:post, @links[:publish])
+        ZC.standard_request(:post, @links[:publish], zc_id: @zc_id)
       end
     end
   end

--- a/lib/stash/zenodo_replicate/file_change_list.rb
+++ b/lib/stash/zenodo_replicate/file_change_list.rb
@@ -24,11 +24,12 @@ module Stash
       # slower and use more upload time and bandwidth.  Ideally, we should just update any files that have changed
       # since our last publication, add any files that don't exist at Zenodo and remove any files that no longer exist
       # in our data and leave the rest of the files that stayed the same alone.
-      def initialize(resource:)
+      def initialize(resource:, zc_id:)
         # gets filenames for items already in Zenodo
-        resp = ZC.standard_request(:get, "#{ZC.base_url}/api/deposit/depositions/#{resource.zenodo_copies.data.first.deposition_id}")
+        @zc_id = zc_id
+        resp = ZC.standard_request(:get, "#{ZC.base_url}/api/deposit/depositions/#{resource.zenodo_copies.data.first.deposition_id}",
+                                   zc_id: @zc_id)
         @existing_zenodo_filenames = resp[:files].map { |f| f[:filename] }
-
         @resource = resource
       end
 

--- a/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -43,7 +43,7 @@ module Stash
           my_headers = { 'Content-Type': 'application/json' }.merge(args.fetch(:headers, {}))
           my_args = args.merge(params: my_params, headers: my_headers)
 
-          log_to_database(item: "REQUEST: #{method}, #{url}\n   #{my_args.merge(:params => { :access_token => 'hidden'})}",
+          log_to_database(item: "REQUEST: #{method}, #{url}\n   #{my_args&.merge(:params => { :access_token => 'hidden'})}",
                           zen_copy: zen_copy)
           r = http.send(method, url, my_args)
           log_to_database(item: "RESPONSE: #{r.inspect}", zen_copy: zen_copy)

--- a/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -43,7 +43,7 @@ module Stash
           my_headers = { 'Content-Type': 'application/json' }.merge(args.fetch(:headers, {}))
           my_args = args.merge(params: my_params, headers: my_headers)
 
-          log_to_database(item: "REQUEST: #{method}, #{url}\n   #{my_args&.merge(:params => { :access_token => 'hidden'})}",
+          log_to_database(item: "REQUEST: #{method}, #{url}\n   #{my_args&.merge(params: { access_token: 'hidden' })}",
                           zen_copy: zen_copy)
           r = http.send(method, url, my_args)
           log_to_database(item: "RESPONSE: #{r.inspect}", zen_copy: zen_copy)

--- a/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -43,7 +43,8 @@ module Stash
           my_headers = { 'Content-Type': 'application/json' }.merge(args.fetch(:headers, {}))
           my_args = args.merge(params: my_params, headers: my_headers)
 
-          log_to_database(item: "REQUEST: #{method}, #{url}\n   #{my_args}", zen_copy: zen_copy)
+          log_to_database(item: "REQUEST: #{method}, #{url}\n   #{my_args.merge(:params => { :access_token => 'hidden'})}",
+                          zen_copy: zen_copy)
           r = http.send(method, url, my_args)
           log_to_database(item: "RESPONSE: #{r.inspect}", zen_copy: zen_copy)
 

--- a/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -22,17 +22,13 @@ module Stash
         false
       end
 
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def self.standard_request(method, url, **args)
         retries = 0
 
         # the zenodo copy so we can log all the requests to the database
-        zen_copy = if args[:zc_id]
-                     StashEngine::ZenodoCopy.where(id: args[:zc_id]).first
-                   else
-                     nil
-                   end
+        zen_copy = (StashEngine::ZenodoCopy.where(id: args[:zc_id]).first if args[:zc_id])
         args.delete(:zc_id)
-
 
         # if the caller wants to give a retry_limit, they can.  Useful for file uploads where there is streaming
         retry_limit = args[:retries] || RETRY_LIMIT
@@ -78,6 +74,7 @@ module Stash
           # rubocop:enable Style/GuardClause
         end
       end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       def self.log_to_database(item:, zen_copy:)
         return unless zen_copy

--- a/lib/stash/zenodo_software/copier.rb
+++ b/lib/stash/zenodo_software/copier.rb
@@ -133,7 +133,8 @@ module Stash
 
         # resources method is the method off resource to call to get file list for that type of file like software or supplemental
         # will raise exception if there are problems between file lists both places
-        Stash::ZenodoSoftware::FileCollection.check_uploaded_list(resource: @resource, resource_method: @resource_method, deposition_id: @resp[:id])
+        Stash::ZenodoSoftware::FileCollection.check_uploaded_list(resource: @resource, resource_method:
+          @resource_method, deposition_id: @resp[:id], zc_id: @copy.id)
 
         # clean up the S3 storage of zenodo files that have been successfully replicated
         Stash::Aws::S3.delete_dir(s3_key: @resource.s3_dir_name(type: @s3_method))

--- a/lib/stash/zenodo_software/copier.rb
+++ b/lib/stash/zenodo_software/copier.rb
@@ -72,9 +72,9 @@ module Stash
         @resp = {}
         @resource = StashEngine::Resource.find(@copy.resource_id)
         file_change_list = FileChangeList.new(resource: @resource, resource_method: @resource_method)
-        @file_collection = FileCollection.new(file_change_list_obj: file_change_list)
+        @file_collection = FileCollection.new(file_change_list_obj: file_change_list, zc_id: @copy.id)
         # I was creating this later, but it can be created earlier and eases testing to do it earlier
-        @deposit = Stash::ZenodoReplicate::Deposit.new(resource: @resource)
+        @deposit = Stash::ZenodoReplicate::Deposit.new(resource: @resource, zc_id: @copy.id)
       end
 
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize

--- a/lib/stash/zenodo_software/file_collection.rb
+++ b/lib/stash/zenodo_software/file_collection.rb
@@ -76,8 +76,8 @@ module Stash
       end
 
       # resource method is :software_files or :supp_files, the method from resource to get the right type of files
-      def self.check_uploaded_list(resource:, resource_method:, deposition_id:)
-        response = Stash::ZenodoReplicate::Deposit.get_by_deposition(deposition_id: deposition_id)
+      def self.check_uploaded_list(resource:, resource_method:, deposition_id:, zc_id:)
+        response = Stash::ZenodoReplicate::Deposit.get_by_deposition(deposition_id: deposition_id, zc_id: zc_id)
         resource.reload # just in case it's out of date
         dry_files = resource.public_send(resource_method).present_files
         zen_files = response[:files]

--- a/lib/stash/zenodo_software/file_collection.rb
+++ b/lib/stash/zenodo_software/file_collection.rb
@@ -12,7 +12,8 @@ module Stash
 
       ZC = Stash::ZenodoReplicate::ZenodoConnection # keep code shorter with this
 
-      def initialize(file_change_list_obj:)
+      def initialize(file_change_list_obj:, zc_id:)
+        @zc_id = zc_id
         @file_change_list = file_change_list_obj
       end
 
@@ -25,7 +26,7 @@ module Stash
       def remove_files(zenodo_bucket_url:)
         @file_change_list.delete_list.each do |del_file|
           url = "#{zenodo_bucket_url}/#{ERB::Util.url_encode(del_file)}"
-          ZC.standard_request(:delete, url)
+          ZC.standard_request(:delete, url, zc_id: @zc_id)
         end
       end
 
@@ -33,7 +34,7 @@ module Stash
         @file_change_list.upload_list.each do |upload|
           next if upload.upload_file_size.nil? || upload.upload_file_size == 0
 
-          streamer = Streamer.new(file_model: upload, zenodo_bucket_url: zenodo_bucket_url)
+          streamer = Streamer.new(file_model: upload, zenodo_bucket_url: zenodo_bucket_url, zc_id: @zc_id)
           digests = ['md5']
           digests.push(upload.digest_type) if upload.digest_type.present? && upload.digest.present?
           digests.uniq!

--- a/lib/stash/zenodo_software/streamer.rb
+++ b/lib/stash/zenodo_software/streamer.rb
@@ -7,11 +7,12 @@ module Stash
   module ZenodoSoftware
     class Streamer
 
-      def initialize(file_model:, zenodo_bucket_url:)
+      def initialize(file_model:, zenodo_bucket_url:, zc_id:)
         # on one end we'll have S3 or an HTTP URL and on the other end of the pipe the zenodo put request that looks like
         # PUT "#{@bucket_url}/#{ERB::Util.url_encode(file_model.upload_file_name)}"
         # ZC.standard_request(:put, upload_url, body: File.open(upload_file, 'rb'), headers: { 'Content-Type': nil })
 
+        @zc_id = zc_id
         @file_model = file_model
         @upload_url = "#{zenodo_bucket_url}/#{ERB::Util.url_encode(file_model.upload_file_name)}"
       end
@@ -54,7 +55,8 @@ module Stash
             .standard_request(:put, @upload_url,
                               body: read_pipe,
                               headers: { 'Content-Type': nil, 'Content-Length': response.headers['Content-Length'] },
-                              retries: 0)
+                              retries: 0,
+                              zc_id: @zc_id)
           # rescue HTTP::Error, Stash::ZenodoReplicate::ZenodoError  => e
           # puts 'caught error in thread'
         end

--- a/spec/lib/stash/zenodo_replicate/deposit_spec.rb
+++ b/spec/lib/stash/zenodo_replicate/deposit_spec.rb
@@ -14,7 +14,8 @@ module Stash
 
       before(:each) do
         @resource = create(:resource)
-        @szd = Stash::ZenodoReplicate::Deposit.new(resource: @resource)
+        @zenodo_copy = create(:zenodo_copy, resource: @resource, identifier: @resource.identifier)
+        @szd = Stash::ZenodoReplicate::Deposit.new(resource: @resource, zc_id: @zenodo_copy.id)
       end
 
       describe '#new_deposition' do

--- a/spec/lib/stash/zenodo_software/file_collection_spec.rb
+++ b/spec/lib/stash/zenodo_software/file_collection_spec.rb
@@ -133,7 +133,8 @@ module Stash
           expect do
             FileCollection.check_uploaded_list(resource: @resource,
                                                resource_method: :software_files,
-                                               deposition_id: @zenodo_copy.deposition_id)
+                                               deposition_id: @zenodo_copy.deposition_id,
+                                               zc_id: @zenodo_copy.id)
           end.not_to raise_error
         end
 
@@ -147,7 +148,8 @@ module Stash
           expect do
             FileCollection.check_uploaded_list(resource: @resource,
                                                resource_method: :software_files,
-                                               deposition_id: @zenodo_copy.deposition_id)
+                                               deposition_id: @zenodo_copy.deposition_id,
+                                               zc_id: @zenodo_copy.id)
           end.to raise_error(FileError, /The number of Dryad files \(9\) does not match/)
         end
 
@@ -160,7 +162,8 @@ module Stash
           expect do
             FileCollection.check_uploaded_list(resource: @resource,
                                                resource_method: :software_files,
-                                               deposition_id: @zenodo_copy.deposition_id)
+                                               deposition_id: @zenodo_copy.deposition_id,
+                                               zc_id: @zenodo_copy.id)
           end.to raise_error(FileError, /#{f.upload_file_name} \(id: #{f.id}\) exists in the Dryad database but not in Zenodo/)
         end
 
@@ -175,7 +178,8 @@ module Stash
           expect do
             FileCollection.check_uploaded_list(resource: @resource,
                                                resource_method: :software_files,
-                                               deposition_id: @zenodo_copy.deposition_id)
+                                               deposition_id: @zenodo_copy.deposition_id,
+                                               zc_id: @zenodo_copy.id)
           end.to raise_error(FileError, /Dryad and Zenodo file sizes do not match for #{f.upload_file_name}/)
         end
       end

--- a/spec/lib/stash/zenodo_software/file_collection_spec.rb
+++ b/spec/lib/stash/zenodo_software/file_collection_spec.rb
@@ -17,9 +17,10 @@ module Stash
         @software_http_upload = create(:software_file, upload_file_size: 1000,
                                                        url: 'http://example.org/example', resource: @resource)
 
+        @zenodo_copy = create(:zenodo_copy, resource: @resource, identifier: @resource.identifier)
         @change_list = FileChangeList.new(resource: @resource, resource_method: :software_files)
 
-        @file_collection = FileCollection.new(file_change_list_obj: @change_list)
+        @file_collection = FileCollection.new(file_change_list_obj: @change_list, zc_id: @zenodo_copy.id)
         @bucket_url = 'https://example.org/my/great/test/bucket'
       end
 
@@ -36,7 +37,8 @@ module Stash
         it 'calls to remove any files in the list supplied by the change list class' do
           filenames = [Faker::File.file_name, Faker::File.file_name]
           allow(@change_list).to receive(:delete_list).and_return(filenames)
-          expect(Stash::ZenodoReplicate::ZenodoConnection).to receive(:standard_request).with(:delete, anything).twice
+          expect(Stash::ZenodoReplicate::ZenodoConnection).to receive(:standard_request).with(:delete, anything,
+                                                                                              anything).twice
           @file_collection.remove_files(zenodo_bucket_url: @bucket_url)
         end
       end
@@ -60,8 +62,9 @@ module Stash
           @resource = create(:resource)
           @software_http_upload = create(:software_file, upload_file_size: 0,
                                                          url: 'http://example.org/example', resource: @resource)
+          zc = create(:zenodo_copy, resource: @resource, identifier: @resource.identifier)
           @change_list = FileChangeList.new(resource: @resource, resource_method: :software_files)
-          @file_collection = FileCollection.new(file_change_list_obj: @change_list)
+          @file_collection = FileCollection.new(file_change_list_obj: @change_list, zc_id: zc.id)
           @bucket_url = 'https://example.org/my/great/test/bucket'
 
           allow(@change_list).to receive(:upload_list).and_return(@resource.software_files)

--- a/spec/lib/stash/zenodo_software/streamer_spec.rb
+++ b/spec/lib/stash/zenodo_software/streamer_spec.rb
@@ -15,15 +15,18 @@ module Stash
         @resource = create(:resource)
         @resource.software_files << create(:software_file)
 
+        @zenodo_copy = create(:zenodo_copy, resource: @resource, identifier: @resource.identifier)
+
         # @software_http_upload = create(:software_file, upload_file_size: 1000,
         #                               url: 'http://example.org/example', resource: @resource)
 
-        @file_collection = FileCollection.new(file_change_list_obj: @change_list)
+        @file_collection = FileCollection.new(file_change_list_obj: @change_list, zc_id: @zenodo_copy.id)
         @bucket_url = 'https://example.org/my/great/test/bucket'
 
         @random_body = Random.new.bytes(rand(1000)).b
 
-        @streamer = Streamer.new(file_model: @resource.software_files.first, zenodo_bucket_url: @bucket_url)
+        @streamer = Streamer.new(file_model: @resource.software_files.first, zenodo_bucket_url: @bucket_url,
+                                 zc_id: @zenodo_copy.id)
       end
 
       describe '#stream' do
@@ -97,7 +100,7 @@ module Stash
           data_file = @resource.data_files.first
 
           # allow(data_file).to receive(:zenodo_replication_url).and_raise(Stash::Download::MerrittError, "can't create presigned url")
-          @streamer = Streamer.new(file_model: data_file, zenodo_bucket_url: @bucket_url)
+          @streamer = Streamer.new(file_model: data_file, zenodo_bucket_url: @bucket_url, zc_id: @zenodo_copy.id)
 
           expect do
             @streamer.stream(digest_types: ['md5'])


### PR DESCRIPTION
This passes the zenodo copy id for the database table so we can log the whole zenodo request/response cycle into our error_info field.  Also expands the size of the field for all the retries and crap that may be in there.

These are a lot of changes, but mostly finding the chain of calls to pass the id for the item through multiple laters and revisions of tests to include it.