### PR TITLE
Workarounds for Merritt-Sword returning errors for non-error states

### DIFF
--- a/stash/stash-merritt/lib/stash/merritt/sword_helper.rb
+++ b/stash/stash-merritt/lib/stash/merritt/sword_helper.rb
@@ -20,8 +20,12 @@ module Stash
         else
           do_create
         end
-      rescue RestClient::Exceptions::ReadTimeout, RestClient::InternalServerError, RestClient::ServiceUnavailable
+      rescue RestClient::Exceptions::ReadTimeout, RestClient::ServiceUnavailable
         raise GoneAsynchronous
+      rescue RestClient::InternalServerError => e
+        raise GoneAsynchronous if e&.response&.body&.include?('java.net.SocketTimeoutException')
+
+        raise e
       ensure
         resource.version_zipfile = File.basename(package.payload)
         resource.save!

--- a/stash/stash-merritt/lib/stash/merritt/sword_helper.rb
+++ b/stash/stash-merritt/lib/stash/merritt/sword_helper.rb
@@ -20,7 +20,7 @@ module Stash
         else
           do_create
         end
-      rescue RestClient::Exceptions::ReadTimeout, RestClient::ServiceUnavailable
+      rescue RestClient::Exceptions::ReadTimeout, RestClient::GatewayTimeout
         raise GoneAsynchronous
       rescue RestClient::InternalServerError => e
         raise GoneAsynchronous if e&.response&.body&.include?('java.net.SocketTimeoutException')

--- a/stash/stash-merritt/lib/stash/merritt/sword_helper.rb
+++ b/stash/stash-merritt/lib/stash/merritt/sword_helper.rb
@@ -20,7 +20,7 @@ module Stash
         else
           do_create
         end
-      rescue RestClient::Exceptions::ReadTimeout
+      rescue RestClient::Exceptions::ReadTimeout, RestClient::InternalServerError, RestClient::ServiceUnavailable
         raise GoneAsynchronous
       ensure
         resource.version_zipfile = File.basename(package.payload)


### PR DESCRIPTION
Something changed in the past month or so and now we get `500 Internal Server Error` when large items are ingested in Merritt, even though they succeed later.

David also said he'll send us 503s for some items for this case, also.  So adding that in.

By looking through the logs, I found out that these specific 500 errors seem to have java.net.SocketTimeoutException in the document body.  So I'm looking for this string to ignore the error. Other 500 errors can mean other things have gone wrong in other ways in Merritt so I don't really want to catch every one (so I'm re-raising others that don't have that string the body).

I hope this will make our life less annoying and so we don't have to babysit these constantly and make manual corrections all the time and be one less distraction.