### PR TITLE
Allow superusers to apply waivers

### DIFF
--- a/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -206,30 +206,27 @@ module StashEngine
         format.js do
           if @identifier.payment_type == 'stripe'
             # if it's already invoiced, show a warning
-            @error_message = '<p>Unable to apply a waiver to a dataset that was already invoiced.</p>'
-            render :curation_activity_error
+            @error_message = 'Unable to apply a waiver to a dataset that was already invoiced.'
+            render :curation_activity_error and return
           elsif params[:waiver_basis] == 'none'
-            @error_message = '<p>No waiver message selected, so waiver was not applied.'
-            redner :curation_activity_error
+            @error_message = 'No waiver message selected, so waiver was not applied.'
+            render :curation_activity_error and return
+          elsif params[:waiver_basis] == 'other'
+            basis = 'unspecified'
+            if params[:other].present?
+              basis = params[:other]
+            else
+              @error_message = 'No waiver message selected, so waiver was not applied.'
+              render :curation_activity_error and return
+            end
           else
-            # Update the waiver settings
-
-            basis = if params[:waiver_basis] == 'other'
-                      if params[:other].present?
-                        params[:other]
-                      else
-                        'unspecified'
-                      end
-                    else
-                      params[:waiver_basis]
-                    end
-
-            @identifier.update(payment_type: 'waiver',
-                               payment_id: '',
-                               waiver_basis: basis)
-
-            render
+            params[:waiver_basis]
           end
+
+          @identifier.update(payment_type: 'waiver',
+                             payment_id: '',
+                             waiver_basis: basis)
+          render
         end
       end
     end

--- a/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -220,12 +220,13 @@ module StashEngine
               render :curation_activity_error and return
             end
           else
-            params[:waiver_basis]
+            basis = params[:waiver_basis]
           end
 
           @identifier.update(payment_type: 'waiver',
                              payment_id: '',
                              waiver_basis: basis)
+
           render
         end
       end

--- a/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -199,24 +199,19 @@ module StashEngine
     # rubocop:enable Metrics/AbcSize
 
     def waiver_add
-      puts 'XXXXXX add waiver '
-      puts "XXXXXXp #{params} "
-
       @identifier = Identifier.find(params[:id])
       @resource = @identifier.latest_resource
-
-      puts "XXXX id #{@identifier.id}"
-      puts "XXXX user #{current_user.id}"
 
       respond_to do |format|
         format.js do
           if @identifier.payment_type == 'stripe'
-            puts 'XXXXX a'
             # if it's already invoiced, show a warning
             @error_message = '<p>Unable to apply a waiver to a dataset that was already invoiced.</p>'
             render :curation_activity_error
+          elsif params[:waiver_basis] == 'none'
+            @error_message = '<p>No waiver message selected, so waiver was not applied.'
+            redner :curation_activity_error
           else
-            puts 'XXXXX b'
             # Update the waiver settings
 
             basis = if params[:waiver_basis] == 'other'
@@ -233,7 +228,6 @@ module StashEngine
                                payment_id: '',
                                waiver_basis: basis)
 
-            puts "XXXXX c #{basis}"
             render
           end
         end

--- a/app/views/stash_engine/admin_datasets/_payment_info_table.html.erb
+++ b/app/views/stash_engine/admin_datasets/_payment_info_table.html.erb
@@ -1,0 +1,24 @@
+<table class="c-lined-table" id="payment_info_table">
+  <tr class="c-lined-table__head">
+    <th class="c-admin-table">
+      Payment type
+    </th>
+    <th class="c-admin-table">
+      Payment id
+    </th>
+    <th class="c-admin-table">
+      Waiver basis
+    </th>
+  </tr>
+  <tr class="c-lined-table__row">
+    <td>
+      <% if @identifier.user_must_pay? && (@identifier.payment_type.blank? || @identifier.payment_type == 'unknown') %>
+        User
+      <% else %>
+        <%= @identifier.payment_type %>
+      <% end %>
+    </td>
+    <td><%= @identifier.payment_id %></td>
+    <td><%= @identifier.waiver_basis %></td>
+  </tr>
+</table>

