### PR TITLE
Update at-a-glance stats for curation stats page

### DIFF
--- a/app/controllers/stash_engine/admin_datasets_controller/stats.rb
+++ b/app/controllers/stash_engine/admin_datasets_controller/stats.rb
@@ -40,6 +40,10 @@ module StashEngine
         datasets_with_resource_state_count(state: 'submitted')
       end
 
+      def datasets_submitted_unclaimed_count
+        datasets_with_curation_status_count(status: 'submitted', only_unclaimed: true)
+      end
+
       def datasets_available_for_curation
         datasets_with_curation_status_count(status: 'submitted') +
           datasets_with_curation_status_count(status: 'curation')
@@ -54,8 +58,9 @@ module StashEngine
         ident_query.count
       end
 
-      def datasets_with_curation_status_count(status:)
+      def datasets_with_curation_status_count(status:, only_unclaimed: false)
         query = "#{STATUS_QUERY_BASE} WHERE ser.updated_at < '#{@untouched_since}' AND ser.created_at > '#{@since}' AND seca.status = '#{status}'"
+        query += ' AND ser.current_editor_id is NULL' if only_unclaimed
         ApplicationRecord.connection.execute(query)&.first&.first
       end
 

--- a/app/controllers/stash_engine/curation_stats_controller.rb
+++ b/app/controllers/stash_engine/curation_stats_controller.rb
@@ -12,7 +12,7 @@ module StashEngine
       @current_stats = CurationStats.where(date: 1.month.ago..Date.today).order('date DESC')
 
       @admin_stats = StashEngine::AdminDatasetsController::Stats.new
-      @admin_stats_2day = StashEngine::AdminDatasetsController::Stats.new(untouched_since: Time.now - 2.days)
+      @admin_stats_3day = StashEngine::AdminDatasetsController::Stats.new(untouched_since: Time.now - 3.days)
 
       respond_to do |format|
         format.html

--- a/app/views/stash_engine/curation_stats/index.html.erb
+++ b/app/views/stash_engine/curation_stats/index.html.erb
@@ -3,9 +3,10 @@
 
 <div class="o-admin-container">
     <div class="o-admin-left-head">
-	<div class="o-heading__level3">At a glance</div>
-	<%= @admin_stats.datasets_available_for_curation %> datasets currently available for curation<br/>
-	<%= @admin_stats_2day.datasets_available_for_curation %> datasets available for curation and not touched in 48 hours 
+      <div class="o-heading__level3">At a glance</div>
+      <%= @admin_stats.datasets_submitted_unclaimed_count %> datasets currently in 'Submitted' status (that are unclaimed/unassigned)<br/>
+      <%= @admin_stats.datasets_available_for_curation %> datasets currently available for curation<br/>
+      <%= @admin_stats_3day.datasets_available_for_curation %> datasets available for curation and not touched in 72 hours 
     </div>
 </div>
 


### PR DESCRIPTION
- Use 72 hours for "untouched" time instead of 48 hours, since curators often don't work weekends.
- Add a stat for the total number of datasets in the queue that have not been assigned to a curator (this is typically only "new" datasets, since versions of older datasets are almost always auto-assigned to a curator) 