### PR TITLE
Use owner_author when calculating waiver

### DIFF
--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -356,7 +356,7 @@ module StashEngine
     end
 
     def submitter_affiliation
-      latest_resource&.authors&.first&.affiliation
+      latest_resource&.owner_author&.affiliation
     end
 
     def large_files?

--- a/spec/models/stash_engine/identifier_spec.rb
+++ b/spec/models/stash_engine/identifier_spec.rb
@@ -628,8 +628,8 @@ module StashEngine
     end
 
     describe '#submitter_affiliation' do
-      it 'returns the current version\'s first author\'s affiliation' do
-        expect(@identifier.submitter_affiliation).to eql(@identifier.latest_resource&.authors&.first&.affiliation)
+      it 'returns the current version\'s submitter\'s affiliation' do
+        expect(@identifier.submitter_affiliation).to eql(@identifier.latest_resource&.owner_author&.affiliation)
       end
     end
 


### PR DESCRIPTION
Corrects bug in fee waiver calculation when the submitter is not the first author.