### PR TITLE
Correct API response formatting issue

### DIFF
--- a/app/controllers/stash_api/datasets_controller.rb
+++ b/app/controllers/stash_api/datasets_controller.rb
@@ -36,7 +36,7 @@ module StashApi
     # post /datasets
     def create
       respond_to do |format|
-        format.any do
+        format.json do
           dp = DatasetParser.new(hash: params['dataset'], id: nil, user: @user)
           @stash_identifier = dp.parse
           ds = Dataset.new(identifier: @stash_identifier.to_s, user: @user) # sets up display objects
@@ -50,7 +50,7 @@ module StashApi
       # The Editorial Manager API sends metadata that is largely similar to our normal API, but it needs to be
       # reformatted before and after the normal processing.
       respond_to do |format|
-        format.any do
+        format.json do
           deposit_request = params['article'].blank?
 
           if @stash_identifier&.first_submitted_resource.present?

--- a/app/controllers/stash_api/datasets_controller.rb
+++ b/app/controllers/stash_api/datasets_controller.rb
@@ -368,7 +368,7 @@ module StashApi
       # otherwise this is a PUT of the dataset metadata
       check_status { return } # check it's in progress, clone a submitted or raise an error
       respond_to do |format|
-        format.any do
+        format.json do
           dp = if @resource
                  DatasetParser.new(hash: params['dataset'], id: @resource.identifier, user: @user) # update dataset
                else


### PR DESCRIPTION
Possibly associated with https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2181, though I'm not completely certain until I get more information about the calls they are making.

Apparently, Rails 6 changed how the formats were processed in certain situations, so we must be more specific with the type of format in these situations.