### PR TITLE
Add rake task to update all our tables to utf8mb4 instead of utf8

### DIFF
--- a/lib/tasks/mysql.rake
+++ b/lib/tasks/mysql.rake
@@ -1,0 +1,28 @@
+require 'byebug'
+
+namespace :mysql do
+  desc 'update utf8 to utf8mb4 for existing tables'
+  task update_utf8mb4: :environment do
+    $stdout.sync = true # keeps stdout from buffering and writes right away
+    puts "Are you sure you want to update all tables to utf8mb4 for #{Rails.env}?  (Type 'yes' to proceed.)"
+    response = $stdin.gets
+    exit 1 unless response.strip.casecmp('YES').zero?
+
+
+    tables = ActiveRecord::Base.connection.tables
+    tables.each do |table|
+      puts "#{Time.new} Updating #{table}" # it's nice to see times to know how slow it is ;-)
+
+      query = "ALTER TABLE #{table} CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+      ActiveRecord::Base.connection.execute(query)
+    end
+
+    # note: to alter the default for a database, do this, but it doesn't alter the varchar/text columns which the
+    # above does.
+    #
+    # ALTER DATABASE
+    #     database_name
+    #     CHARACTER SET = utf8mb4
+    #     COLLATE = utf8mb4_unicode_ci;
+  end
+end

--- a/lib/tasks/mysql.rake
+++ b/lib/tasks/mysql.rake
@@ -1,5 +1,3 @@
-require 'byebug'
-
 namespace :mysql do
   desc 'update utf8 to utf8mb4 for existing tables'
   task update_utf8mb4: :environment do
@@ -7,7 +5,6 @@ namespace :mysql do
     puts "Are you sure you want to update all tables to utf8mb4 for #{Rails.env}?  (Type 'yes' to proceed.)"
     response = $stdin.gets
     exit 1 unless response.strip.casecmp('YES').zero?
-
 
     tables = ActiveRecord::Base.connection.tables
     tables.each do |table|


### PR DESCRIPTION
This problem came up when testing the MySQL 8 migration.  It was the only issue aside from a table not being "dynamic" on a test database that we never use on dev.

Apparently there is a fairly easy way to update the tables with a SQL command.

A possible concern is changing a varchar(255) to a varchar(191) and losing data. However since we've configured rails to default to UTF8MB4 all of our varchar fields have a max length of 191 or less already. We've done a bunch of these individual field conversions in the past.  I don't see any reason we'd lose data since our varchar fields are already within the utf8mb4 limit.

This query will do that and I've created a rake task to do this (so we don't have to do it at the same time as a deployment and can run it separately from deployment or migration).

```
ALTER TABLE tablename CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
```
For the entire database the query below changes the default (which I did already, but it only applies the default to new fields/tables):

```
    ALTER DATABASE
        database_name
        CHARACTER SET = utf8mb4
        COLLATE = utf8mb4_unicode_ci;
```

I ran this rake task on development and had no problems. Any reservations?  Or something we could talk about in the Dev coffee next week.