### PR TITLE
Fix display of autocomplete dropdown

### DIFF
--- a/app/assets/stylesheets/stash_engine/ui.css
+++ b/app/assets/stylesheets/stash_engine/ui.css
@@ -5069,7 +5069,6 @@ html.no-details .o-showhide__summary {
   background-color: #fafafa;
   position: absolute;
   top: 1em;
-  right: 16px;
   z-index: 1000;
   padding: 0;
   list-style: none;

--- a/ui-library/scss/_auto-complete.scss
+++ b/ui-library/scss/_auto-complete.scss
@@ -12,7 +12,6 @@
     background-color: #fafafa;
     position: absolute;
     top: 1em;
-    right: 16px;
     z-index: 1000;
     padding: 0;
     list-style: none;


### PR DESCRIPTION
Small style fix for alignment of autocomplete dropdown (missed when removing the question mark display)