### PR TITLE
Remove bogus Kaust email

### DIFF
--- a/config/tenants/kaust.yml
+++ b/config/tenants/kaust.yml
@@ -25,7 +25,7 @@ default: &default
     entity_id: https://waseet.kaust.edu.sa/idp/shibboleth
     entity_domain: waseet.kaust.edu.sa
   default_license: cc0
-  campus_contacts: ["daryl.grenz@kaust.edu.sa"]
+  campus_contacts: []
   data_deposit_agreement: false
   partner_display: true
   covers_dpc: true
@@ -71,5 +71,5 @@ production:
     account: <%= Rails.application.credentials[Rails.env.to_sym][:datacite_username] %>
     password: <%= Rails.application.credentials[Rails.env.to_sym][:datacite_password] %>
     sandbox: false
-  campus_contacts: [""]
+  campus_contacts: ["daryl.grenz@kaust.edu.sa"]
 

--- a/config/tenants/kaust.yml
+++ b/config/tenants/kaust.yml
@@ -71,5 +71,5 @@ production:
     account: <%= Rails.application.credentials[Rails.env.to_sym][:datacite_username] %>
     password: <%= Rails.application.credentials[Rails.env.to_sym][:datacite_password] %>
     sandbox: false
-  campus_contacts: ["daryl.grenz@kaust.edu.sa"]
+  campus_contacts: []
 


### PR DESCRIPTION
A user at Kaust was accidentally notified of some testing I was doing in the dev environment. This PR removes them from the dev config, so they are no longer notified of test activity.

Normally, I would add them to the production config, but this user seemed surprised to be getting any message, and I can find no record that they ever asked to be added to notifications, so it seems best to avoid adding new notifications.