### PR TITLE
Web-to-lead form for Salesforce integration

### DIFF
--- a/app/views/layouts/_contact_thanks.html.erb
+++ b/app/views/layouts/_contact_thanks.html.erb
@@ -1,0 +1,5 @@
+<h1>Thanks for Contacting Us</h1>
+
+<p>Thank you for contacting Dryad. We will be in touch with you shortly.</p>
+
+

--- a/app/views/layouts/_interested.html.erb
+++ b/app/views/layouts/_interested.html.erb
@@ -31,30 +31,30 @@
   value="ryan@datadryad.org">                               -->
 <!--  ----------------------------------------------------------------------  -->
 
-<label for="first_name" class="c-input__label">First name</label>
-<input id="first_name" class="c-input__text" maxlength="80" name="first_name" type="text" /><br>
+<label for="first_name" class="required c-input__label">First name</label>
+<input id="first_name" class="c-input__text" maxlength="80" name="first_name" type="text" /><br><br>
 
-<label for="last_name" class="c-input__label">Last name</label>
-<input id="last_name" class="c-input__text" maxlength="80" name="last_name" size="20" type="text" /><br>
+<label for="last_name" class="required c-input__label">Last name</label>
+<input id="last_name" class="c-input__text" maxlength="80" name="last_name" size="20" type="text" /><br><br>
 
-<label for="email" class="c-input__label">Email address</label>Please use your institutional email address if possible
-<input id="email" class="c-input__text" maxlength="80" name="email" size="20" type="text" /><br>
+<label for="email" class="required c-input__label">Email address</label>Please use your institutional email address if possible
+<input id="email" class="c-input__text" maxlength="80" name="email" size="20" type="text" /><br><br>
 
 <label for="company" class="c-input__label">Institution or organization</label>Please use your primary institutional affiliation
-<input id="company" class="c-input__text" name="company" title="Institution" /><br>
+<input id="company" class="c-input__text" name="company" title="Institution" /><br><br>
 
 <label for="title" class="c-input__label">Job Title</label>Please use your current job title
-<input id="title" class="c-input__text" maxlength="40" name="title" size="20" type="text" /><br>
+<input id="title" class="c-input__text" maxlength="40" name="title" size="20" type="text" /><br><br>
 
 <label for="<%= APP_CONFIG.salesforce.participation_field_id %>" class="c-input__label">How would you like to participate?</label>Select all that apply
 <select  id="<%= APP_CONFIG.salesforce.participation_field_id %>" multiple="multiple" name="<%= APP_CONFIG.salesforce.participation_field_id %>" title="Participation">
   <option value="Join our mailing list">Join our mailing list</option>
   <option value="Set up a demo or meeting">Set up a demo or meeting</option>
   <option value="Get help with an issue">Get help with an issue</option>
-</select><br>
+</select><br><br>
 
 <label for="<%= APP_CONFIG.salesforce.comment_field_id %>" class="c-input__label">Comments</label>
-<textarea  id="<%= APP_CONFIG.salesforce.comment_field_id %>" name="<%= APP_CONFIG.salesforce.comment_field_id %>" rows="3" type="text" wrap="soft"></textarea><br>
+<textarea  id="<%= APP_CONFIG.salesforce.comment_field_id %>" name="<%= APP_CONFIG.salesforce.comment_field_id %>" rows="3" type="text" wrap="soft"></textarea><br><br>
 
 <div class="g-recaptcha" data-sitekey="<%= APP_CONFIG.google_recaptcha_sitekey %>"></div><br>
 <button class="o-button__plain-text1" style="width:min-content;" type="submit" name="submit">Submit</button>

--- a/app/views/layouts/_interested.html.erb
+++ b/app/views/layouts/_interested.html.erb
@@ -17,10 +17,10 @@
 <!--  NOTE: Please add the following <FORM> element to your page.             -->
 <!--  ----------------------------------------------------------------------  -->
 
-<form class="c-input" action="https://test.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST">
+<form class="c-input" action="<%= APP_CONFIG.salesforce.web_to_lead_target %>" method="POST">
 
