### PR TITLE
NIH updater

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -19,5 +19,6 @@ ActiveSupport::Inflector.inflections do |inflect|
 end
 
 ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "NIH"
   inflect.acronym "XML"
 end

--- a/lib/stash/nih.rb
+++ b/lib/stash/nih.rb
@@ -1,0 +1,75 @@
+require 'http'
+
+# Library for working with the API for the National Institutes of Health
+
+module Stash
+  class NIH
+
+    NIH_BASE = 'https://api.reporter.nih.gov/v1/projects/Search'.freeze
+    NIH_ID = 'http://dx.doi.org/10.13039/100000002'.freeze
+
+    # Mapping from nonstandard names/spellings that appear in actual NIH grants to the standardized spelling
+    # rubocop:disable Layout/LineLength
+    IC_MAPPING =
+      {
+        'National Heart Lung and Blood Institute' => 'National Heart, Lung, and Blood Institute',
+        'National Institute of Arthritits and Musculoskeletal and Skin Diseases' => 'National Institute of Arthritis and Musculoskeletal and Skin Diseases',
+        'National Library of Medicine' => 'U.S. National Library of Medicine',
+        'John E. Fogarty International Center for Advanced Study in the Health Sciences' => 'Fogarty International Center',
+        'National Center for Complementary and Intergrative Health' => 'National Center for Complementary and Integrative Health'
+      }.freeze
+    # rubocop:enable Layout/LineLength
+
+    def self.find_grant(award_id)
+      return if award_id.blank? || award_id.size < 5
+
+      response = HTTP.post(NIH_BASE, json: nih_award_id_criteria(award_id))
+      resp = JSON.parse(response)
+      grants = resp['results']
+      return if grants.blank?
+
+      grants[0]
+    end
+
+    # Update a StashDatacite::Contributor using the named NIH Institute or Center
+    def self.set_contributor_to_ic(contributor:, ic_name:)
+      group_record = StashDatacite::ContributorGrouping.where(name_identifier_id: NIH_ID).first
+      return if group_record.blank?
+
+      ics = group_record.json_contains
+      ics.each do |ic|
+        next unless ic['contributor_name'] == clean_ic_name(ic_name)
+
+        contributor.update(contributor_name: ic['contributor_name'],
+                           identifier_type: ic['identifier_type'],
+                           name_identifier_id: ic['name_identifier_id'])
+        break
+      end
+    end
+
+    def self.clean_ic_name(ic_name)
+      IC_MAPPING[ic_name] || ic_name
+    end
+
+    # Criteria object that is passed as a query to the NIH API, initilaized with a single award_id
+    def self.nih_award_id_criteria(award_id)
+      {
+        criteria:
+         {
+           project_nums: [award_id]
+         },
+        include_fields: %w[
+          ProjectTitle AbstractText FiscalYear
+          Organization OrgCountry OrgState OrgName
+          ProjectNum ProjectNumSplit
+          ContactPiName PrincipalInvestigators ProgramOfficers
+          ProjectStartDate ProjectEndDate
+          AwardAmount AgencyIcFundings PrefTerms
+        ],
+        offset: 0,
+        limit: 25
+      }
+    end
+
+  end
+end

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -266,6 +266,8 @@ namespace :identifiers do
   task nih_funders_clean: :environment do
     # For each funder entry that is NIH
     StashEngine::Identifier.all.each do |i|
+      next if i.latest_resource.nil?
+
       i.latest_resource.contributors.each do |contrib|
         next unless contrib.contributor_name == 'National Institutes of Health'
 

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -267,16 +267,15 @@ namespace :identifiers do
     # For each funder entry that is NIH
     StashEngine::Identifier.all.each do |i|
       i.latest_resource.contributors.each do |contrib|
-        puts "XXX #{contrib.contributor_name}"
         next unless contrib.contributor_name == 'National Institutes of Health'
 
-        puts "  lookup #{contrib.award_number}"
+        puts "NIH lookup #{contrib.award_number}"
         # - look up the actual grant with the NIH API
         g = Stash::NIH.find_grant(contrib.award_number)
-        puts "   found #{g['project_num']}"
+        puts "NIH  found #{g['project_num']}"
         # - see which Institute or Center is the first funder
         ic = g['agency_ic_fundings'][0]['name']
-        puts "  funder #{ic}"
+        puts "NIH funder #{ic}"
         # - replace with the equivalent IC in Dryad
         Stash::NIH.set_contributor_to_ic(contributor: contrib, ic_name: ic)
       end

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -1,4 +1,5 @@
 require 'httparty'
+require 'stash/nih'
 require 'stash/salesforce'
 require 'stash/google/journal_g_mail'
 require_relative 'identifier_rake_functions'
@@ -258,6 +259,27 @@ namespace :identifiers do
     rescue StandardError => e
       p "    Exception! #{e.message}"
 
+    end
+  end
+
+  desc 'Update NIH funder entry'
+  task nih_funders_clean: :environment do
+    # For each funder entry that is NIH
+    StashEngine::Identifier.all.each do |i|
+      i.latest_resource.contributors.each do |contrib|
+        puts "XXX #{contrib.contributor_name}"
+        next unless contrib.contributor_name == 'National Institutes of Health'
+
+        puts "  lookup #{contrib.award_number}"
+        # - look up the actual grant with the NIH API
+        g = Stash::NIH.find_grant(contrib.award_number)
+        puts "   found #{g['project_num']}"
+        # - see which Institute or Center is the first funder
+        ic = g['agency_ic_fundings'][0]['name']
+        puts "  funder #{ic}"
+        # - replace with the equivalent IC in Dryad
+        Stash::NIH.set_contributor_to_ic(contributor: contrib, ic_name: ic)
+      end
     end
   end
 


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2007

Updates funder information by looking up grant records at NIH, parsing out the Institute or Center that led the funding, and updating the contributor record.

To test:
1. Go to the NIH Reporter tool and find a grant. https://reporter.nih.gov/
2. Create a dataset in Dryad with the funder name "National Institutes of Health" and the award number (project number) for your grant.
3. Run the tool: `rails identifiers:nih_funders_clean`
4. View the dataset and verify that the funder has been updated to the entity listed as the first "Funding IC" on the grant page.

Note that this code does not currently update records at Datacite. I'm wondering whether to include that process here, or run a broader update of Datacite.