### PR TITLE
NIH in SOLR

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -89,6 +89,7 @@ class CatalogController < ApplicationController
     config.add_facet_field Settings.FIELDS.RELATED_PUBLICATION_NAME, label: 'Journal', limit: 8
     config.add_facet_field Settings.FIELDS.AUTHOR_AFFILIATION_NAME, label: 'Institution', limit: 8
     config.add_facet_field Settings.FIELDS.DATASET_FILE_EXT, label: 'File Extension', limit: 8
+    config.add_facet_field Settings.FIELDS.FUNDER, label: 'Funder', limit: 8
 
     # config.add_facet_field Settings.FIELDS.RIGHTS, label: 'Access', limit: 8, partial: "icon_facet"
     # config.add_facet_field Settings.FIELDS.GEOM_TYPE, label: 'Data type', limit: 8, partial: "icon_facet"
@@ -122,6 +123,7 @@ class CatalogController < ApplicationController
     config.add_index_field Settings.FIELDS.RELATED_PUBLICATION_NAME
     config.add_index_field Settings.FIELDS.AUTHOR_AFFILIATION_NAME
     config.add_index_field Settings.FIELDS.DATASET_FILE_EXT
+    config.add_index_field Settings.FIELDS.FUNDER
 
     # solr fields to be displayed in the show (single result) view
     #  The ordering of the field names is the order of the display

--- a/app/models/stash_datacite/contributor.rb
+++ b/app/models/stash_datacite/contributor.rb
@@ -12,7 +12,6 @@ module StashDatacite
 
     scope :funder, -> { where(contributor_type: 'funder') }
 
-
     ContributorTypes = Datacite::Mapping::ContributorType.map(&:value)
 
     ContributorTypesEnum = ContributorTypes.map { |i| [i.downcase.to_sym, i.downcase] }.to_h

--- a/app/models/stash_datacite/contributor.rb
+++ b/app/models/stash_datacite/contributor.rb
@@ -10,6 +10,9 @@ module StashDatacite
     scope :completed, -> { where("TRIM(IFNULL(contributor_name, '')) > ''") } # only non-null & blank
     # scope :completed, ->  { where("TRIM(IFNULL(award_number, '')) > '' AND TRIM(IFNULL(contributor_name, '')) > ''") } # only non-null & blank
 
+    scope :funder, -> { where(contributor_type: 'funder') }
+
+
     ContributorTypes = Datacite::Mapping::ContributorType.map(&:value)
 
     ContributorTypesEnum = ContributorTypes.map { |i| [i.downcase.to_sym, i.downcase] }.to_h

--- a/app/models/stash_datacite/contributor_grouping.rb
+++ b/app/models/stash_datacite/contributor_grouping.rb
@@ -1,0 +1,61 @@
+module StashDatacite
+  class ContributorGrouping < ApplicationRecord
+    self.table_name = 'dcs_contributor_groupings'
+
+    enum contributor_type: {
+      contactperson: 0,
+      datacollector: 1,
+      datacurator: 2,
+      datamanager: 3,
+      distributor: 4,
+      editor: 5,
+      funder: 6,
+      hostinginstitution: 7,
+      producer: 8,
+      projectleader: 9,
+      projectmanager: 10,
+      projectmember: 11,
+      registrationagency: 12,
+      registrationauthority: 13,
+      relatedperson: 14,
+      researcher: 15,
+      researchgroup: 16,
+      rightsholder: 17,
+      sponsor: 18,
+      supervisor: 19,
+      workpackageleader: 20
+    }
+
+    enum identifier_type: {
+      isni: 0,
+      grid: 1,
+      crossref_funder_id: 2,
+      ror: 3,
+      other: 4
+    }
+
+    # In order for this to group you should have a contributor_name and the rest defined for the group.
+    # The json_contains field should have a JSON array with individual group records so you know
+    # what makes up the special group.
+    #
+    # example:
+    # [
+    #   {
+    #     "contributor_name": "Center for Information Technology",
+    # 		"contributor_type": "funder",
+    # 		"identifier_type": "crossref_funder_id",
+    # 		"name_identifier_id": "http://dx.doi.org/10.13039/100000093"
+    # 	},
+    #   {
+    # 		"contributor_name": "National Center for Advancing Translational Sciences",
+    # 		"contributor_type": "funder",
+    # 		"identifier_type": "crossref_funder_id",
+    # 		"name_identifier_id": "http://dx.doi.org/10.13039/100006108"
+    # 	},
+    #  ... etc
+    # ]
+    #
+
+
+  end
+end

