### PR TITLE
Automatic reporting on invoices that are voided in Stripe, but still exist in Dryad

### DIFF
--- a/app/mailers/stash_engine/user_mailer.rb
+++ b/app/mailers/stash_engine/user_mailer.rb
@@ -107,6 +107,15 @@ module StashEngine
            subject: "#{rails_env} Failed to update Zenodo for #{@zen.identifier} for event type #{@zen.copy_type}")
     end
 
+    def voided_invoices(voided_identifier_list)
+      return unless voided_identifier_list.present?
+
+      @submission_error_emails = APP_CONFIG['submission_error_email'] || [@helpdesk_email]
+      @identifiers = voided_identifier_list
+      mail(to: @submission_error_emails,
+           subject: "#{rails_env} Voided invoices need to be updated")
+    end
+
     private
 
     # rubocop:disable Style/NestedTernaryOperator

--- a/app/views/stash_engine/user_mailer/voided_invoices.html.erb
+++ b/app/views/stash_engine/user_mailer/voided_invoices.html.erb
@@ -1,0 +1,17 @@
+<% # @identifiers is a list if Identifier objects associated with voided invoices
+%>
+
+<p>There are invoices that have been voided in Stripe, but they are still active in Dryad.
+   Check on their status, and update the payment information appropriately.</p>
+
+<table border="1"> 
+  <tr><th>Identifier</th><th>DOI</th><th>Invoice</th></tr>
+  <% @identifiers.each do |i| %>
+  <tr>
+    <td style="padding: 5px;"><%= i.id %></td>
+    <td style="padding: 5px;"><%= i.identifier %></td>
+    <td style="padding: 5px;"><%= i.payment_id %></td>
+  </tr>
+  <% end %>
+</table>
+

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -235,6 +235,7 @@ aws_db:
 
 local:
   <<: *DEVELOPMENT
+  submission_error_email: [dryad.submission.error.emails@mailinator.com]
   send_journal_published_notices: false
 
 local_dev:

--- a/cron/weekly.sh
+++ b/cron/weekly.sh
@@ -10,6 +10,8 @@ cd /apps/dryad/apps/ui/current/
 
 bundle exec rails publication_updater:crossref >> /apps/dryad/apps/ui/shared/cron/logs/publication_updater_crossref.log 2>&1
 
+bundle exec rails identifiers:voided_invoices_report >>/apps/dryad/apps/ui/shared/cron/logs/voided_invoices_report.log 2>&1
+
 # putting this in background since I don't want to delay the counter processor starting
 bundle exec rails counter:populate_citations >> /apps/dryad/apps/ui/shared/cron/logs/citation_populator.log 2>&1 &!
 

--- a/lib/stash/payments/invoicer.rb
+++ b/lib/stash/payments/invoicer.rb
@@ -16,11 +16,9 @@ module Stash
       Stripe.api_key = APP_CONFIG.payments.key
       Stripe.api_version = '2022-11-15'
 
-      def self.find_recent
-        Stripe::Invoice.search({
-                                 query: 'total>999 AND metadata[\'order_id\']:\'6735\''
-
-                               })
+      def self.find_recent_voids
+        d = Date.today - 2.months
+        Stripe::Invoice.list({ created: { gt: d.to_time.to_i }, status: 'void' }).data
       end
 
       def self.data_processing_charge(identifier:)

--- a/lib/stash/payments/invoicer.rb
+++ b/lib/stash/payments/invoicer.rb
@@ -1,6 +1,7 @@
 # this require needed in tests, but not really in app, though it doesn't hurt anything
 require_relative '../../../app/helpers/stash_engine/application_helper'
 require 'stripe'
+
 module Stash
   module Payments
     class Invoicer
@@ -10,6 +11,17 @@ module Stash
       include StashEngine::ApplicationHelper
 
       attr_reader :resource, :curator
+
+      # Settings used by all Stripe services
+      Stripe.api_key = APP_CONFIG.payments.key
+      Stripe.api_version = '2022-11-15'
+
+      def self.find_recent
+        Stripe::Invoice.search({
+                                 query: 'total>999 AND metadata[\'order_id\']:\'6735\''
+
+                               })
+      end
 
       def self.data_processing_charge(identifier:)
         return APP_CONFIG.payments.data_processing_charge unless APP_CONFIG.payments&.dpc_change_date
@@ -29,12 +41,11 @@ module Stash
       # For an end-user, generate an invoice with a single charge
       # based on the DPC, and immediately finalize the invoice.
       def charge_user_via_invoice
-        set_api_key
         customer_id = stripe_user_customer_id
         return unless customer_id.present?
 
-        create_invoice_items_for_dpc(customer_id)
         invoice = create_invoice(customer_id)
