### PR TITLE
Reinstate  peer_review notifications to journals

### DIFF
--- a/app/models/stash_engine/curation_activity.rb
+++ b/app/models/stash_engine/curation_activity.rb
@@ -219,9 +219,12 @@ module StashEngine
       return if previously_published?
 
       case status
-      when 'published', 'embargoed', 'peer_review'
+      when 'published', 'embargoed'
         StashEngine::UserMailer.status_change(resource, status).deliver_now
         StashEngine::UserMailer.journal_published_notice(resource, status).deliver_now
+      when 'peer_review'
+        StashEngine::UserMailer.status_change(resource, status).deliver_now
+        StashEngine::UserMailer.journal_review_notice(resource, status).deliver_now
       when 'submitted'
         return if previously_submitted? # Don't send multiple emails for the same resource
 


### PR DESCRIPTION
While reviewing email notifications for https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2195, I realized that journals were no longer receiving notifications when datasets enter `peer_review` status. A review of the `automated_notifications` history revealed that this behavior changed on December 6.

The problem was introduced with the Rails 6 upgrade as a side effect of simplifying some conditional behavior, in commit d567ffd22ba09245c457ed468aa23eee5ebcc269. 

This PR reverses the change that introduced the problem.