-<input type=hidden name='captcha_settings' value='{"keyname":"Dryad_v2","fallback":"true","orgId":"00D54000000YogL","ts":""}'>
-<input type=hidden name="oid" value="00D54000000YogL">
+<input type=hidden name='captcha_settings' value='{"keyname":"Dryad_v2","fallback":"true","orgId":"<%= APP_CONFIG.salesforce.org_id %>","ts":""}'>
+<input type=hidden name="oid" value="<%= APP_CONFIG.salesforce.org_id %>">
 <input type=hidden name="retURL" value="<%= Rails.application.routes.url_helpers.contact_thanks_url %>">
 
 <!--  ----------------------------------------------------------------------  -->
@@ -37,24 +37,24 @@
 <label for="last_name" class="c-input__label">Last name</label>
 <input id="last_name" class="c-input__text" maxlength="80" name="last_name" size="20" type="text" /><br>
 
-<label for="00N5400000ifBP6" class="c-input__label">Institution</label>Please use your primary institutional affiliation
-<input id="00N5400000ifBP6" class="c-input__text" name="00N5400000ifBP6" title="Institution" /><br>
-
 <label for="email" class="c-input__label">Email address</label>Please use your institutional email address if possible
 <input id="email" class="c-input__text" maxlength="80" name="email" size="20" type="text" /><br>
+
+<label for="company" class="c-input__label">Institution or organization</label>Please use your primary institutional affiliation
+<input id="company" class="c-input__text" name="company" title="Institution" /><br>
 
 <label for="title" class="c-input__label">Job Title</label>Please use your current job title
 <input id="title" class="c-input__text" maxlength="40" name="title" size="20" type="text" /><br>
 
-<label for="00N5400000ifBPB" class="c-input__label">How would you like to participate?</label>Select all that apply
-<select  id="00N5400000ifBPB" multiple="multiple" name="00N5400000ifBPB" title="Participation">
+<label for="<%= APP_CONFIG.salesforce.participation_field_id %>" class="c-input__label">How would you like to participate?</label>Select all that apply
+<select  id="<%= APP_CONFIG.salesforce.participation_field_id %>" multiple="multiple" name="<%= APP_CONFIG.salesforce.participation_field_id %>" title="Participation">
   <option value="Join our mailing list">Join our mailing list</option>
   <option value="Set up a demo or meeting">Set up a demo or meeting</option>
   <option value="Get help with an issue">Get help with an issue</option>
 </select><br>
 
-<label for="00N5400000ifBP4" class="c-input__label">Comments</label>
-<textarea  id="00N5400000ifBP4" name="00N5400000ifBP4" rows="3" type="text" wrap="soft"></textarea><br>
+<label for="<%= APP_CONFIG.salesforce.comment_field_id %>" class="c-input__label">Comments</label>
+<textarea  id="<%= APP_CONFIG.salesforce.comment_field_id %>" name="<%= APP_CONFIG.salesforce.comment_field_id %>" rows="3" type="text" wrap="soft"></textarea><br>
 
 <div class="g-recaptcha" data-sitekey="<%= APP_CONFIG.google_recaptcha_sitekey %>"></div><br>
 <button class="o-button__plain-text1" style="width:min-content;" type="submit" name="submit">Submit</button>

--- a/app/views/layouts/_interested.html.erb
+++ b/app/views/layouts/_interested.html.erb
@@ -41,27 +41,22 @@
 <input id="email" class="c-input__text" maxlength="80" name="email" size="20" type="text" /><br>
 
 <label for="00N5400000ifBP6" class="c-input__label">Institution</label>
-<select id="00N5400000ifBP6" class="c-input__text" name="00N5400000ifBP6" title="Institution"><option value="">--None--</option><option value="No service">No service</option>
-<option value="Planning">Planning</option>
-<option value="Implementing">Implementing</option>
-<option value="Mature">Mature</option>
+<select id="00N5400000ifBP6" class="c-input__text" name="00N5400000ifBP6" title="Institution">
+  <option value="">--None--</option>
+  <option value="No service">No service</option>
+  <option value="Planning">Planning</option>
+  <option value="Implementing">Implementing</option>
+  <option value="Mature">Mature</option>
 </select><br>
 
-<label for="00N5400000ifBP5" class="c-input__label">Current status</label>
-<select  id="00N5400000ifBP5" name="00N5400000ifBP5" title="Current Status"><option value="">--None--</option><option value="Faculty member">Faculty member</option>
-<option value="Postdoc">Postdoc</option>
-<option value="Graduate student">Graduate student</option>
-<option value="Undergraduate student">Undergraduate student</option>
-<option value="Librarian">Librarian</option>
-<option value="Industry Professional">Industry Professional</option>
-<option value="Nonprofit Professional">Nonprofit Professional</option>
-<option value="Government Professional">Government Professional</option>
-</select><br>
+<label for="title" class="c-input__label">Title</label>
+<input id="title" class="c-input__text" maxlength="40" name="title" size="20" type="text" /><br>
 
 <label for="00N5400000ifBPB" class="c-input__label">Participation</label>
