### PR TITLE
closes #2026

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -194,8 +194,8 @@ defaults: &DEFAULTS
 
 development: &DEVELOPMENT
   <<: *DEFAULTS
-  submission_error_email: [dryad.submission.error.emails@mailinator.com, sfisher@ucop.edu, ryan@datadryad.org]
-  zenodo_error_email: [dryad.submission.error.emails@mailinator.com, sfisher@ucop.edu, ryan@datadryad.org]
+  submission_error_email: [dryad.submission.error.emails@mailinator.com, sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
+  zenodo_error_email: [dryad.submission.error.emails@mailinator.com, sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
   shib_sp_host: dryad-dev.cdlib.org
   page_error_email: ~
   feedback_email_from: no-reply-dryad-dev@datadryad.org
@@ -224,10 +224,10 @@ local_dev:
 
 stage:
   <<: *DEFAULTS
-  submission_error_email: [dryad.submission.error.emails@mailinator.com, sfisher@ucop.edu, ryan@datadryad.org]
-  zenodo_error_email: [dryad.submission.error.emails@mailinator.com, sfisher@ucop.edu, ryan@datadryad.org]
+  submission_error_email: [dryad.submission.error.emails@mailinator.com, sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
+  zenodo_error_email: [dryad.submission.error.emails@mailinator.com, sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
   shib_sp_host: dryad-stg.cdlib.org
-  page_error_email: [scott.fisher@ucop.edu, ryan@datadryad.org]
+  page_error_email: [scott.fisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
   feedback_email_from: no-reply-dryad-stg@datadryad.org
   google_analytics_id: UA-145629338-3
   s3:
@@ -238,8 +238,8 @@ stage:
 
 migration:
   <<: *DEFAULTS
-  submission_error_email: [sfisher@ucop.edu, ryan@datadryad.org]
-  zenodo_error_email: [sfisher@ucop.edu, ryan@datadryad.org]
+  submission_error_email: [sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
+  zenodo_error_email: [sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
   shib_sp_host: dryad-stg.cdlib.org
   page_error_email: ["scott.fisher@ucop.edu"]
   feedback_email_from: no-reply-dryad-migration@datadryad.org
@@ -257,9 +257,9 @@ production:
   <<: *DEFAULTS
   google_analytics_id: UA-145629338-1
   shib_sp_host: datadryad.org
-  page_error_email: [scott.fisher@ucop.edu, ryan@datadryad.org]
-  submission_error_email: [sfisher@ucop.edu, ryan@datadryad.org, Maria.Praetzellis@ucop.edu]
-  zenodo_error_email: [sfisher@ucop.edu, ryan@datadryad.org]
+  page_error_email: [scott.fisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
+  submission_error_email: [sfisher@ucop.edu, ryan@datadryad.org, Maria.Praetzellis@ucop.edu, audrey@datadryad.org]
+  zenodo_error_email: [sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
   helpdesk_email: help@datadryad.org
   feedback_email_from: no-reply-dryad@datadryad.org
   # orcid production credentials


### PR DESCRIPTION
Adds Audrey to all the error emails.  Hooray!

@ahamelers Once you start getting notified, I'd recommend setting up some email rules.  I send both dev and stage notifications to other folders that I rarely look at unless I'm troubleshooting problems on those servers.

I try to glance at production problems daily and clean up emails. Many of the production notifications are routine or things that can be frequently ignored unless they're really persistent. Some of the production notifications can be occasionally useful to see either new issues or bad bots trying shenanigans on our site, though. I think you'll get ideas of some of the routine things very quickly and most are related to transient problems in external services that we don't have much control over. (Merritt, Zenodo, CrossRef, DataCite, EZID, etc).

Notifications of the same errors are thinned so we should never have something that spams the mailbox in too extreme of a way even if it repeats in a crazy endless loop since things are notified on a power of 2 (2^y) pattern.  I think the counter resets every 6 hours or something, so from the same server we get notified on 1st, 2nd, 4th, 8th, 16th, 32nd, etc occurrences (even 1024 of the same problem is only 10 emails and get notified less frequently as numbers of problems go up).  You'll only receive a limited number of notifications so as not to fill your inbox with thousands of emails in some crazy situation but it gives a good idea what is going on.

We should also see about getting you on the Nagios alerts and give you some info about how to handle them in the rare case that you need to do something about them. You'll also see those alerts in the dryad-nagios slack channel.