--- a/app/models/stash_datacite/contributor_grouping.rb
+++ b/app/models/stash_datacite/contributor_grouping.rb
@@ -56,6 +56,5 @@ module StashDatacite
     # ]
     #
 
-
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,6 +42,7 @@ FIELDS:
   :RELATED_PUBLICATION_NAME: 'dryad_related_publication_name_s'
   :AUTHOR_AFFILIATION_NAME: 'dryad_author_affiliation_name_sm'
   :DATASET_FILE_EXT: 'dryad_dataset_file_ext_sm'
+  :FUNDER: 'dcs_funder_sm'
 
 # Institution deployed at
 INSTITUTION: 'Dryad'

--- a/config/solr_config/schema.xml
+++ b/config/solr_config/schema.xml
@@ -192,6 +192,7 @@
   <copyField source="dryad_author_affiliation_name_sm" dest="dryad_author_affiliation_name_tmi" maxChars="1000"/>
   <copyField source="dryad_author_affiliation_id_sm" dest="dryad_author_affiliation_id_tmi" maxChars="100"/>
   <copyField source="dryad_dataset_file_ext_sm" dest="dryad_dataset_file_ext_tmi" maxChars="100"/>
+  <copyField source="dcs_funder_sm" dest="dcs_funder_tmi" maxChars="1000"/>
 
   <!-- core text search -->
   <copyField source="*_ti"               dest="text" />
@@ -215,6 +216,7 @@
   <copyField source="dct_spatial_sm" dest="spell"/>
   <!-- briley 06/03/2019 - fields to store the publication that cites the dataset -->
   <copyField source="dryad_related_publication_name_s" dest="spell"/>
+  <copyField source="dcs_funder_sm" dest="spell"/>
 
   <!-- for suggestions -->
   <copyField source="dc_title_s" dest="suggest"/>
@@ -225,6 +227,7 @@
   <copyField source="dct_spatial_sm" dest="suggest"/>
   <!-- briley 06/03/2019 - fields to store the publication that cites the dataset -->
   <copyField source="dryad_related_publication_name_s" dest="suggest"/>
+  <copyField source="dcs_funder_sm" dest="suggest"/>
 
   <!-- for bbox value -->
   <copyField source="solr_geom" dest="solr_bboxtype"/>

--- a/config/solr_config/solrconfig.xml
+++ b/config/solr_config/solrconfig.xml
@@ -133,6 +133,7 @@
         dryad_related_publication_id_ti^11
         dryad_author_affiliation_id_tmi^12
         dryad_dataset_file_ext_tmi^13
+        dcs_funder_tmi^14
       </str>
       <!-- briley 06/03/2019 - field to store the publication id that cites the dataset -->
       <str name="pf"><!-- phrase boost within result set -->
@@ -153,6 +154,7 @@
         dryad_related_publication_id_ti^11
         dryad_author_affiliation_id_tmi^12
         dryad_dataset_file_ext_tmi^13
+        dcs_funder_tmi^14
       </str>
       <bool name="facet">true</bool>
       <int name="facet.mincount">1</int>
@@ -173,6 +175,7 @@
       <!-- sfisher 08/22/2019 - provide a facet for author affiliation(s) -->
       <str name="facet.field">dryad_author_affiliation_name_sm</str>
       <str name="facet.field">dryad_dataset_file_ext_sm</str>
+      <str name="facet.field">dcs_funder_sm</str>
 
       <str name="spellcheck">true</str>
     </lst>

--- a/db/migrate/20220930172309_create_contributor_groupings.rb
+++ b/db/migrate/20220930172309_create_contributor_groupings.rb
@@ -1,0 +1,13 @@
+class CreateContributorGroupings < ActiveRecord::Migration[5.2]
+  def change
+    create_table :dcs_contributor_groupings do |t|
+      t.text :contributor_name
+      t.integer :contributor_type, default: 6
+      t.integer :identifier_type, default: 2
+      t.string :name_identifier_id
+      t.json :json_contains
+
+      t.timestamps
+    end
+  end
+end

