### PR TITLE
Revise frictionless callback to make 404 errors when file is missing

### DIFF
--- a/app/controllers/stash_api/frictionless_reports_controller.rb
+++ b/app/controllers/stash_api/frictionless_reports_controller.rb
@@ -39,8 +39,8 @@ module StashApi
 
     def require_file
       @stash_file = StashEngine::GenericFile.where(id: params[:file_id]).first
-      render json: { error: 'not-found' }.to_json, status: 404 if @stash_file.nil?
-      @resource = @stash_file.resource # for require_permission to use
+      @resource = @stash_file&.resource # for require_permission to use
+      render json: { error: 'not-found' }.to_json, status: 404 if @stash_file.nil? || @resource.nil?
     end
 
     def require_viewable_report

--- a/spec/requests/stash_api/frictionless_reports_controller_spec.rb
+++ b/spec/requests/stash_api/frictionless_reports_controller_spec.rb
@@ -121,6 +121,17 @@ module StashApi
         hsh = response_body_hash
         expect(hsh['error']).to eq('incorrect status set')
       end
+
+      it 'returns a 404 if the file or resource has been removed since report started processing' do
+        @generic_file.destroy!
+        @generic_file2.destroy!
+        response_code = put @path,
+                            params: { status: 'noissues', report: @frict_report2.report }.to_json, # same as report2 json
+                            headers: default_authenticated_headers
+        expect(response_code).to eq(404)
+        hsh = response_body_hash
+        expect(hsh['error']).to eq('not-found')
+      end
     end
   end
 end


### PR DESCRIPTION
I thought this was in place before but maybe it didn't work since the render of the 404 wasn't the last thing in the method?  I'm not sure why it didn't catch these.

- Moved render to the end of the method
- Added a test for a situation where the file or resource is now missing when the results of validation triggers the callback

This should get rid of the errors like below that we see in our email.  I believe people upload files that validate by Frictionless.  They get impatient and decide to delete them instead of waiting for validation to finish.  So when the callback from the Lambda fires with results the file is gone and can't update results.

```
A NoMethodError occurred in frictionless_reports#update:

  undefined method `resource' for nil:NilClass
Did you mean?  rescue
  app/controllers/stash_api/frictionless_reports_controller.rb:43:in `require_file'
```

