### PR TITLE
Copy CEDAR config to stage environment

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -243,6 +243,14 @@ stage:
     bucket: dryad-s3-stg
     key: AKIAIQ5XWADKJZ556SBQ
     secret: <%= Rails.application.credentials[Rails.env.to_sym][:s3_secret] %>
+  cedar:
+    editor_url: "/cedar-embeddable-editor/cedar-embeddable-editor-2.6.18-SNAPSHOT.js"
+    template_base_url: "/cedar-embeddable-editor"
+    templates:
+      - [1, "Files", "Ted's File Description"]
+      - [40, "YOUTUBE",  "Youtube"]
+      - [43, "NCBI-MIAIRR", "MiAIRR V1.1.0"]
+      - [45, "NCBI-HUMAN", "CEDAR-NCBI Human Tissue"]
 
 migration:
   <<: *DEFAULTS


### PR DESCRIPTION
Allow the CEDAR editor to display in the stage environment, so the CEDAR team can see it and perform tests.