### PR TITLE
Re-adding instructions for unpublishing

### DIFF
--- a/app/views/stash_datacite/licenses/_review.html.erb
+++ b/app/views/stash_datacite/licenses/_review.html.erb
@@ -64,7 +64,7 @@
 			publication of your dataset, you will receive an invoice for
 			&dollar;<%=  Stash::Payments::Invoicer.data_processing_charge(identifier: @resource.identifier) / 100 %> USD.
 			We’re sensitive to the fact that fees for individual
-			researchers are a burden and create inequities. If you'd
+			researchers can be a burden and create inequities. If you'd
 			like to request a fee waiver, please contact <a href="mailto:help@datadryad.org">help@datadryad.org</a>.
 		</p>
 

--- a/documentation/server_maintenance/troubleshooting.md
+++ b/documentation/server_maintenance/troubleshooting.md
@@ -295,7 +295,8 @@ See the instructions for "Private for peer review above" since it's almost the s
 changes.
 
 - In the step of setting "peer_review_end_date" set it to NULL instead.
-- In the step of adding a curation_activity description, set to "Set to unpublished at curator request"
+- In the step of adding a curation_activity description, set to "curation" and
+  "Set to unpublished at curator request" instead of the peer_review state.
 
 We cannot easily remove everything from Zenodo or DataCite without a lot of problems and it sounds
 like it will eventually get published again, anyway. For Zenodo, set the embargo an 

--- a/documentation/server_maintenance/troubleshooting.md
+++ b/documentation/server_maintenance/troubleshooting.md
@@ -64,18 +64,27 @@ Dataset submission issues
 =========================
 
 
-Forcing a dataset to submit
+Dealing with submission problems/resubmitting
 ---------------------------
 
-Sometimes a dataset becomes "stuck in progress". This is often due to
-confusion on the part of a user, but there are times when the user
-loses access to editing a particular version of a dataset. Find the
-most recent resource object associated with that dataset, and force it
-to submit:
+Go to the `Submission queue` page, check the box and click `Resend checked submissions` if there is
+a problem.  If there is weirdness in the queuing and resubmitting you can look at `stash_engine_repo_queue_states`
+and search by the resource_id.  A normal submission goes through 'enqueued', 'processing', 
+'provisional_complete' and 'complete'.  `provisional_complete' means we got a success message from 
+Merritt SWORD but we haven't seen it show up in Merritt as really completed yet and we wait to see
+a real completion before taking actions since it may be delayed or rarely has a problem in Merritt.
 
-```
-StashEngine.repository.submit(resource_id: <resource_id>)
-```
+If a submission has failed in Merritt, do the following on the server(s) to see Merritt error messages
+to give to them or to troubleshoot the problem.
+
+`less /apps/dryad/apps/ui/current/log/production.log`
+
+- Press `>` to go to the end of the file.
+- Press CTRL-C to stop line number calculation.
+- type `\Submission failed` which will search in a forward direction (you will not find it).
+- type 'N' (must be a capital letter) to search backwards for the (N)ext of the same string, this should find the last 
+  submission failures in the log.
+
 
 Diagnosing a failed submission
 ------------------------------
@@ -127,14 +136,11 @@ Check that the Merritt submission status daemon is running.
 
 Be sure we can get results for queries from Merritt.
 
-The daemon can be run manually with rake task like:
+The daemon can be restarted on the server like:
 ```
-RAILS_ENV=<environment> bundle exec rails merritt_status:update
+sudo cdlsysctl restart merritt_status_updater
+# it can be run manually like `RAILS_ENV=<environment> bundle exec rails merritt_status:update' if needed
 ```
-
-However, it will start automatically from systemd startup and
-can be managed through it as the preferred method.
-
 
 If the user needs to change a data problem that caused a submission error (rare)
 --------------------------------------------------------------------------------
@@ -250,13 +256,17 @@ INSERT INTO `stash_engine_curation_activities` (`status`, `user_id`, `note`, `ke
   VALUES ('peer_review', '0', 'Set to peer review at curator request', NULL, '2022-07-27', '2022-07-27', 
   <resource-id>);
 
-select * from stash_engine_zenodo_copies where resource_id=;
+select * from stash_engine_zenodo_copies where identifier_id=;
 ```
+For each finished `data`, `supp_publish` and `software_publish` record in the
+`stash_engine_zenodo_copies` table do the following procedure. (see last query above)
 
-Now run a command like the one one below if it has been published to Zenodo.  It will
+Now run a command like the one one below for each of these published to Zenodo.  It will
 re-open the published record, set embargo and publish it again with the
 embargo date.  You can find the deposition_id in the stash_engine_zenodo_copies
-table. The zenodo_copy_id is the id from that same table.
+table. The zenodo_copy_id is the `stash_engine_zenodo_copies.id` from that same table.
+
+
 ```
 # the arguments are 1) resource_id, 2) deposition_id at zenodo, 3) date, 4) zenodo_copy_id
 RAILS_ENV=production bundle exec rake dev_ops:embargo_zenodo 97683 4407065 2023-07-25 1234
@@ -278,6 +288,19 @@ What to do at datacite?
 - Under state, choose `Registered` instead of `Findable` and hopefully this is good enough since not a lot of other choices.
 - Click `Update DOI`
 - (if it's EZID, you may have to do this a different way, but most are datacite dois)
+
+# This dataset was accidentally published early (unpublish now and likely again published later)
+
+See the instructions for "Private for peer review above" since it's almost the same process with a few minor
+changes.
+
+- In the step of setting "peer_review_end_date" set it to NULL instead.
+- In the step of adding a curation_activity description, set to "Set to unpublished at curator request"
+
+We cannot easily remove everything from Zenodo or DataCite without a lot of problems and it sounds
+like it will eventually get published again, anyway. For Zenodo, set the embargo an 
+unreasonably long time into the future for the items that were published there. For Datacite change
+to `Registered` instead of `Findable` so at least it's not searchable.
 
 
 Permanently removing data that was accidentally published (and should never be)


### PR DESCRIPTION
 since someone removed them.  It's not quite the same as private for peer review, I think.

@ahamelers I updated that instructions you had questions about.  It looks like you managed to find a branch or tag with old instructions that someone had deleted in our main branch.

I've re-put the temporarily "remove my dataset" back in since we do get asked for that sometimes and made some other small updates.  It's pretty similar to "private for peer review."

I'm honestly not super clear on the distinction these days.  I think originally both embargoed and "private for peer review" datasets always had an end-date set, but that might be different these days.  I guess "private for peer review" prevents them being published by curators somehow (or they know not to publish?).

Things that have not been published are also private (and reviewers can be given review links also).

I find the distinctions between these 3 states kind of confusing.  Maybe @ryscher  can clarify where I'm wrong or what the differences/similarities are and if the end-date is still used for PPR.

From my understanding:

- Embargo
  - Always time limited
  - Are already curated
  - Shows metadata but not files
  - It will be published after certain date
  - Private preview links work
- Private for Peer Review
  - Sometimes time limited, sometimes not (what circumstances?)
  - Curators don't look at them until it's "ready"
  - When time expires or else a journal gives an accept (?) notice then it's ready for curation and then curators look
  - Private preview links work
- Not published yet
  - Curators curate soon and aren't waiting on a journal acceptance in order to embargo or publish
  - Private preview links work for submitted versions



