### PR TITLE
PPR detail report

### DIFF
--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -345,8 +345,8 @@ namespace :identifiers do
         next unless in_ppr
 
         csv << [i.identifier, i.publication_article_doi, i.manuscript_number,
-                ca.resource.stash_version.version, date_entered_ppr, 'None', 'None',
-                ca.resource.size, i.journal&.title, i.journal&.default_to_ppr, i.journal&.manuscript_number_regex&.present?, who_pays]
+                i.latest_resource.stash_version.version, date_entered_ppr, 'None', 'None',
+                i.latest_resource.size, i.journal&.title, i.journal&.default_to_ppr, i.journal&.manuscript_number_regex&.present?, who_pays]
         in_ppr = false
       end
     end


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2043

Detailed report of the times and contexts for datasets to be in PPR status.

Instead of one row per dataset, this report creates one row per PPR status, so we can focus on each time datasets enter and exit PPR.

To run: `rails identifiers:ppr_detail_report`