-<select  id="00N5400000ifBPB" multiple="multiple" name="00N5400000ifBPB" title="Participation"><option value="Join our mailing list">Join our mailing list</option>
-<option value="Set up a demo or meeting">Set up a demo or meeting</option>
-<option value="Get help with an issue">Get help with an issue</option>
+<select  id="00N5400000ifBPB" multiple="multiple" name="00N5400000ifBPB" title="Participation">
+  <option value="Join our mailing list">Join our mailing list</option>
+  <option value="Set up a demo or meeting">Set up a demo or meeting</option>
+  <option value="Get help with an issue">Get help with an issue</option>
 </select><br>
 
 <label for="00N5400000ifBP4" class="c-input__label">Comments</label>

--- a/app/views/layouts/_interested.html.erb
+++ b/app/views/layouts/_interested.html.erb
@@ -8,6 +8,10 @@
 <!--  ----------------------------------------------------------------------  -->
 
 <META HTTP-EQUIV="Content-type" CONTENT="text/html; charset=UTF-8">
+<script src="https://www.google.com/recaptcha/api.js"></script>
+<script>
+ function timestamp() { var response = document.getElementById("g-recaptcha-response"); if (response == null || response.value.trim() == "") {var elems = JSON.parse(document.getElementsByName("captcha_settings")[0].value);elems["ts"] = JSON.stringify(new Date().getTime());document.getElementsByName("captcha_settings")[0].value = JSON.stringify(elems); } } setInterval(timestamp, 500); 
+</script>
 
 <!--  ----------------------------------------------------------------------  -->
 <!--  NOTE: Please add the following <FORM> element to your page.             -->
@@ -15,30 +19,32 @@
 
 <form action="https://test.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST">
 
-<input type=hidden name="oid" value="00D17000000edjf">
-<input type=hidden name="retURL" value="https://datadryad.org/stash/contact_thanks">
+<input type=hidden name='captcha_settings' value='{"keyname":"Dryad_v2","fallback":"true","orgId":"00D54000000YogL","ts":""}'>
+<input type=hidden name="oid" value="00D54000000YogL">
+<input type=hidden name="retURL" value="<%= Rails.application.routes.url_helpers.contact_thanks_url %>">
 
 <!--  ----------------------------------------------------------------------  -->
 <!--  NOTE: These fields are optional debugging elements. Please uncomment    -->
 <!--  these lines if you wish to test in debug mode.                          -->
-<!--  <input type="hidden" name="debug" value=1>                              -->
-<!--  <input type="hidden" name="debugEmail"                                  -->
-<!--  value="dimitra@cloudmasonry.com.invalid">                               -->
+<!--  <input type="hidden" name="debug" value=1>                             
+ <input type="hidden" name="debugEmail"                                 
+  value="ryan@datadryad.org">                               -->
 <!--  ----------------------------------------------------------------------  -->
 
-<label for="first_name">First Name</label><input  id="first_name" maxlength="40" name="first_name" size="20" type="text" /><br>
+ <label for="first_name" class="c-input__label">First Name</label>
+ <input id="first_name" class="c-input__text" maxlength="40" name="first_name" type="text" /><br>
 
 <label for="last_name">Last Name</label><input  id="last_name" maxlength="80" name="last_name" size="20" type="text" /><br>
 
 <label for="email">Email</label><input  id="email" maxlength="80" name="email" size="20" type="text" /><br>
 
-Institution:<select  id="00N1700000ij4IQ" name="00N1700000ij4IQ" title="Institution"><option value="">--None--</option><option value="No service">No service</option>
+Institution:<select  id="00N5400000ifBP6" name="00N5400000ifBP6" title="Institution"><option value="">--None--</option><option value="No service">No service</option>
 <option value="Planning">Planning</option>
 <option value="Implementing">Implementing</option>
 <option value="Mature">Mature</option>
 </select><br>
 
