### PR TITLE
Changes the call to render from within standard Ruby library

### DIFF
--- a/lib/stash/link_out/labslink_service.rb
+++ b/lib/stash/link_out/labslink_service.rb
@@ -51,9 +51,9 @@ module Stash
 
       def generate_provider_file!
         # Note that the view referenced below lives in the Dryad repo in the dryad/app/views dir
-        doc = Nokogiri::XML(ActionView::Base.new(ActionView::LookupContext.new('app/views'), {}, nil)
+        doc = Nokogiri::XML(ActionView::Base.with_empty_template_cache.new(ActionView::LookupContext.new('app/views'), {}, nil)
           .render(
-            file: Rails.root.join('app', 'views', 'link_out', 'labslink_provider.xml.erb'),
+            template: 'link_out/labslink_provider.xml.erb',
             locals: {
               id: @ftp.ftp_provider_id,
               name: 'Dryad Data Platform',
@@ -70,9 +70,9 @@ module Stash
         identifiers = StashEngine::Identifier.cited_by_pubmed
 
         # Note that the view referenced below lives in the Dryad repo in the dryad/app/views dir
-        doc = Nokogiri::XML(ActionView::Base.new(ActionView::LookupContext.new('app/views'), {}, nil)
+        doc = Nokogiri::XML(ActionView::Base.with_empty_template_cache.new(ActionView::LookupContext.new('app/views'), {}, nil)
           .render(
-            file: Rails.root.join('app', 'views', 'link_out', 'labslink_links.xml.erb'),
+            template: 'link_out/labslink_links.xml.erb',
             locals: {
               provider_id: @ftp.ftp_provider_id,
               database: 'MED',

--- a/lib/stash/link_out/pubmed_sequence_service.rb
+++ b/lib/stash/link_out/pubmed_sequence_service.rb
@@ -117,9 +117,9 @@ module Stash
       end
 
       def generate_fragment(idx, db, hash)
-        Nokogiri::XML.fragment(ActionView::Base.new(ActionView::LookupContext.new('app/views'), {}, nil)
+        Nokogiri::XML.fragment(ActionView::Base.with_empty_template_cache.new(ActionView::LookupContext.new('app/views'), {}, nil)
           .render(
-            file: Rails.root.join('app', 'views', 'link_out', 'sequence_links.xml.erb'),
+            template: 'link_out/sequence_links.xml.erb',
             locals: {
               counter: idx,
               provider_id: @ftp.ftp_provider_id,

--- a/lib/stash/link_out/pubmed_service.rb
+++ b/lib/stash/link_out/pubmed_service.rb
@@ -74,9 +74,9 @@ module Stash
 
       def generate_provider_file!
         # Note that the view referenced below lives in the Dryad repo in the dryad/app/views dir
-        doc = Nokogiri::XML(ActionView::Base.new(ActionView::LookupContext.new('app/views'), {}, nil)
+        doc = Nokogiri::XML(ActionView::Base.with_empty_template_cache.new(ActionView::LookupContext.new('app/views'), {}, nil)
           .render(
-            file: Rails.root.join('app', 'views', 'link_out', 'pubmed_provider.xml.erb'),
+            template: 'link_out/pubmed_provider.xml.erb',
             locals: {
               id: @ftp.ftp_provider_id,
               abbreviation: @ftp.ftp_username,
@@ -96,9 +96,9 @@ module Stash
         end
 
         # Note that the view referenced below lives in the Dryad repo in the dryad/app/views dir
-        doc = Nokogiri::XML(ActionView::Base.new(ActionView::LookupContext.new('app/views'), {}, nil)
+        doc = Nokogiri::XML(ActionView::Base.with_empty_template_cache.new(ActionView::LookupContext.new('app/views'), {}, nil)
           .render(
-            file: Rails.root.join('app', 'views', 'link_out', 'pubmed_links.xml.erb'),
+            template: 'link_out/pubmed_links.xml.erb',
             locals: {
               provider_id: @ftp.ftp_provider_id,
               database: 'PubMed',


### PR DESCRIPTION
 to use template rendering instead and also additional options required to do the raw render outside of Rails.  Checked in debugger and it is outputting contents of erb replacements.