### PR TITLE
Remove Author.primary in favor of Resource.owner_author

### DIFF
--- a/app/models/stash_engine/author.rb
+++ b/app/models/stash_engine/author.rb
@@ -23,11 +23,6 @@ module StashEngine
       enable
     end
 
-    def self.primary(resource_id)
-      r = StashEngine::Resource.find(resource_id)
-      r&.owner_author
-    end
-
     def ==(other)
       return false unless other.present?
       return true if author_orcid.present? && other.author_orcid == author_orcid

--- a/app/models/stash_engine/author.rb
+++ b/app/models/stash_engine/author.rb
@@ -24,7 +24,8 @@ module StashEngine
     end
 
     def self.primary(resource_id)
-      where(resource_id: resource_id).where.not(author_email: nil).order(:id)&.first
+      r = StashEngine::Resource.find(resource_id)
+      r&.owner_author
     end
 
     def ==(other)

--- a/lib/stash/payments/invoicer.rb
+++ b/lib/stash/payments/invoicer.rb
@@ -122,7 +122,7 @@ module Stash
       end
 
       def stripe_user_customer_id
-        author = StashEngine::Author.primary(resource.id)
+        author = resource.owner_author
         return if author.blank?
         return if author.author_email.blank?
         return author.stripe_customer_id if author.stripe_customer_id.present?

--- a/spec/models/stash/payments/invoicer_spec.rb
+++ b/spec/models/stash/payments/invoicer_spec.rb
@@ -22,13 +22,13 @@ module Stash
         allow(@resource).to receive(:identifier).and_return(@identifier)
 
         @author = double(StashEngine::Author)
-        allow(StashEngine::Author).to receive(:primary).with(@resource_id).and_return(@author)
         allow(StashEngine::Author).to receive(:where).and_return(nil)
         allow(@author).to receive(:update).and_return(true)
         allow(@author).to receive(:id).and_return(9)
         allow(@author).to receive(:author_email).and_return('jane.doe@example.org')
         allow(@author).to receive(:author_standard_name).and_return('Jane Doe')
         allow(@author).to receive(:stripe_customer_id).and_return(nil)
+        allow(@resource).to receive(:owner_author).and_return(@author)
 
         @cust_id = '9999'
         fake_invoice_item = OpenStruct.new(customer: @cust_id, amount: '99.99', currency: 'usd', description: 'Data Processing Charge')
@@ -58,7 +58,7 @@ module Stash
       end
 
       it 'does not create an invoice when the resource has no primary author' do
-        allow(StashEngine::Author).to receive(:primary).with(@resource_id).and_return(nil)
+        allow(@resource).to receive(:owner_author).and_return(nil)
         expect(@invoicer.charge_user_via_invoice).to eql(nil)
       end
 

--- a/spec/models/stash_engine/author_spec.rb
+++ b/spec/models/stash_engine/author_spec.rb
@@ -186,14 +186,6 @@ module StashEngine
           end
         end
 
-        it 'primary returns correct author' do
-          @resource.authors = []
-          create(:author, resource: @resource, author_first_name: 'Wrong', author_email: nil)
-          right_author = create(:author, resource: @resource, author_first_name: 'Right', author_email: 'right@one.org')
-          create(:author, resource: @resource, author_first_name: 'Wrong2', author_email: nil)
-          expect(Author.primary(@resource)).to eql(right_author)
-        end
-
       end
     end
   end


### PR DESCRIPTION
The `Author.primary` had not been updated when we introduced `Resource.owner_author`, so it was possible for the incorrect author to be selected when generating a Stripe invoice. This corrects the problem, and fixes the underlying cause for https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2053