### PR TITLE
Fix long reports that overflow database field, now LONGTEXT

### DIFF
--- a/db/migrate/20221201224121_change_frictionless_report_report_to_long_text.rb
+++ b/db/migrate/20221201224121_change_frictionless_report_report_to_long_text.rb
@@ -1,0 +1,5 @@
+class ChangeFrictionlessReportReportToLongText < ActiveRecord::Migration[6.1]
+  def change
+    change_column :stash_engine_frictionless_reports, :report, :text, :limit => 4294967295
+  end
+end

--- a/documentation/dryad_install.md
+++ b/documentation/dryad_install.md
@@ -169,8 +169,13 @@ rails s
 Some portions of Dryad's interface rely on Node and React. See the [Node Installation](node_npm_server_install.md) instructions.
 
 Dryad's submission system validates files with the Frictionless Data
-toolkit. See the [Frictionless
-Installation](frictionless_integration/INSTALL.md) instructions.
+toolkit. The [Frictionless
+Installation](frictionless_integration/INSTALL.md) instructions are deprecated since it uses an
+AWS Lambda for validating files.  The [implementation overview](frictionless_integration/implementation_overview.md) 
+gives a few details.  In order to get your local server to work with the callbacks, you'll need to have them
+publicly accessible and create an environment with the correct domain name or use an environment that uses
+our dev database.  To mock the functionality, you could manually
+insert a validation report into the stash_engine_frictionless_reports table to examine UI elements.
 
 ## Final search configuration
 

--- a/documentation/frictionless_integration/INSTALL.md
+++ b/documentation/frictionless_integration/INSTALL.md
@@ -1,5 +1,7 @@
 # Frictionless Integration Install
 
+# NOTE: this document is deprecated, but it may be useful to install a local copy of the frictionless python libraries for other kinds of testing
+
 Some of these install instructions are specific to our installation.
 [We've also documented an overview of how we integrated Frictionless](./implementation_overview.md).
 

--- a/documentation/server_maintenance/troubleshooting.md
+++ b/documentation/server_maintenance/troubleshooting.md
@@ -429,6 +429,26 @@ you can still change the payment_type to the desired value, but let
 the curation team know that the associated Stripe invoice needs to be
 voided.
 
+Tabular data file isn't validating in Frictionless
+==================================================
+There could be a number of reasons for this, but there are a number of things to check to find where an error
+might be happening.
+
+- Check that the file has been uploaded correctly to S3 (check web browser console to see it completes and
+  for any errors).
+- The code should be polling an endpoint waiting for the report to appear in our database on the file upload
+  page (you should also see this polling in the web browser javascript console)
+- Log into the AWS Console and examine the AWS Lambda function.  You can browse logs stored on amazon to see
+  if there are any errors for recent runs of the Lambda function that validates.
+- When the validation completes it will call a URL in our API to deposit the results of the validation
+  which happens asynchronously in the background (this explains the polling a couple points above).
+- Look at rails web server logs while you try to do the frictionless validation to see if any errors appear
+  in the logs from the API method that updates the frictionless report.
+
+For using in a development environment you will either need to use an environment that connects to our
+standard development database (like `local_dev`) or create your own environment with configuration of
+a domain name in the rails environment so that the callback can reach your instance's API to deposit results.
+
 Issues with testing
 =====================
 
@@ -438,3 +458,4 @@ Many failures with `latest_resource` and `current_status`
 This can be caused by the database triggers being dropped. To reinstantiate the
 complete database setup:
 `bin/rails db:migrate:reset RAILS_ENV=test`
+


### PR DESCRIPTION
https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2088

The field size needed to be expanded to LONGTEXT on stage and production since a dataset has so many long errors.  For the time being I've changed these to longtext directly on stage/production.

Also some documentation changes.