### PR TITLE
Fixes geoblacklight by upgrading blacklight

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'amatch', '~> 0.4.0'
 gem 'amoeba', '~> 3.2.0'
 gem 'aws-sdk-lambda'
 gem 'aws-sdk-s3', '~> 1.113'
-gem 'blacklight', '~> 7.19.2' # do we really need this should be required by geoblacklight
+gem 'blacklight'
 gem 'bootsnap', require: false
 gem 'bootstrap', '~> 4.0'
 gem 'concurrent-ruby', '~> 1.1.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -807,7 +807,7 @@ DEPENDENCIES
   aws-sdk-lambda
   aws-sdk-s3 (~> 1.113)
   binding_of_caller
-  blacklight (~> 7.19.2)
+  blacklight
   bootsnap
   bootstrap (~> 4.0)
   byebug


### PR DESCRIPTION
Upgrading blacklight alone seems to have done the trick! Upgrading geoblacklight doesn't seem necessary at this time as it causes more problems, if we want to do it it would take a little more effort (https://geoblacklight.org/docs/upgrading/Upgrading_to_version_4_0/).

There's also a change not mentioned in this documentation, which is that search_builder.rb would need to change from.

```ruby
class SearchBuilder < Blacklight::SearchBuilder
  include Blacklight::Solr::SearchBuilderBehavior
  include Geoblacklight::SpatialSearchBehavior
```

to

```ruby
class SearchBuilder < Blacklight::SearchBuilder
  include Blacklight::Solr::SearchBuilderBehavior
  include Geoblacklight::SuppressedRecordsSearchBehavior
```