### PR TITLE
Make assets serve by Puma from the public directory

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass


### PR DESCRIPTION
For whatever reason, the previous config now doesn't work and setting `config.public_file_server.enabled = true` fixes the asset serving problem on the production server.

I tested this manually by changing it manually on the 01-prd server, restarting puma and testing directly against localhost:3000 on the server by using curl and wget to retrieve files.

Previous setting was getting 404s for the assets listed in the homepage.  New setting was getting 200s and retrieving the files.