### PR TITLE
Should fix #2085 peer review not being notified

### DIFF
--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -213,7 +213,7 @@ namespace :identifiers do
   task peer_review_reminder: :environment do
     p 'Mailing users whose datasets have been in peer_review for a while...'
     StashEngine::Resource.where(hold_for_peer_review: true)
-      .where('stash_engine_resources.peer_review_end_date <= ?', Date.today)
+      .where('stash_engine_resources.peer_review_end_date <= ? OR stash_engine_resources.peer_review_end_date IS NULL', Date.today)
       .each do |r|
 
       reminder_flag = 'peer_review_reminder CRON'


### PR DESCRIPTION
The main ones in that ticket from Jess were created in 2021 and the resource didn't have a `peer_review_end_date` filled in.

This allows notification if the `peer_review_end_date` has passed or if the `peer_review_end_date` is NULL in the database.  It still leaves the stuff about finding the CRON info in the history for finding if the last reminder is blank or if the last reminder was created more than a month ago.

So any items with blank peer_review_end_dates will be notified every month.  Does this seem like correct behavior, @ryscher ?  It seems like Jess would've like these notified, even if they have no end date.

