### PR TITLE
Fixes for Merritt Sword cutting off at 66 minutes

### DIFF
--- a/lib/stash/repo/submission_result.rb
+++ b/lib/stash/repo/submission_result.rb
@@ -5,6 +5,7 @@ module Stash
     # Encapsulates a submission result
     class SubmissionResult
       attr_reader :resource_id, :request_desc, :message, :error
+      attr_accessor :deferred
 
       # @param resource_id [Integer] the ID of the submitted resource
       # @param request_desc [String, nil] a description of the request that produced this result
@@ -15,10 +16,20 @@ module Stash
         @request_desc = request_desc
         @message = message
         @error = error
+
+        # for asyncronous processing, gets set if the request has gone asynchronous and not really
+        # success or failure until Merritt finishes in a state that we don't have access to until showing in the
+        # OAI-PMH feed as a separate process.  Deferred is hoped a success, but shouldn't be setting finished states
+        # in the database until done so by OAI feed and not by our own process.
+        @deferred = false
       end
 
       def success?
         error.nil?
+      end
+
+      def deferred?
+        @deferred
       end
 
       def log_to(logger)

--- a/spec/models/stash-merritt/sword_helper_spec.rb
+++ b/spec/models/stash-merritt/sword_helper_spec.rb
@@ -137,7 +137,6 @@ module Stash
             end
           end
 
-
           describe 'update' do
 
             before(:each) do

--- a/spec/models/stash-merritt/sword_helper_spec.rb
+++ b/spec/models/stash-merritt/sword_helper_spec.rb
@@ -130,7 +130,13 @@ module Stash
               expect(@sword_client).to receive(:create).and_raise(RestClient::RequestFailed)
               expect { @helper.submit! }.to raise_error(RestClient::RequestFailed)
             end
+
+            it 'handles RestClient::Exceptions::ReadTimeout and returns and raises GoneAsynchronous exception' do
+              expect(@sword_client).to receive(:create).and_raise(RestClient::Exceptions::ReadTimeout)
+              expect { @helper.submit! }.to raise_error(Stash::Merritt::SwordHelper::GoneAsynchronous)
+            end
           end
+
 
           describe 'update' do
 

--- a/spec/models/stash/repo/repository_spec.rb
+++ b/spec/models/stash/repo/repository_spec.rb
@@ -137,6 +137,26 @@ module Stash
             submit_resource
           end
 
+          describe 'when result.deferred? = true' do
+            it "doesn't update repo queue states with success" do
+              result = SubmissionResult.new(resource_id: resource_id, request_desc: 'test', message: 'whee!')
+              result.deferred = true
+              allow(job).to receive(:submit!).and_return(result)
+
+              expect(StashEngine::RepoQueueState).to receive(:create).with(
+                resource_id: resource_id,
+                hostname: repo.class.hostname,
+                state: 'enqueued'
+              )
+              expect(StashEngine::RepoQueueState).not_to receive(:create).with(
+                resource_id: resource_id,
+                hostname: repo.class.hostname,
+                state: 'completed'
+              )
+              submit_resource
+            end
+          end
+
           describe 'unexpected errors' do
             before(:each) do
               allow_any_instance_of(ActionMailer::MessageDelivery).to receive(:deliver_now).and_raise(Net::SMTPAuthenticationError)

--- a/stash/stash-merritt/lib/stash/merritt/submission_job.rb
+++ b/stash/stash-merritt/lib/stash/merritt/submission_job.rb
@@ -51,6 +51,12 @@ module Stash
         package = create_package
         submit(package)
         Stash::Repo::SubmissionResult.success(resource_id: resource_id, request_desc: description, message: 'Success')
+      rescue SwordHelper::GoneAsynchronous
+        res = Stash::Repo::SubmissionResult
+                .success(resource_id: resource_id, request_desc: description,
+                         message: 'Presumed eventual success -- check in OAI-PMH for completion')
+        res.deferred = true
+        res
       end
 
       def resource

--- a/stash/stash-merritt/lib/stash/merritt/submission_job.rb
+++ b/stash/stash-merritt/lib/stash/merritt/submission_job.rb
@@ -53,8 +53,8 @@ module Stash
         Stash::Repo::SubmissionResult.success(resource_id: resource_id, request_desc: description, message: 'Success')
       rescue SwordHelper::GoneAsynchronous
         res = Stash::Repo::SubmissionResult