--- a/app/views/stash_engine/admin_datasets/_waiver_popup.html.erb
+++ b/app/views/stash_engine/admin_datasets/_waiver_popup.html.erb
@@ -7,7 +7,7 @@
 </script>
 
 <div class="o-admin-dialog">
-  <% if @identifier.payment_type == 'stripe' && @identifier.payment_id.starts_with?("IN") %>
+  <% if @identifier.payment_type == 'stripe' && @identifier.payment_id.starts_with?("in_") %>
     <h1>Warning!</h1>
     <p>
       This dataset has been approved for publication, and the submitter has already

--- a/app/views/stash_engine/admin_datasets/_waiver_popup.html.erb
+++ b/app/views/stash_engine/admin_datasets/_waiver_popup.html.erb
@@ -7,27 +7,33 @@
 </script>
 
 <div class="o-admin-dialog">
-  <h1>Add fee waiver</h1>
-  <%= form_with(model: @identifier, url: waiver_add_path, method: :post, local: false ) do |f| -%>
-  <div class="c-input">
-    <div id="select_div" class="c-input">
-      <label class="c-input__label" for="waiver_basis">Please provide a reason for applying a waiver</label>
-      <select name="waiver_basis" onchange="showOther('other_div', this)">
-	<option value="none">- Select a reason -</option>
-	<option value="country_not_detected">Waiver country, but not detected automatically</option>
-	<option value="early_career_researcher">Early-career researcher</option>
-	<option value="other">Other</option>
-      </select>
-    </div>
-      
-    <div id="other_div" class="c-input" style="display: none;">
-      <label class="c-input__label" for="other">Other reason</label>
-      <input class="c-input__text" size="80" type="text" name="other" />
-    </div>
-  </div>
-  <%= f.submit 'Submit' %>
-  <%= f.button 'Cancel', type: 'button', id: 'cancel_dialog' %>
-
+  <% if @identifier.payment_type == 'stripe' && @identifier.payment_id.starts_with?("IN") %>
+    <h1>Warning!</h1>
+    <p>
+      This dataset has been approved for publication, and the submitter has already
+      received an invoice. Please ensure invoice <%= @identifier.payment_id %> is voided.
+    </p>
+  <% else %>
+    <h1>Add fee waiver</h1>
+    <%= form_with(model: @identifier, url: waiver_add_path, method: :post, local: false ) do |f| -%>
+      <div class="c-input">
+	<div id="select_div" class="c-input">
+	  <label class="c-input__label" for="waiver_basis">Please provide a reason for applying a waiver</label>
+	  <select name="waiver_basis" onchange="showOther('other_div', this)">
+	    <option value="none">- Select a reason -</option>
+	    <option value="country_not_detected">Waiver country, but not detected automatically</option>
+	    <option value="early_career_researcher">Early-career researcher</option>
+	    <option value="other">Other</option>
+	  </select>
+	</div>	
+	<div id="other_div" class="c-input" style="display: none;">
+	  <label class="c-input__label" for="other">Other reason</label>
+	  <input class="c-input__text" size="80" type="text" name="other" />
+	</div>
+      </div>
+      <%= f.submit 'Submit' %>
+      <%= f.button 'Cancel', type: 'button', id: 'cancel_dialog' %>
+    <% end %>
   <% end %>
 </div>
 

--- a/app/views/stash_engine/admin_datasets/_waiver_popup.html.erb
+++ b/app/views/stash_engine/admin_datasets/_waiver_popup.html.erb
@@ -22,7 +22,11 @@
 	  <select name="waiver_basis" onchange="showOther('other_div', this)">
 	    <option value="none">- Select a reason -</option>
 	    <option value="country_not_detected">Waiver country, but not detected automatically</option>
-	    <option value="early_career_researcher">Early-career researcher</option>
+	    <option value="unaware_of_dpc">Author unaware of DPC</option>
+	    <option value="no_funds">Author/Institution no funds</option>
+	    <option value="sponsoring_entity_updated">Sponsoring entity updated</option>
+	    <option value="political_economic_situation">Political/Economic situation</option>
+	    <option value="fee_increase">Fee increase</option>
 	    <option value="other">Other</option>
 	  </select>
 	</div>	

