### PR TITLE
Copy 30-minute cron to 1 hour

### DIFF
--- a/cron/every_hour.sh
+++ b/cron/every_hour.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+: ${1:?"Need to pass in environment (e.g. development, stage, production)"}
+
+PATH=$PATH:/apps/dryad/local/bin
+
+cd /apps/dryad/apps/ui/current/
+
+# Opting not to record output in logs since it would display the command in clear text
+nice -n 19 ionice -c 3 bundle exec rails dev_ops:backup RAILS_ENV=$1


### PR DESCRIPTION
I made a copy of this script from every_30.sh to every_hour.sh .  Both exist right now.  Then we will need to get Ashley to change our crons in puppet (or can we do it and where?) so we get rid of the 30 minute and replace it with an hourly trigger of the hourly script in cron.  Then we can do another PR to remove the every_30.sh script.

The only thing in the 30 minute script is the database backup right now so I don't think we need to keep it. If we want to keep the 30 minute cron we will want to empty the script of the command that runs the database backup.