--- a/dryad-config-example/settings.yml
+++ b/dryad-config-example/settings.yml
@@ -31,6 +31,7 @@ FIELDS:
   :RELATED_PUBLICATION_NAME: 'dryad_related_publication_name_s'
   :AUTHOR_AFFILIATION_NAME: 'dryad_author_affiliation_name_sm'
   :DATASET_FILE_EXT: 'dryad_dataset_file_ext_sm'
+  :FUNDER: 'dcs_funder_sm'
 
 # Institution deployed at
 INSTITUTION: 'Dryad'

--- a/lib/stash/indexer/indexing_resource.rb
+++ b/lib/stash/indexer/indexing_resource.rb
@@ -254,9 +254,7 @@ module Stash
 
       def dataset_funders
         # Also do we only want to add items with valid FundRef entries?
-        contrib_names = @resource.contributors.funder.completed.map do |funder|
-          funder.contributor_name
-        end
+        contrib_names = @resource.contributors.funder.completed.map(&:contributor_name)
         contrib_names << group_funders
         contrib_names.flatten.reject(&:blank?).uniq
       end
@@ -266,7 +264,7 @@ module Stash
       def group_funders
         extra_funders = []
         StashDatacite::ContributorGrouping.where(contributor_type: 'funder').each do |group|
-          identifier_ids = group.json_contains.map{|i| i["name_identifier_id"]}
+          identifier_ids = group.json_contains.map { |i| i['name_identifier_id'] }
           count = @resource.contributors.funder.completed.where(name_identifier_id: identifier_ids).count
           extra_funders.push(group.contributor_name) if count.positive?
         end

--- a/lib/stash/indexer/indexing_resource.rb
+++ b/lib/stash/indexer/indexing_resource.rb
@@ -88,6 +88,7 @@ module Stash
           dryad_author_affiliation_name_sm: author_affiliations,
           dryad_author_affiliation_id_sm: author_affiliation_ids,
           dryad_dataset_file_ext_sm: dataset_file_exts,
+          dcs_funder_sm: dataset_funders,
           updated_at_dt: updated_at_str
         }
       end
@@ -248,6 +249,16 @@ module Stash
       def dataset_file_exts
         @resource.data_files.present_files.map do |df|
           File.extname(df.upload_file_name.to_s).gsub(/^./, '').downcase
+        end.flatten.reject(&:blank?).uniq
+      end
+
+      def dataset_funders
+        # TODO:  We need more special handling for NIH institutes and main entry for NIH since all specific
+        # subdivisions of NIH should also insert into top-level of NIH for broad (or narrower) discovery
+        #
+        # Also do we only want to add items with valid FundRef entries?
+        @resource.contributors.funder.completed.map do |funder|
+          funder.contributor_name
         end.flatten.reject(&:blank?).uniq
       end
 

--- a/spec/factories/stash_datacite/contributor_groupings.rb
+++ b/spec/factories/stash_datacite/contributor_groupings.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
 
   factory :contributor_grouping, class: StashDatacite::ContributorGrouping do
 
-    contributor_name    { "National Institutes of Health" }
+    contributor_name    { 'National Institutes of Health' }
     contributor_type    { 'funder' }
     identifier_type     { 'crossref_funder_id' }
     name_identifier_id  { 'http://dx.doi.org/10.13039/100000002' }

--- a/spec/factories/stash_datacite/contributor_groupings.rb
+++ b/spec/factories/stash_datacite/contributor_groupings.rb
@@ -1,0 +1,12 @@
+require 'json'
+FactoryBot.define do
+
+  factory :contributor_grouping, class: StashDatacite::ContributorGrouping do
+
+    contributor_name    { "National Institutes of Health" }
+    contributor_type    { 'funder' }
+    identifier_type     { 'crossref_funder_id' }
+    name_identifier_id  { 'http://dx.doi.org/10.13039/100000002' }
+    json_contains       { JSON.parse(File.read(File.join(Rails.root, 'spec/fixtures/nih_group.json'))) }
+  end
+end

--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -330,7 +330,7 @@ RSpec.feature 'Admin', type: :feature do
         menu.click
         click_on('Dataset Curation')
         select 'Status', from: 'curation_status'