--- a/app/views/stash_engine/admin_datasets/_waiver_popup.html.erb
+++ b/app/views/stash_engine/admin_datasets/_waiver_popup.html.erb
@@ -1,20 +1,33 @@
 <% # local: identifier %>
+
+<script>
+  function showOther(divId, element) {
+    document.getElementById(divId).style.display = element.value == 'other' ? 'block' : 'none';
+  }
+</script>
+
 <div class="o-admin-dialog">
   <h1>Add fee waiver</h1>
   <%= form_with(model: @identifier, url: waiver_add_path, method: :post, local: false ) do |f| -%>
   <div class="c-input">
-    <label class="c-input__label" for="waiver_basis">Please provide a reason for applying a waiver</label>
-    <select name="waiver_basis">
-      <option value="country_not_detected">Waiver country, but not detected automatically</option>
-      <option value="early_career_researcher">Early-career researcher</option>
-      <option value="other">Other</option>
-    </select><br/>
-
-    <label class="c-input__label" for="other">Other reason</label>
-    <input type="text" name="other" />
+    <div id="select_div" class="c-input">
+      <label class="c-input__label" for="waiver_basis">Please provide a reason for applying a waiver</label>
+      <select name="waiver_basis" onchange="showOther('other_div', this)">
+	<option value="none">- Select a reason -</option>
+	<option value="country_not_detected">Waiver country, but not detected automatically</option>
+	<option value="early_career_researcher">Early-career researcher</option>
+	<option value="other">Other</option>
+      </select>
+    </div>
+      
+    <div id="other_div" class="c-input" style="display: none;">
+      <label class="c-input__label" for="other">Other reason</label>
+      <input class="c-input__text" size="80" type="text" name="other" />
+    </div>
   </div>
   <%= f.submit 'Submit' %>
   <%= f.button 'Cancel', type: 'button', id: 'cancel_dialog' %>
 
   <% end %>
 </div>
+

--- a/app/views/stash_engine/admin_datasets/_waiver_popup.html.erb
+++ b/app/views/stash_engine/admin_datasets/_waiver_popup.html.erb
@@ -1,0 +1,20 @@
+<% # local: identifier %>
+<div class="o-admin-dialog">
+  <h1>Add fee waiver</h1>
+  <%= form_with(model: @identifier, url: waiver_add_path, method: :post, local: false ) do |f| -%>
+  <div class="c-input">
+    <label class="c-input__label" for="waiver_basis">Please provide a reason for applying a waiver</label>
+    <select name="waiver_basis">
+      <option value="country_not_detected">Waiver country, but not detected automatically</option>
+      <option value="early_career_researcher">Early-career researcher</option>
+      <option value="other">Other</option>
+    </select><br/>
+
+    <label class="c-input__label" for="other">Other reason</label>
+    <input type="text" name="other" />
+  </div>
+  <%= f.submit 'Submit' %>
+  <%= f.button 'Cancel', type: 'button', id: 'cancel_dialog' %>
+
+  <% end %>
+</div>

--- a/app/views/stash_engine/admin_datasets/activity_log.html.erb
+++ b/app/views/stash_engine/admin_datasets/activity_log.html.erb
@@ -105,6 +105,13 @@
   </div>
 </div>
 
+<% if current_user.superuser? %>
+<div id="payment_info" style="clear: both">
+  <div style="float: left"><h2>Payment information</h2></div>
+  <%= render partial: 'payment_info_table' %>
+</div>
+<% end %>
+
 <% if current_user.curator? %>
     <div id="dangerous_actions">
 	<div style="float: left"><h2>Dangerous actions</h2>
@@ -119,6 +126,19 @@
 		<p>Forcibly editing a dataset will assign it to you, and begin an editing session.
 		Please only do this if you know the author is unable/unwilling to submit it.</p>
 	    </div>
+
+	    <% if current_user.superuser? && @identifier.payment_type != 'waiver' %>
+	      <div style="float: left" id="apply_fee_waiver">
+	        <%= form_with(url: stash_url_helpers.url_for(controller: '/stash_engine/admin_datasets', action: 'waiver_popup', id: @identifier.id,
+		    sub_method: 'post', only_path: true),
+                    method: :get, local: false) do -%>
+	        <button class="o-button__submit">Apply fee waiver</button>
+		<p>&nbsp;</p>
+		<% end %>
+  	      </div>
+	    <% end %>
+	    
 	</div>
     </div>
 <% end %>
