### PR TITLE
error over 50GB replication to zenodo immediately (see #2097)

### DIFF
--- a/lib/stash/zenodo_replicate/copier.rb
+++ b/lib/stash/zenodo_replicate/copier.rb
@@ -47,6 +47,7 @@ module Stash
 
       def add_to_zenodo
         # sanity checks
+        error_if_over_50gb # these error eventually and interfere with other jobs, so for now this is here
         error_if_not_enqueued
         error_if_replicating
         error_if_out_of_order

--- a/lib/stash/zenodo_replicate/copier_mixin.rb
+++ b/lib/stash/zenodo_replicate/copier_mixin.rb
@@ -31,6 +31,18 @@ module Stash
         raise ZenodoError, "identifier_id #{@copy.identifier_id}: Cannot replicate when a previous replication for the " \
               'identifier has not finished yet. Items must replicate in order.'
       end
+
+      def error_if_over_50gb
+        file_map = { data: 'StashEngine::DataFile', software: 'StashEngine::SoftwareFile', supp: 'StashEngine::SuppFile' }
+        submission_size = StashEngine::GenericFile.where(type: file_map[@dataset_type])
+          .where(resource_id: @resource.id)
+          .where.not(file_state: 'deleted')
+          .sum(:upload_file_size)
+        return if submission_size < 50_000_000_000
+
+        raise ZenodoError, "resource #{@resource.id} has over 50GB of content which is being skipped for replication to " \
+              "Zenodo since it's not currently reliable"
+      end
     end
   end
 end

--- a/spec/lib/stash/zenodo_replicate/copier_spec.rb
+++ b/spec/lib/stash/zenodo_replicate/copier_spec.rb
@@ -99,6 +99,15 @@ module Stash
           expect(@ztc2.state).to eq('error')
           expect(@ztc2.error_info).to include('Items must replicate in order')
         end
+
+        it 'rejects an over 50GB submission' do
+          create(:data_file, upload_file_size: 6e+10, resource_id: @resource.id)
+          @szr = Stash::ZenodoReplicate::Copier.new(copy_id: @ztc.id)
+          @szr.add_to_zenodo
+          @ztc.reload
+          expect(@ztc.state).to eq('error')
+          expect(@ztc.error_info).to include('over 50GB')
+        end
       end
     end
   end


### PR DESCRIPTION
This errors immediately instead of taking up the queue slots for 24 hours before erroring on large submissions for data files to zenodo.

This should make less distractions and wasted time on our part until/unless we decide to put work and collaboration into fixing this.