### PR TITLE
Add cache clearing for items older than 21 days to avoid rack-attack filling inodes

### DIFF
--- a/cron/weekly.sh
+++ b/cron/weekly.sh
@@ -8,6 +8,10 @@ PATH=$PATH:/apps/dryad/local/bin
 
 cd /apps/dryad/apps/ui/current/
 
+# clear out cache older than 3 weeks old, remove empty directories in cache
+find /apps/dryad/apps/ui/shared/tmp/cache -mtime +21 -type f -exec rm {} \;
+find /apps/dryad/apps/ui/shared/tmp/cache -empty -type d -delete
+
 bundle exec rails publication_updater:crossref >> /apps/dryad/apps/ui/shared/cron/logs/publication_updater_crossref.log 2>&1
 
 bundle exec rails identifiers:voided_invoices_report >>/apps/dryad/apps/ui/shared/cron/logs/voided_invoices_report.log 2>&1


### PR DESCRIPTION
Martin gave us additional warnings about this approaching capacity yesterday.  In the past I've gone in and occasionally cleared things manually with `Rack::Attack.reset!` in the rails console yet I do it infrequently and it's hard to track.  I looked through all our cron scripts and the crontab since I thought this might have been done already, but it seems not.

From the discussion in the ticket, the find commands are a fine alternative and doesn't remove all history, just more recent.

https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1533

I hope this mitigates us having inode emergencies where we're notified we have to fix something right away.