-Current Status:<select  id="00N1700000ij4IV" name="00N1700000ij4IV" title="Current Status"><option value="">--None--</option><option value="Faculty member">Faculty member</option>
+Current Status:<select  id="00N5400000ifBP5" name="00N5400000ifBP5" title="Current Status"><option value="">--None--</option><option value="Faculty member">Faculty member</option>
 <option value="Postdoc">Postdoc</option>
 <option value="Graduate student">Graduate student</option>
 <option value="Undergraduate student">Undergraduate student</option>
@@ -48,14 +54,16 @@ Current Status:<select  id="00N1700000ij4IV" name="00N1700000ij4IV" title="Curre
 <option value="Government Professional">Government Professional</option>
 </select><br>
 
-Participation:<select  id="00N1700000ij4Ia" multiple="multiple" name="00N1700000ij4Ia" title="Participation"><option value="Join our mailing list">Join our mailing list</option>
+Participation:<select  id="00N5400000ifBPB" multiple="multiple" name="00N5400000ifBPB" title="Participation"><option value="Join our mailing list">Join our mailing list</option>
 <option value="Set up a demo or meeting">Set up a demo or meeting</option>
 <option value="Get help with an issue">Get help with an issue</option>
 </select><br>
 
-Comments:<textarea  id="00N1700000ij4If" name="00N1700000ij4If" rows="3" type="text" wrap="soft"></textarea><br>
+Comments:<textarea  id="00N5400000ifBP4" name="00N5400000ifBP4" rows="3" type="text" wrap="soft"></textarea><br>
 
+<div class="g-recaptcha" data-sitekey="<%= APP_CONFIG.google_recaptcha_sitekey %>"></div><br>
 <input type="submit" name="submit">
 
 </form>
+
 

--- a/app/views/layouts/_interested.html.erb
+++ b/app/views/layouts/_interested.html.erb
@@ -1,4 +1,4 @@
-<h1>Interested?</h1>
+<h1>Interested in working with Dryad?</h1>
 
 
 <!--  ----------------------------------------------------------------------  -->
@@ -17,7 +17,7 @@
 <!--  NOTE: Please add the following <FORM> element to your page.             -->
 <!--  ----------------------------------------------------------------------  -->
 
-<form action="https://test.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST">
+<form class="c-input" action="https://test.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST">
 
 <input type=hidden name='captcha_settings' value='{"keyname":"Dryad_v2","fallback":"true","orgId":"00D54000000YogL","ts":""}'>
 <input type=hidden name="oid" value="00D54000000YogL">
@@ -31,20 +31,24 @@
   value="ryan@datadryad.org">                               -->
 <!--  ----------------------------------------------------------------------  -->
 
- <label for="first_name" class="c-input__label">First Name</label>
- <input id="first_name" class="c-input__text" maxlength="40" name="first_name" type="text" /><br>
+<label for="first_name" class="c-input__label">First name</label>
+<input id="first_name" class="c-input__text" maxlength="80" name="first_name" type="text" /><br>
 
-<label for="last_name">Last Name</label><input  id="last_name" maxlength="80" name="last_name" size="20" type="text" /><br>
+<label for="last_name" class="c-input__label">Last name</label>
+<input id="last_name" class="c-input__text" maxlength="80" name="last_name" size="20" type="text" /><br>
 
-<label for="email">Email</label><input  id="email" maxlength="80" name="email" size="20" type="text" /><br>
+<label for="email" class="c-input__label">Email</label>
+<input id="email" class="c-input__text" maxlength="80" name="email" size="20" type="text" /><br>
 
-Institution:<select  id="00N5400000ifBP6" name="00N5400000ifBP6" title="Institution"><option value="">--None--</option><option value="No service">No service</option>
+<label for="00N5400000ifBP6" class="c-input__label">Institution</label>
+<select id="00N5400000ifBP6" class="c-input__text" name="00N5400000ifBP6" title="Institution"><option value="">--None--</option><option value="No service">No service</option>
 <option value="Planning">Planning</option>
 <option value="Implementing">Implementing</option>
 <option value="Mature">Mature</option>
 </select><br>
 
-Current Status:<select  id="00N5400000ifBP5" name="00N5400000ifBP5" title="Current Status"><option value="">--None--</option><option value="Faculty member">Faculty member</option>
+<label for="00N5400000ifBP5" class="c-input__label">Current status</label>
+<select  id="00N5400000ifBP5" name="00N5400000ifBP5" title="Current Status"><option value="">--None--</option><option value="Faculty member">Faculty member</option>
 <option value="Postdoc">Postdoc</option>
 <option value="Graduate student">Graduate student</option>
 <option value="Undergraduate student">Undergraduate student</option>
