### PR TITLE
Prevent page clicking while form submits

### DIFF
--- a/app/assets/stylesheets/stash_engine/ui.css
+++ b/app/assets/stylesheets/stash_engine/ui.css
@@ -8229,6 +8229,9 @@ body, body#yes-really {
     padding: 10px 30px;
   }
 }
+body.prevent-clicks, body.prevent-clicks *, body#yes-really.prevent-clicks, body#yes-really.prevent-clicks * {
+  pointer-events: none;
+}
 
 *:focus {
   outline: 2px solid #cf4817;

--- a/app/views/stash_engine/admin_datasets/activity_log.html.erb
+++ b/app/views/stash_engine/admin_datasets/activity_log.html.erb
@@ -118,7 +118,7 @@
 
 	    <div style="float: left">
 		<% res = @identifier&.latest_resource %>
-		<%= form_with(url: stash_url_helpers.metadata_entry_pages_new_version_path, method: :post) do -%>
+		<%= form_with(url: stash_url_helpers.metadata_entry_pages_new_version_path, method: :post, :html => {onsubmit: "document.body.classList.add('prevent-clicks')"}) do -%>
 			<button class="o-button__submit">Forcibly edit dataset</button>
 			<%= hidden_field_tag :resource_id, res&.id, id: "resource_id_#{res&.id}" %>
 			<%= hidden_field_tag :return_url, '/stash/dashboard' %>

--- a/ui-library/scss/main.scss
+++ b/ui-library/scss/main.scss
@@ -128,6 +128,10 @@ body, body#yes-really {
 		padding: 10px 30px;
 	}
 
+	&.prevent-clicks, &.prevent-clicks * {
+		pointer-events: none;
+	}
+
 }
 
 *:focus {


### PR DESCRIPTION
This solution can be used for other remote forms where submitting the form goes to a new page; forms where actions are completed on the same page will also need the class to be removed when the form action is complete.