-        find('#curation_status').set("Status\n") # trying to get headless to work reliably
+        # find('#curation_status').set("Status\n") # trying to get headless to work reliably
 
         expect(page).to have_selector('#js-curation-state-1')
         expect(page).to have_content(@resource.title)

--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -330,7 +330,7 @@ RSpec.feature 'Admin', type: :feature do
         menu.click
         click_on('Dataset Curation')
         select 'Status', from: 'curation_status'
-        # find('#curation_status').set("Status\n") # trying to get headless to work reliably
+        find('#curation_status').set("Status\n") # trying to get headless to work reliably
         page.find('#js-curation-state-1', wait: 5) # might this make intermittent weirdness better on github servers?
 
         expect(page).to have_selector('#js-curation-state-1')

--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -331,6 +331,7 @@ RSpec.feature 'Admin', type: :feature do
         click_on('Dataset Curation')
         select 'Status', from: 'curation_status'
         # find('#curation_status').set("Status\n") # trying to get headless to work reliably
+        page.find('#js-curation-state-1', wait: 5) # might this make intermittent weirdness better on github servers?
 
         expect(page).to have_selector('#js-curation-state-1')
         expect(page).to have_content(@resource.title)

--- a/spec/features/stash_engine/curation_activity_spec.rb
+++ b/spec/features/stash_engine/curation_activity_spec.rb
@@ -227,6 +227,9 @@ RSpec.feature 'CurationActivity', type: :feature do
       it 'allows curation editing and aborting editing of user dataset and return to list in same state afterward' do
         # the button to edit has this class on it
         find('.js-trap-curator-url').click
+
+        expect(page).to have_field('Dataset Title') # so it waits for actual ajax doc to load before doing anything else
+
         click_on('Cancel and Discard Changes')
         find('#railsConfirmDialogYes').click
         expect(URI.parse(current_url).request_uri).to eq("#{dashboard_path}?curation_status=curation")

--- a/spec/fixtures/nih_group.json
+++ b/spec/fixtures/nih_group.json
@@ -1,0 +1,170 @@
+[
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "NIH Office of the Director",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000052"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Cancer Institute",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000054"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Eye Institute",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000053"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Heart, Lung, and Blood Institute",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000050"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Human Genome Research Institute",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000051"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Institute on Aging",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000049"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Institute on Alcohol Abuse and Alcoholism",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000027"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Institute of Allergy and Infectious Diseases",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000060"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Institute of Arthritis and Musculoskeletal and Skin Diseases",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000069"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Institute of Biomedical Imaging and Bioengineering",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000070"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "Eunice Kennedy Shriver National Institute of Child Health and Human Development",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100009633"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Institute on Deafness and Other Communication Disorders",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000055"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Institute of Dental and Craniofacial Research",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000072"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Institute of Diabetes and Digestive and Kidney Diseases",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000062"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Institute on Drug Abuse",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000026"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Institute of Environmental Health Sciences",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000066"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Institute of General Medical Sciences",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000057"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Institute of Mental Health",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000025"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Institute on Minority Health and Health Disparities",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100006545"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Institute of Neurological Disorders and Stroke",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000065"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Institute of Nursing Research",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000056"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "U.S. National Library of Medicine",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000092"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "Center for Information Technology",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000093"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "Center for Scientific Review",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100005440"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "Fogarty International Center",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000061"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Center for Advancing Translational Sciences",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100006108"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "National Center for Complementary and Integrative Health",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100008460"
+  },
+  {
+    "identifier_type": "crossref_funder_id",
+    "contributor_name": "NIH Clinical Center",
+    "contributor_type": "funder",
+    "name_identifier_id": "http://dx.doi.org/10.13039/100000098"
+  }
+]

--- a/spec/lib/stash_datacite/indexing_resource_spec.rb
+++ b/spec/lib/stash_datacite/indexing_resource_spec.rb
@@ -333,6 +333,7 @@ module Stash
             dc_creator_sm: [@author1.author_full_name,
                             @author2.author_full_name],
             dc_type_s: 'Dataset',
+            dcs_funder_sm: [@contributor.contributor_name],
             dc_description_s: @resource.descriptions.where(description_type: 'abstract').map(&:description).join("\r"),
             dc_subject_sm: [@subject1.subject, @subject2.subject],
             dct_spatial_sm: [],