@@ -54,15 +58,17 @@ Current Status:<select  id="00N5400000ifBP5" name="00N5400000ifBP5" title="Curre
 <option value="Government Professional">Government Professional</option>
 </select><br>
 
-Participation:<select  id="00N5400000ifBPB" multiple="multiple" name="00N5400000ifBPB" title="Participation"><option value="Join our mailing list">Join our mailing list</option>
+<label for="00N5400000ifBPB" class="c-input__label">Participation</label>
+<select  id="00N5400000ifBPB" multiple="multiple" name="00N5400000ifBPB" title="Participation"><option value="Join our mailing list">Join our mailing list</option>
 <option value="Set up a demo or meeting">Set up a demo or meeting</option>
 <option value="Get help with an issue">Get help with an issue</option>
 </select><br>
 
-Comments:<textarea  id="00N5400000ifBP4" name="00N5400000ifBP4" rows="3" type="text" wrap="soft"></textarea><br>
+<label for="00N5400000ifBP4" class="c-input__label">Comments</label>
+<textarea  id="00N5400000ifBP4" name="00N5400000ifBP4" rows="3" type="text" wrap="soft"></textarea><br>
 
 <div class="g-recaptcha" data-sitekey="<%= APP_CONFIG.google_recaptcha_sitekey %>"></div><br>
-<input type="submit" name="submit">
+<button class="o-button__plain-text1" style="width:min-content;" type="submit" name="submit">Submit</button>
 
 </form>
 

--- a/app/views/layouts/_interested.html.erb
+++ b/app/views/layouts/_interested.html.erb
@@ -37,22 +37,16 @@
 <label for="last_name" class="c-input__label">Last name</label>
 <input id="last_name" class="c-input__text" maxlength="80" name="last_name" size="20" type="text" /><br>
 
-<label for="email" class="c-input__label">Email</label>
+<label for="00N5400000ifBP6" class="c-input__label">Institution</label>Please use your primary institutional affiliation
+<input id="00N5400000ifBP6" class="c-input__text" name="00N5400000ifBP6" title="Institution" /><br>
+
+<label for="email" class="c-input__label">Email address</label>Please use your institutional email address if possible
 <input id="email" class="c-input__text" maxlength="80" name="email" size="20" type="text" /><br>
 
-<label for="00N5400000ifBP6" class="c-input__label">Institution</label>
-<select id="00N5400000ifBP6" class="c-input__text" name="00N5400000ifBP6" title="Institution">
-  <option value="">--None--</option>
-  <option value="No service">No service</option>
-  <option value="Planning">Planning</option>
-  <option value="Implementing">Implementing</option>
-  <option value="Mature">Mature</option>
-</select><br>
-
-<label for="title" class="c-input__label">Title</label>
+<label for="title" class="c-input__label">Job Title</label>Please use your current job title
 <input id="title" class="c-input__text" maxlength="40" name="title" size="20" type="text" /><br>
 
-<label for="00N5400000ifBPB" class="c-input__label">How would you like to participate?</label>
+<label for="00N5400000ifBPB" class="c-input__label">How would you like to participate?</label>Select all that apply
 <select  id="00N5400000ifBPB" multiple="multiple" name="00N5400000ifBPB" title="Participation">
   <option value="Join our mailing list">Join our mailing list</option>
   <option value="Set up a demo or meeting">Set up a demo or meeting</option>

--- a/app/views/layouts/_interested.html.erb
+++ b/app/views/layouts/_interested.html.erb
@@ -52,7 +52,7 @@
 <label for="title" class="c-input__label">Title</label>
 <input id="title" class="c-input__text" maxlength="40" name="title" size="20" type="text" /><br>
 
-<label for="00N5400000ifBPB" class="c-input__label">Participation</label>
+<label for="00N5400000ifBPB" class="c-input__label">How would you like to participate?</label>
 <select  id="00N5400000ifBPB" multiple="multiple" name="00N5400000ifBPB" title="Participation">
   <option value="Join our mailing list">Join our mailing list</option>
   <option value="Set up a demo or meeting">Set up a demo or meeting</option>

