### PR TITLE
make them uncompressed for zip version downloads

### DIFF
--- a/documentation/presign-version/presign-test.rb
+++ b/documentation/presign-version/presign-test.rb
@@ -30,7 +30,7 @@ http = HTTP.timeout(connect: 30, read: 30).timeout(1.hour.to_i).follow(max_hops:
 assemble_version_url = URI::HTTPS.build(
     host: mrt_domain,
     path: File.join('/api', 'assemble-version', url_encode(url_encode(ark)), version.to_s),
-    query: {format: 'zip', content: 'producer'}.to_query)
+    query: {format: 'zipunc', content: 'producer'}.to_query)
 
 puts "The ASSEMBLE call"
 puts "--- GET: #{assemble_version_url} ---"

--- a/lib/stash/download/version_presigned.rb
+++ b/lib/stash/download/version_presigned.rb
@@ -112,7 +112,7 @@ module Stash
 
       def assemble_version_url
         path = ::File.join('/api', 'assemble-version', ERB::Util.url_encode(@local_id), @version.to_s).to_s
-        query = { format: 'zip', content: 'producer' }.to_query
+        query = { format: 'zipunc', content: 'producer' }.to_query
         "#{@domain}#{path}?#{query}"
       end
 

--- a/spec/lib/stash/download/version_presigned_spec.rb
+++ b/spec/lib/stash/download/version_presigned_spec.rb
@@ -18,13 +18,13 @@ module Stash
       describe 'urls for Merritt service' do
         it 'creates correct assemble_version_url' do
           u = @vp.assemble_version_url
-          expect(u).to end_with("/api/assemble-version/#{ERB::Util.url_encode(@local_id)}/1?content=producer&format=zip")
+          expect(u).to end_with("/api/assemble-version/#{ERB::Util.url_encode(@local_id)}/1?content=producer&format=zipunc")
         end
 
         it 'handles ports for assemble_version_url' do
           @vp.instance_variable_set(:@domain, 'https://truculent.com:2838')
           u = @vp.assemble_version_url
-          expect(u).to eq("https://truculent.com:2838/api/assemble-version/#{ERB::Util.url_encode(@local_id)}/1?content=producer&format=zip")
+          expect(u).to eq("https://truculent.com:2838/api/assemble-version/#{ERB::Util.url_encode(@local_id)}/1?content=producer&format=zipunc")
         end
 
         it 'creates correct status_url' do
@@ -77,21 +77,21 @@ module Stash
 
       describe '#assemble' do
         it 'returns non-success status in hash for items not in the 200 http status range' do
-          stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zip})
+          stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zipunc})
             .to_return(status: 404, body: 'Not found', headers: {})
 
           expect(@vp.assemble[:status]).to eq(404)
         end
 
         it 'raises errors when Merritt has a problem so we know about it' do
-          stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zip})
+          stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zipunc})
             .to_return(status: 500, body: 'Internal server error', headers: {})
 
           expect { @vp.assemble }.to raise_exception(Stash::Download::MerrittException).with_message(/Merritt/)
         end
 
         it 'returns a 408 status code if Merritt gives us one' do
-          stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zip})
+          stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zipunc})
             .to_return(status: 408, body: 'Not found', headers: {})
 
           expect(@vp.assemble[:status]).to eq(408)
@@ -99,7 +99,7 @@ module Stash
 
         it 'saves token and predicted availability time to database on good response' do
           token = SecureRandom.uuid
-          stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zip})
+          stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zipunc})
             .to_return(status: 200, body:
                   { status: 200, token: token,
                     'anticipated-availability-time': (Time.new + 30).to_s }.to_json,
@@ -118,7 +118,7 @@ module Stash
         it 'parses and returns json status' do
           # do assembly first so we have status to check
           token = SecureRandom.uuid
-          stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zip})
+          stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zipunc})
             .to_return(status: 200, body:
                   { status: 200, token: token,
                     'anticipated-availability-time': (Time.new + 30).to_s }.to_json,
@@ -142,7 +142,7 @@ module Stash
         it 'handles non-json status and a 404' do
           # do assembly first so we have status to check
           token = SecureRandom.uuid
-          stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zip})
+          stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zipunc})
             .to_return(status: 200, body:
                   { status: 200, token: token,
                     'anticipated-availability-time': (Time.new + 30).to_s }.to_json,

--- a/spec/requests/stash_engine/download_helpers.rb
+++ b/spec/requests/stash_engine/download_helpers.rb
@@ -53,12 +53,12 @@ module DownloadHelpers
   end
 
   def stub_404_assemble
-    stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zip})
+    stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zipunc})
       .to_return(status: 404, body: 'Internal server error', headers: {})
   end
 
   def stub_408_assemble
-    stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zip})
+    stub_request(:get, %r{/api/assemble-version/.+/1\?content=producer&format=zipunc})
       .to_return(status: 408, body:
             {  status: 408,
                message: 'Timed out' }.to_json,


### PR DESCRIPTION
This should save Merritt some CPU and other resources in creating zips.

Tested on my machine and worked fine as far as I can see.