### PR TITLE
fee increase functionality

### DIFF
--- a/app/views/stash_datacite/licenses/_review.html.erb
+++ b/app/views/stash_datacite/licenses/_review.html.erb
@@ -62,7 +62,7 @@
 		<p>
 			Dryad charges a fee for data publication that covers curation and preservation of published datasets. Upon
 			publication of your dataset, you will receive an invoice for
-			&dollar;<%=  APP_CONFIG.payments.data_processing_charge / 100 %>. If you have any questions,
+			&dollar;<%=  Stash::Payments::Invoicer.data_processing_charge(identifier: @resource.identifier) / 100 %>. If you have any questions,
 			please <a href="mailto:help@datadryad.org">contact us</a>.
 		</p>
 

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -42,6 +42,8 @@ defaults: &DEFAULTS
     service: stripe
     key: <%= Rails.application.credentials[Rails.env.to_sym][:stripe_key] %> 
     data_processing_charge: 12000 # charge in cents
+    data_processing_charge_new: 15000 # charge in cents
+    dpc_change_date: 2023-01-04
     large_file_size: 5.0e+10 # 50 GB
     additional_storage_chunk_size: 1.0e+10 # 10 GB
     additional_storage_chunk_cost: 5000 # in cents
@@ -214,6 +216,8 @@ development: &DEVELOPMENT
     # Very small limit for large files to facilitate testing (500KB)
     large_file_size: 5.0e+5
     data_processing_charge: 12000 # charge in cents
+    data_processing_charge_new: 15000 # charge in cents
+    dpc_change_date: 2022-12-13
     additional_storage_chunk_size: 1.0e+5 # (100KB)
     additional_storage_chunk_cost: 5000
   cedar:
@@ -307,6 +311,8 @@ production:
     key: <%= Rails.application.credentials[Rails.env.to_sym][:stripe_key] %>
     large_file_size: 5.0e+10
     data_processing_charge: 12000 # charge in cents
+    data_processing_charge_new: 15000 # charge in cents
+    dpc_change_date: 2023-01-04
     additional_storage_chunk_size: 1.0e+10 # (10GB)
     additional_storage_chunk_cost: 5000
   s3:

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -217,7 +217,7 @@ development: &DEVELOPMENT
     large_file_size: 5.0e+5
     data_processing_charge: 12000 # charge in cents
     data_processing_charge_new: 15000 # charge in cents
-    dpc_change_date: 2022-12-13
+    dpc_change_date: 2022-12-14
     additional_storage_chunk_size: 1.0e+5 # (100KB)
     additional_storage_chunk_cost: 5000
   cedar:

--- a/dryad-config-example/app_config.yml
+++ b/dryad-config-example/app_config.yml
@@ -36,7 +36,7 @@ defaults: &DEFAULTS
     key: replace-me
     data_processing_charge: 12000 # charge in cents
     data_processing_charge_new: 15000 # charge in cents	
-    dpc_change_date: nil
+    dpc_change_date: 2023-01-01
     large_file_size: 5.0e+10
     additional_storage_chunk_size: 1.0e+10 # 10 GB
     additional_storage_chunk_cost: 5000 # in cents

--- a/dryad-config-example/app_config.yml
+++ b/dryad-config-example/app_config.yml
@@ -35,6 +35,8 @@ defaults: &DEFAULTS
     service: stripe
     key: replace-me
     data_processing_charge: 12000 # charge in cents
+    data_processing_charge_new: 15000 # charge in cents	
+    dpc_change_date: nil
     large_file_size: 5.0e+10
     additional_storage_chunk_size: 1.0e+10 # 10 GB
     additional_storage_chunk_cost: 5000 # in cents

--- a/lib/stash/payments/invoicer.rb
+++ b/lib/stash/payments/invoicer.rb
@@ -96,7 +96,7 @@ module Stash
       def create_invoice_items_for_dpc(customer_id)
         items = [Stripe::InvoiceItem.create(
           customer: customer_id,
-          amount: data_processing_charge(identifier: resource.identifier),
+          amount: Invoicer.data_processing_charge(identifier: resource.identifier),
           currency: 'usd',
           description: "Data processing charge for #{resource.identifier} (#{filesize(ds_size)})"
         )]

--- a/lib/stash/payments/invoicer.rb
+++ b/lib/stash/payments/invoicer.rb
@@ -11,6 +11,16 @@ module Stash
 
       attr_reader :resource, :curator
 
+      def self.data_processing_charge(identifier:)
+        return APP_CONFIG.payments.data_processing_charge unless APP_CONFIG.payments&.dpc_change_date
+
+        if identifier.created_at >= APP_CONFIG.payments.dpc_change_date
+          APP_CONFIG.payments.data_processing_charge_new
+        else
+          APP_CONFIG.payments.data_processing_charge
+        end
+      end
+
       def initialize(resource:, curator:)
         @resource = resource
         @curator = curator
@@ -86,7 +96,7 @@ module Stash
       def create_invoice_items_for_dpc(customer_id)
         items = [Stripe::InvoiceItem.create(
           customer: customer_id,
-          amount: APP_CONFIG.payments.data_processing_charge,
+          amount: data_processing_charge(identifier: resource.identifier),
           currency: 'usd',
           description: "Data processing charge for #{resource.identifier} (#{filesize(ds_size)})"
         )]

--- a/spec/lib/yaml_helper_spec.rb
+++ b/spec/lib/yaml_helper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe YamlHelper do
 
     # outputs the YAML and re-parses it
     yaml_text = YamlHelper.output_test_section(example_filename: 'app_config.yml')
-    manipulated_yaml = YAML.safe_load(yaml_text)
+    manipulated_yaml = YAML.safe_load(yaml_text, [Date])
 
     # see if the two match, they should
     expect(direct_to_file['test']['old_dryad_access_token']).to eq(manipulated_yaml['test']['old_dryad_access_token'])


### PR DESCRIPTION
Allow fees to increase automatically on a set date. After a reasonable period of time (1 year?), we can move the "new" price to be the regular price.

The easiest way to test this is to set the cutoff date in the past, then create and publish a dataset. You should see the correct (old) price in both the submission system and the stripe invoice. Then change the cutoff date to the future and test again.