--- a/app/views/layouts/_interested.html.erb
+++ b/app/views/layouts/_interested.html.erb
@@ -1,0 +1,61 @@
+<h1>Interested?</h1>
+
+
+<!--  ----------------------------------------------------------------------  -->
+<!--  NOTE: Please add the following <META> element to your page <HEAD>.      -->
+<!--  If necessary, please modify the charset parameter to specify the        -->
+<!--  character set of your HTML page.                                        -->
+<!--  ----------------------------------------------------------------------  -->
+
+<META HTTP-EQUIV="Content-type" CONTENT="text/html; charset=UTF-8">
+
+<!--  ----------------------------------------------------------------------  -->
+<!--  NOTE: Please add the following <FORM> element to your page.             -->
+<!--  ----------------------------------------------------------------------  -->
+
+<form action="https://test.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST">
+
+<input type=hidden name="oid" value="00D17000000edjf">
+<input type=hidden name="retURL" value="https://datadryad.org/stash/contact_thanks">
+
+<!--  ----------------------------------------------------------------------  -->
+<!--  NOTE: These fields are optional debugging elements. Please uncomment    -->
+<!--  these lines if you wish to test in debug mode.                          -->
+<!--  <input type="hidden" name="debug" value=1>                              -->
+<!--  <input type="hidden" name="debugEmail"                                  -->
+<!--  value="dimitra@cloudmasonry.com.invalid">                               -->
+<!--  ----------------------------------------------------------------------  -->
+
+<label for="first_name">First Name</label><input  id="first_name" maxlength="40" name="first_name" size="20" type="text" /><br>
+
+<label for="last_name">Last Name</label><input  id="last_name" maxlength="80" name="last_name" size="20" type="text" /><br>
+
+<label for="email">Email</label><input  id="email" maxlength="80" name="email" size="20" type="text" /><br>
+
+Institution:<select  id="00N1700000ij4IQ" name="00N1700000ij4IQ" title="Institution"><option value="">--None--</option><option value="No service">No service</option>
+<option value="Planning">Planning</option>
+<option value="Implementing">Implementing</option>
+<option value="Mature">Mature</option>
+</select><br>
+
+Current Status:<select  id="00N1700000ij4IV" name="00N1700000ij4IV" title="Current Status"><option value="">--None--</option><option value="Faculty member">Faculty member</option>
+<option value="Postdoc">Postdoc</option>
+<option value="Graduate student">Graduate student</option>
+<option value="Undergraduate student">Undergraduate student</option>
+<option value="Librarian">Librarian</option>
+<option value="Industry Professional">Industry Professional</option>
+<option value="Nonprofit Professional">Nonprofit Professional</option>
+<option value="Government Professional">Government Professional</option>
+</select><br>
+
+Participation:<select  id="00N1700000ij4Ia" multiple="multiple" name="00N1700000ij4Ia" title="Participation"><option value="Join our mailing list">Join our mailing list</option>
+<option value="Set up a demo or meeting">Set up a demo or meeting</option>
+<option value="Get help with an issue">Get help with an issue</option>
+</select><br>
+
+Comments:<textarea  id="00N1700000ij4If" name="00N1700000ij4If" rows="3" type="text" wrap="soft"></textarea><br>
+
+<input type="submit" name="submit">
+
+</form>
+

--- a/app/views/stash_engine/pages/contact_thanks.html.erb
+++ b/app/views/stash_engine/pages/contact_thanks.html.erb
@@ -1,0 +1,3 @@
+<% @page_title = 'Thanks for contacting Dryad' %>
+
+<div class="markdown_styles contact-page"><%= render "layouts/contact_thanks" %></div>

--- a/app/views/stash_engine/pages/interested.html.erb
+++ b/app/views/stash_engine/pages/interested.html.erb
@@ -1,0 +1,3 @@
+<% @page_title = 'Interested in Dryad' %>
+
+<div class="markdown_styles contact-page"><%= render "layouts/interested" %></div>

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -5,13 +5,11 @@
 <% else %>
 
 defaults: &DEFAULTS
-  google_analytics_id: null
   shared_resource_model: StashEngine::Resource
   stash_mount: /stash
   ezid:
     host: ezid.cdlib.org
     port: 443
-  google_maps_api_key: <%= Rails.application.credentials[Rails.env.to_sym][:google_maps_api_key] %>
   contact_us_uri: help@datadryad.org
   # sandbox orcid credentials
   orcid:
@@ -160,6 +158,9 @@ defaults: &DEFAULTS
     bucket: dryad-s3-dev
     key: AKIAIQ5XWADKJZ556SBQ
     secret: <%= Rails.application.credentials[Rails.env.to_sym][:s3_secret] %>