-                .success(resource_id: resource_id, request_desc: description,
-                         message: 'Presumed eventual success -- check in OAI-PMH for completion')
+          .success(resource_id: resource_id, request_desc: description,
+                   message: 'Presumed eventual success -- check in OAI-PMH for completion')
         res.deferred = true
         res
       end

--- a/stash/stash-merritt/lib/stash/merritt/sword_helper.rb
+++ b/stash/stash-merritt/lib/stash/merritt/sword_helper.rb
@@ -1,8 +1,12 @@
 require 'stash/sword'
+require 'rest-client' # so we have access to its exception classes
 
 module Stash
   module Merritt
     class SwordHelper
+
+      class GoneAsynchronous < StandardError; end
+
       attr_reader :logger, :package
 
       def initialize(package:, logger: nil)
@@ -16,6 +20,9 @@ module Stash
         else
           do_create
         end
+      rescue RestClient::Exceptions::ReadTimeout => e
+        raise GoneAsynchronous
+      ensure
         resource.version_zipfile = File.basename(package.payload)
         resource.save!
       end

--- a/stash/stash-merritt/lib/stash/merritt/sword_helper.rb
+++ b/stash/stash-merritt/lib/stash/merritt/sword_helper.rb
@@ -20,7 +20,7 @@ module Stash
         else
           do_create
         end
-      rescue RestClient::Exceptions::ReadTimeout => e
+      rescue RestClient::Exceptions::ReadTimeout
         raise GoneAsynchronous
       ensure
         resource.version_zipfile = File.basename(package.payload)

--- a/stash/stash-sword/lib/stash/sword/client.rb
+++ b/stash/stash-sword/lib/stash/sword/client.rb
@@ -46,9 +46,6 @@ module Stash
         response = do_post(uri, payload, create_request_headers(payload, doi, packaging))
         receipt_from(response)
       rescue StandardError => e
-        # do something different if RestClient::Exceptions::ReadTimeout
-        # don't return DepositReceipt but need to be sure whoever calls this doesn't freak out since we'll get
-        # an update from the OAI-PMH feed
         log_error(e)
         raise
       end

--- a/stash/stash-sword/lib/stash/sword/client.rb
+++ b/stash/stash-sword/lib/stash/sword/client.rb
@@ -46,6 +46,9 @@ module Stash
         response = do_post(uri, payload, create_request_headers(payload, doi, packaging))
         receipt_from(response)
       rescue StandardError => e
+        # do something different if RestClient::Exceptions::ReadTimeout
+        # don't return DepositReceipt but need to be sure whoever calls this doesn't freak out since we'll get
+        # an update from the OAI-PMH feed
         log_error(e)
         raise
       end

--- a/stash/stash-sword/lib/stash/sword/http_helper.rb
+++ b/stash/stash-sword/lib/stash/sword/http_helper.rb
@@ -13,8 +13,8 @@ module Stash
       # The default number of redirects to follow before erroring out.
       DEFAULT_MAX_REDIRECTS = 5
 
-      # The default number of seconds to allow before timing out. Defaults to 10 minutes.
-      DEFAULT_TIMEOUT = 86_400 # a day
+      # The default number of seconds to allow before timing out.
+      DEFAULT_TIMEOUT = 3600 # 1 hour before timing out to go asynchronous
 
       # @return [String] the User-Agent string to send when making requests
       attr_accessor :user_agent


### PR DESCRIPTION
https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1999

This was tricky to troubleshoot and test.  In order to be sure this worked, I set the timeout in the http_helper.rb file to 1 second (instead of the 3600 seconds it lists below).  Then I went through the UI on my local machine and submitted an item.  This worked out for me in that it was long enough to submit to Merritt Sword and then timed out before it got a success response.

I was able to examine the repo_queue_states_table.  It stayed on "processing" until it got a "completed" response back from the completion by the OAI-PMH feed (from the normal dev server).

Also in the stash_engine_submission_logs it writes "Presumed eventual success -- check in OAI-PMH for completion" instead of a normal success message.