### PR TITLE
Small style change to fix scrolling in modals

### DIFF
--- a/app/assets/stylesheets/stash_engine/ui.css
+++ b/app/assets/stylesheets/stash_engine/ui.css
@@ -4512,6 +4512,10 @@ datalist {
   background-color: white;
 }
 
+.c-uploadmodal__header * {
+  word-break: break-all;
+}
+
 /* Proposed Change Object */
 .c-proposed-change-table__row-separator {
   max-height: 10px;

--- a/ui-library/scss/_modal.scss
+++ b/ui-library/scss/_modal.scss
@@ -31,3 +31,7 @@
 .modalDialog .c-uploadmodal__button-close-modal {
   background-color: white;
 }
+
+.c-uploadmodal__header * {
+  word-break: break-all;
+}


### PR DESCRIPTION
Force break for modal header so no side scroll is added. Particularly for the tabular data check when the modal header might include a long file name (pictured).

<img width="1156" alt="Screenshot 2022-11-21 at 16 44 28" src="https://user-images.githubusercontent.com/1749394/203097360-397de481-efaa-4480-953a-83eaeab5292e.png">