+

--- a/app/views/stash_engine/admin_datasets/curation_activity_error.js.erb
+++ b/app/views/stash_engine/admin_datasets/curation_activity_error.js.erb
@@ -1,6 +1,6 @@
 // replace dialog div with contents of dialog text from partial
 <% title = @resource.title.html_safe %>
 
-$('#genericModalContent').html("<%= escape_javascript("<h1>#{title}</h1>#{@error_message}") %>");
+$('#genericModalContent').html("<h1><%= title %></h1><%= @error_message %>");
 $('#genericModalDialog')[0].showModal();
 

--- a/app/views/stash_engine/admin_datasets/curation_activity_error.js.erb
+++ b/app/views/stash_engine/admin_datasets/curation_activity_error.js.erb
@@ -1,6 +1,6 @@
 // replace dialog div with contents of dialog text from partial
-<% title = @resource.title.html_safe %>
+<% title = @resource.title&.html_safe %>
 
-$('#genericModalContent').html("<h1><%= title %></h1><%= @error_message %>");
+$('#genericModalContent').html("<h1><%= escape_javascript(title) %></h1><%= escape_javascript(@error_message) %>");
 $('#genericModalDialog')[0].showModal();
 

--- a/app/views/stash_engine/admin_datasets/waiver_add.js.erb
+++ b/app/views/stash_engine/admin_datasets/waiver_add.js.erb
@@ -1,0 +1,5 @@
+<% # redrawing full row rather than trying to fix each item. %>
+
+$("#payment_info_table").replaceWith("<%= escape_javascript(render partial: 'payment_info_table', locals: { identifier: @identifier }) %>")
+$("#apply_fee_waiver").replaceWith("<br/>")
+$('#genericModalDialog')[0].close()

--- a/app/views/stash_engine/admin_datasets/waiver_popup.js.erb
+++ b/app/views/stash_engine/admin_datasets/waiver_popup.js.erb
@@ -1,0 +1,15 @@
+// replace dialog div with contents of dialog text from partial
+
+$('#genericModalContent').html("<%= escape_javascript(
+          render partial: 'stash_engine/admin_datasets/waiver_popup', locals: { identifier: @identifier }) %>");
+
+// now open a jquery ui modal dialog
+$(function() {
+    $('#genericModalDialog')[0].showModal();
+
+    // make the cancel button in the dialog hide the dialog
+    $("#cancel_dialog").click(function (e) {
+        e.preventDefault();
+        $('#genericModalDialog')[0].close();
+    });
+});

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -292,6 +292,7 @@ Rails.application.routes.draw do
     get 'ds_admin/index/:id', to: 'admin_datasets#index'
     get 'ds_admin/data_popup/:id', to: 'admin_datasets#data_popup'
     get 'ds_admin/note_popup/:id', to: 'admin_datasets#note_popup'
+    get 'ds_admin/waiver_popup/:id', to: 'admin_datasets#waiver_popup'
     get 'ds_admin/create_salesforce_case/:id', to: 'admin_datasets#create_salesforce_case', as: 'create_salesforce_case'
     get 'ds_admin/curation_activity_popup/:id', to: 'admin_datasets#curation_activity_popup'
     get 'ds_admin/current_editor_popup/:id', to: 'admin_datasets#current_editor_popup'
@@ -300,6 +301,7 @@ Rails.application.routes.draw do
     post 'curation_note/:id', to: 'curation_activity#curation_note', as: 'curation_note'
     post 'curation_activity_change/:id', to: 'admin_datasets#curation_activity_change', as: 'curation_activity_change'
     post 'current_editor_change/:id', to: 'admin_datasets#current_editor_change', as: 'current_editor_change'
+    post 'waiver_add/:id', to: 'admin_datasets#waiver_add', as: 'waiver_add'
 
     # admin report for dataset funders
     get 'ds_admin_funders', to: 'admin_dataset_funders#index', as: 'ds_admin_funders'


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2054

On the Activity log page, if viewing as a superuser:
- Displays the current payment information for this dataset
- Adds a button at the bottom that allows adding a waiver to the dataset, if a waiver is not currently present