+        create_invoice_items_for_dpc(customer_id, invoice.id)
         resource.identifier.payment_id = invoice.id
         resource.identifier.payment_type = stripe_user_waiver? ? 'waiver' : 'stripe'
         resource.identifier.save
@@ -42,7 +53,6 @@ module Stash
       end
 
       def external_service_online?
-        set_api_key
         latest = StashEngine::Identifier.where.not(payment_id: nil).order(updated_at: :desc).first
         return false unless latest.present?
 
@@ -88,14 +98,10 @@ module Stash
       # ------------------------------------------
       private
 
-      def set_api_key
-        Stripe.api_key = APP_CONFIG.payments.key
-      end
-
-      # this is mostly just long because of long text & formatting text
-      def create_invoice_items_for_dpc(customer_id)
+      def create_invoice_items_for_dpc(customer_id, invoice_id)
         items = [Stripe::InvoiceItem.create(
           customer: customer_id,
+          invoice: invoice_id,
           amount: Invoicer.data_processing_charge(identifier: resource.identifier),
           currency: 'usd',
           description: "Data processing charge for #{resource.identifier} (#{filesize(ds_size)})"
@@ -104,6 +110,7 @@ module Stash
         if over_chunks.positive?
           items.push(Stripe::InvoiceItem.create(
                        customer: customer_id,
+                       invoice: invoice_id,
                        unit_amount: APP_CONFIG.payments.additional_storage_chunk_cost,
                        currency: 'usd',
                        quantity: over_chunks,
@@ -115,6 +122,7 @@ module Stash
           overcharge = over_chunks.positive? ? APP_CONFIG.payments.additional_storage_chunk_cost * over_chunks : 0
           items.push(Stripe::InvoiceItem.create(
                        customer: customer_id,
+                       invoice: invoice_id,
                        amount: -(APP_CONFIG.payments.data_processing_charge + overcharge),
                        currency: 'usd',
                        description: "Waiver of charges for #{resource.identifier} (#{filesize(ds_size)})"

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -400,8 +400,10 @@ namespace :identifiers do
 
   desc 'Report on voided invoices'
   task voided_invoices_report: :environment do
-    # Get all invoices created in the past two months
-    inv = Stash::Payments::Invoicer.find_recent
+    # Get all invoices voided recently
+    Stash::Payments::Invoicer.find_recent_voids.each do |inv|
+      puts "Found voided invoice #{inv.id}"
+    end
   end
 
   desc 'Generate a report of items that have been published in a given month'

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -411,7 +411,7 @@ namespace :identifiers do
     end
 
     if alert_list.present?
-      puts "Send alert! #{alert_list.map(&:id)}"
+      puts "Sending alert for identifiers #{alert_list.map(&:id)}"
       StashEngine::UserMailer.voided_invoices(alert_list).deliver_now
     end
   end

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -398,6 +398,12 @@ namespace :identifiers do
     end
   end
 
+  desc 'Report on voided invoices'
+  task voided_invoices_report: :environment do
+    # Get all invoices created in the past two months
+    inv = Stash::Payments::Invoicer.find_recent
+  end
+
   desc 'Generate a report of items that have been published in a given month'
   task shopping_cart_report: :environment do
     # Get the year-month specified in YEAR_MONTH environment variable.

--- a/spec/models/stash/payments/invoicer_spec.rb
+++ b/spec/models/stash/payments/invoicer_spec.rb
@@ -39,7 +39,6 @@ module Stash
         fake_customer = OpenStruct.new(id: @cust_id, email: @author.author_email, description: @author.author_standard_name)
 
         @invoicer = Invoicer.new(resource: @resource, curator: @curator)
-        allow(@invoicer).to receive(:set_api_key).and_return(true)
         allow(@invoicer).to receive(:create_invoice_items_for_dpc).and_return([fake_invoice_item])
         allow(@invoicer).to receive(:create_invoice).and_return(fake_invoice)
         allow(@invoicer).to receive(:create_customer).and_return(fake_customer)


### PR DESCRIPTION
Weekly check to see whether any invoices have been voided in Stripe, but still exist in Dryad. 

When issues are found, an email is sent to the same list as for submission errors. Note that I have updated the `local` environment to use the mailinator address rather than actually sending email to all developers. 

This includes an updated to use the most recent Stripe API. The API version is set explicitly in our code, so other tools that interact with Stripe may use a different version of the API. I set it directly in the class rather than a config file, because any change to the API version will likely affect the structure of the class. The largest effect of the version update is that the objects are now created in reverse order. In the old API, `InvoiceItems` were created first, and then an `Invoice` would collect all pending items for that customer automatically. In the new API, they take the more intuitive approach of creating an `Invoice` first and explicitly adding the `InvoiceItems` to it.