### PR TITLE
Fixing problems caused by Turbolinks in geoblacklight and subsequent pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'amatch', '~> 0.4.0'
 gem 'amoeba', '~> 3.2.0'
 gem 'aws-sdk-lambda'
 gem 'aws-sdk-s3', '~> 1.113'
-gem 'blacklight', '~> 7.19.2' # do we really need this should be required by geoblacklight
+gem 'blacklight' #, '~> 7.19.2' # do we really need this should be required by geoblacklight
 gem 'bootsnap', require: false
 gem 'bootstrap', '~> 4.0'
 gem 'concurrent-ruby', '~> 1.1.10'

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'amatch', '~> 0.4.0'
 gem 'amoeba', '~> 3.2.0'
 gem 'aws-sdk-lambda'
 gem 'aws-sdk-s3', '~> 1.113'
-gem 'blacklight' #, '~> 7.19.2' # do we really need this should be required by geoblacklight
+gem 'blacklight' # , '~> 7.19.2' # do we really need this should be required by geoblacklight
 gem 'bootsnap', require: false
 gem 'bootstrap', '~> 4.0'
 gem 'concurrent-ruby', '~> 1.1.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,8 +85,8 @@ GEM
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.638.0)
-    aws-sdk-core (3.156.0)
+    aws-partitions (1.642.0)
+    aws-sdk-core (3.158.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
@@ -104,7 +104,7 @@ GEM
     aws-sdk-ssm (1.141.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.5.1)
+    aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -114,15 +114,16 @@ GEM
     bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
-    blacklight (7.19.2)
+    blacklight (7.30.0)
       deprecation
       globalid
+      hashdiff
       i18n (>= 1.7.0)
       jbuilder (~> 2.7)
       kaminari (>= 0.15)
       ostruct (>= 0.3.2)
-      rails (>= 5.1, < 7)
-      view_component (>= 2.28.0)
+      rails (>= 5.1, < 7.1)
+      view_component (~> 2.43)
     bootsnap (1.13.0)
       msgpack (~> 1.2)
     bootstrap (4.6.2)
@@ -365,7 +366,7 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
-    irb (1.4.1)
+    irb (1.4.2)
       reline (>= 0.3.0)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
@@ -433,7 +434,7 @@ GEM
     mize (0.4.0)
       protocol (~> 2.0)
     mocha (1.15.0)
-    msgpack (1.5.6)
+    msgpack (1.6.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.2.3)
@@ -516,7 +517,7 @@ GEM
     rack (2.2.4)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
-    rack-protection (3.0.1)
+    rack-protection (3.0.2)
       rack
     rack-proxy (0.7.4)
       rack
@@ -739,7 +740,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webdrivers (5.1.0)
+    webdrivers (5.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
@@ -780,7 +781,7 @@ DEPENDENCIES
   aws-sdk-lambda
   aws-sdk-s3 (~> 1.113)
   binding_of_caller
-  blacklight (~> 7.19.2)
+  blacklight
   bootsnap
   bootstrap (~> 4.0)
   byebug

--- a/app/assets/javascripts/geobl_application.js
+++ b/app/assets/javascripts/geobl_application.js
@@ -13,7 +13,7 @@
 //= require jquery
 //= require jquery_ujs
 // these following two are supposed to be right
-//= require turbolinks
+// require turbolinks
 // require jquery3
 // require rails-ujs
 // require activestorage -- this doesn't work for some reason

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,6 +1,6 @@
 <%# modified splash page for exploring results before doing a search %>
 <%= content_for(:head) %>
-<div class='container'>
+<div class='container' data-turbolinks="false">
   <div class='row text-center'>
     <div class='col-sm'>
       <%= content_tag :h3, t('geoblacklight.home.category_heading') %>

--- a/app/views/catalog/_index_split_default.html.erb
+++ b/app/views/catalog/_index_split_default.html.erb
@@ -1,14 +1,15 @@
 <% # header bar for doc items in index view -%>
 <% # this partial is updated from blacklight 3.4 and we also need to replace icky chars in all the document ids, otherwise the accordion doesn't work %>
-<%= content_tag :div, class: 'documentHeader index-split row', data: { layer_id: document.id, geom: document.geometry.geojson } do %>
-  <h3 class="index_title col">
+<%= content_tag :div, class: 'documentHeader index-split row', data: { layer_id: document.id, geom: document.geometry
+    .geojson, turbolinks: false } do %>
+  <h3 class="index_title col" data-turbolinks="false">
     <% counter = document_counter_with_offset(document_counter) %>
     <span class="document-counter">
       <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
     </span>
     <%= link_to_document document, counter: counter %>
   </h3>
-  <span class='status-icons'>
+  <span class='status-icons' data-turbolinks="false">
     <%= render partial: 'header_icons', locals: { document: document } %>
 
     <button
@@ -22,7 +23,7 @@
   </span>
 <% end %>
 
-<div class='more-info-area'>
+<div class='more-info-area' data-turbolinks="false">
   <div id="doc-<%= document&.id&.gsub(%r{[/:.]}, '-') %>-fields-collapse" class='collapse'>
     <small>
       <%= geoblacklight_present(:index_fields_display, document) %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -13,13 +13,15 @@
     <meta name="turbolinks-visit-control" content="reload">
     <%= stylesheet_link_tag "application", media: "all" %>
     <%#= WAS javascript_include_tag "application" %>
-`    <%# javascript_include_tag "application", media: 'all' %>
-    <%= javascript_include_tag "geobl_application", 'data-turbolinks-track': 'reload' %>
+    <%# javascript_include_tag "application", media: 'all' %>
+    <meta name="turbolinks-cache-control" content="no-cache">
+    <%= javascript_include_tag "geobl_application" %>
 
     <%= content_for(:head) %>
 
   </head>
-  <body id="yes-really" class='<%= render_body_class %> <%= "#{controller_name}_#{action_name}" %>'>
+  <body id="yes-really" class="<%= render_body_class %> <%= "#{controller_name}_#{action_name}" %>"
+        data-turbolinks="false">
   <!-- had to add the id yes-really to force our body styles rather than the nasty bootstrap crap -->
     <%# the geoblacklight extras used to be just below the "skip to main content in the top area" %>
     <%#= render partial: 'layouts/geoblacklight_extras' %>


### PR DESCRIPTION
Turns off turbolinks so it doesn't keep the specialized geoblacklight css/javascript around for subsequent pages that might possibly be navigated to.

Also removes a stray backtick