### PR TITLE
Documentation about ruby app setup for our Frictionless Lambda

### DIFF
--- a/documentation/external_services/amazon_aws_notes.md
+++ b/documentation/external_services/amazon_aws_notes.md
@@ -146,20 +146,20 @@ INPUT json example:
 - Connect to the VPN or use sshuttle so you have access to our standard development database.
 - Start your development environment with `rails s -e local_dev` (add `bundle exec` before this command if needed).
 - This automatically has correct API info filled into the database and callback URLs are directed to our
-  standard development server which will then make updates to the same database that this environment uses.
+  standard development server which will then make updates to the same database that your environment uses.
 
 ## I want to test the lambda the harder way with a web accessible server
 - Set up a server that is publicly accessible on the internet.
 - Go to *app/config/environments* and add a new file for your new environment
   - Change the settings for `config.action_mailer.default_url_options` and 
     `Rails.application.default_url_options` so it has the correct hostname (and port if needed) to
-    create correct URLs for your environment.  See the other environment files for examples
+    create correct URLs in your environment.  See the other environment files for examples
     (especially the development environment).
 - Add the environment to other config files (it might inherit most settings from development).
   - `app_config.yml`
   - `database.yml`
   - `tenants/*.yml` (You may only need to add your special environment to a few tenants you intend to use,
-    but I haven't tested this.)
+    but I haven't tested this yet.)
 - Add an API account with permission to write information. (see `documentation/apis/adding_api_accounts.md`
   and `documentation/apis/choosing_authentication_type.md` and the grant type will be Client Credentials
   Grant in this case and based on a user with appropriate permissions to write for all datasets.)

--- a/documentation/external_services/amazon_aws_notes.md
+++ b/documentation/external_services/amazon_aws_notes.md
@@ -9,7 +9,7 @@ the firewall. Identify the machine’s security group, go to EC2
 settings for that security group, and ensure they allow the activity
 you’re trying.
 
-AWS Client Setup
+AWS client setup
 ==================
 
 How to install the AWS client on a local computer. The client is already installed on EC2 when
@@ -97,13 +97,13 @@ can handle large (> 5GB) uploads which are not supported by single s3 requests.
 
 The library is set up using npm modules.
 
-## Updating node and Evaporate js libraries
+## Updating Node and Evaporate js libraries
 
 The evaporate JS library is updated using yarn as a NPM library. (No longer browserify since we
 transitioned it to React code.)
 
 
-Working With S3
+Working with S3
 =================
 
 Listing bucket contents
@@ -148,7 +148,7 @@ INPUT json example:
 - This automatically has correct API info filled into the database and callback URLs are directed to our
   standard development server which will then make updates to the same database that your environment uses.
 
-## I want to test the lambda the harder way with a web accessible server
+## Lambda from a new web-accessible server
 - Set up a server that is publicly accessible on the internet.
 - Go to *app/config/environments* and add a new file for your new environment
   - Change the settings for `config.action_mailer.default_url_options` and 
@@ -171,7 +171,7 @@ INPUT json example:
   changes and using internal methods in the doorkeeper library.
 
 
-Working With EC2
+Working with EC2
 ==================
 
 Spinning up an EC2 machine


### PR DESCRIPTION
This gives instructions on how to test with it locally or setting up another environment that is configured to have a different public URL if needed.

I wasn't sure where to put this in our docs, but put it under the AWS services since it was related.  I can move it if you have suggestions of better places it should live.