+  google_analytics_id: null
+  google_maps_api_key: <%= Rails.application.credentials[Rails.env.to_sym][:google_maps_api_key] %>
+  google_recaptcha_sitekey: 6Lfhn5kiAAAAAIzZPQEGRa43cDJz-rNVxRcQIkU4
   google:
     gmail_client_id: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_id] %>
     gmail_client_secret: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_secret] %>
@@ -255,7 +256,6 @@ demo:
 
 production:
   <<: *DEFAULTS
-  google_analytics_id: UA-145629338-1
   shib_sp_host: datadryad.org
   page_error_email: [scott.fisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
   submission_error_email: [sfisher@ucop.edu, ryan@datadryad.org, Maria.Praetzellis@ucop.edu, audrey@datadryad.org]
@@ -293,6 +293,7 @@ production:
     bucket: dryad-s3-prd
     key: AKIAIQ5XWADKJZ556SBQ
     secret: <%= Rails.application.credentials[Rails.env.to_sym][:s3_secret] %>
+  google_analytics_id: UA-145629338-1
   google:
     gmail_client_id: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_id] %>
     gmail_client_secret: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_secret] %>

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -187,10 +187,14 @@ defaults: &DEFAULTS
   salesforce:
     server: https://dryad2-dev-ed.lightning.force.com
     username: ryan+sf@datadryad.org
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:salesforce_password] %>
+    password: <%= Rails.application.credentials[Rails.env.to_sym][:salesforce_password] %>    
     security_token: <%= Rails.application.credentials[Rails.env.to_sym][:salesforce_security_token] %>
     client_id: <%= Rails.application.credentials[Rails.env.to_sym][:salesforce_client_id] %>
     client_secret: <%= Rails.application.credentials[Rails.env.to_sym][:salesforce_client_secret] %>
+    web_to_lead_target: https://test.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8
+    org_id: 00D54000000YogL
+    participation_field_id: 00N5400000ifBPB
+    comment_field_id: 00N5400000ifBP4
   mce_key: <%= Rails.application.credentials[Rails.env.to_sym][:tiny_mce] %>
 
 development: &DEVELOPMENT
@@ -308,6 +312,10 @@ production:
     security_token: <%= Rails.application.credentials[Rails.env.to_sym][:salesforce_security_token] %>
     client_id: <%= Rails.application.credentials[Rails.env.to_sym][:salesforce_client_id] %>
     client_secret: <%= Rails.application.credentials[Rails.env.to_sym][:salesforce_client_secret] %>
+    web_to_lead_target: https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8
+    org_id: 00D3h000003z3po
+    participation_field_id: 00N3h00000Ix75q
+    comment_field_id: 00N3h00000Ix75j
 
 # Terminate the if statement from the beginning of this file.
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -249,6 +249,7 @@ Rails.application.routes.draw do
     get 'our_governance', to: 'pages#our_governance'
     get 'our_mission', to: 'pages#our_mission'
     get 'our_membership', to: 'pages#our_membership'
+    get 'interested', to: 'pages#interested'
     get 'join_us', to: 'pages#join_us'
     get 'our_platform', to: 'pages#our_platform'
     get 'code_of_conduct', to: 'pages#code_of_conduct'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,6 +250,7 @@ Rails.application.routes.draw do
     get 'our_mission', to: 'pages#our_mission'
     get 'our_membership', to: 'pages#our_membership'
     get 'interested', to: 'pages#interested'
+    get 'contact_thanks', to: 'pages#contact_thanks'
     get 'join_us', to: 'pages#join_us'
     get 'our_platform', to: 'pages#our_platform'
     get 'code_of_conduct', to: 'pages#code_of_conduct'


### PR DESCRIPTION
Adds a new page, `/stash/interested`, which collects information from people who are interested in partnering with Dryad. 

This page uses a Google reCAPTCHA. The "key" is stored in plaintext in the config, because it is equivalent to an account ID; it must be stored as plaintext in the resultant HTML. The secret associated with this key is not stored anywhere in Dryad; it is stored in Salesforce to validate the results of the CAPTCHA.

When the form is filled out, the user will be redirected to the `contact_thanks` page, but only if Dryad is running on a server with a defined Rails environment (dev, stage, prod). Other servers pass the servername "localhost" to the Salesforce instance, and Salesforce doesn't know where to send the redirect.