--- a/spec/lib/stash_datacite/indexing_resource_spec.rb
+++ b/spec/lib/stash_datacite/indexing_resource_spec.rb
@@ -134,6 +134,41 @@ module Stash
         end
       end
 
+      describe '#dataset_funders' do
+        it 'should return a list of funders as facet values' do
+          expect(@ir.dataset_funders).to eq([@contributor.contributor_name])
+        end
+
+        it 'should call group_funders from dataset_funders to attempt adding additional funders' do
+          expect(@ir).to receive(:group_funders)
+          @ir.dataset_funders
+        end
+      end
+
+      describe '#group_funders' do
+        before(:each) do
+          @contrib_grouping = create(:contributor_grouping)
+        end
+
+        it "doesn't add any facet for grouping if value isn't in sub-institutions" do
+          expect(@ir.group_funders).to eq([])
+        end
+
+        it "adds the main funder entry if any sub-entries are found" do
+          @contrib2 = create(:contributor, contributor_name: 'National Cancer Institute',
+                              contributor_type: 'funder',
+                              identifier_type: 'crossref_funder_id',
+                              name_identifier_id: 'http://dx.doi.org/10.13039/100000054',
+                              resource_id: @resource.id)
+          @contrib3 = create(:contributor, contributor_name: 'National Institute of Allergy and Infectious Diseases',
+                             contributor_type: 'funder',
+                             identifier_type: 'crossref_funder_id',
+                             name_identifier_id: 'http://dx.doi.org/10.13039/100000060',
+                             resource_id: @resource.id)
+          expect(@ir.group_funders).to eq(["National Institutes of Health"])
+        end
+      end
+
       describe '#publication_year' do
         it 'returns correct publication year' do
           expect(@ir.publication_year).to eql(2019)

--- a/spec/lib/stash_datacite/indexing_resource_spec.rb
+++ b/spec/lib/stash_datacite/indexing_resource_spec.rb
@@ -154,18 +154,18 @@ module Stash
           expect(@ir.group_funders).to eq([])
         end
 
-        it "adds the main funder entry if any sub-entries are found" do
+        it 'adds the main funder entry if any sub-entries are found' do
           @contrib2 = create(:contributor, contributor_name: 'National Cancer Institute',
-                              contributor_type: 'funder',
-                              identifier_type: 'crossref_funder_id',
-                              name_identifier_id: 'http://dx.doi.org/10.13039/100000054',
-                              resource_id: @resource.id)
+                                           contributor_type: 'funder',
+                                           identifier_type: 'crossref_funder_id',
+                                           name_identifier_id: 'http://dx.doi.org/10.13039/100000054',
+                                           resource_id: @resource.id)
           @contrib3 = create(:contributor, contributor_name: 'National Institute of Allergy and Infectious Diseases',
-                             contributor_type: 'funder',
-                             identifier_type: 'crossref_funder_id',
-                             name_identifier_id: 'http://dx.doi.org/10.13039/100000060',
-                             resource_id: @resource.id)
-          expect(@ir.group_funders).to eq(["National Institutes of Health"])
+                                           contributor_type: 'funder',
+                                           identifier_type: 'crossref_funder_id',
+                                           name_identifier_id: 'http://dx.doi.org/10.13039/100000060',
+                                           resource_id: @resource.id)
+          expect(@ir.group_funders).to eq(['National Institutes of Health'])
         end
       end
 


### PR DESCRIPTION
- Adds facets for funder
- If someone chooses any NIH institute as a funder it also adds the general NIH facet so can be limited by both higher and lower level.
- Adds a table for tracking a top level funder by who the underlings are
- There is a JSON field that contains the list of funders under the overarching one

To test:

- Be sure to add the entry for the overarching funder to the database in dcs_contributor_groupings (values below: we'll have to do this to the other servers once we deploy but it is already there on our development database).
```
id	contributor_name	contributor_type	identifier_type	name_identifier_id
1	National Institutes of Health	6	2	
```
- The JSON for `json_contains` is available as a fixture below which gets loaded into the factory (which only really creates the NIH values right now).
- Add some datasets from NIH institute funders and publish them
- Reindex the data in SOLR like `RAILS_ENV=development bundle exec rails rsolr:reindex`



