### PR TITLE
Fix for curation-at-a-glance

### DIFF
--- a/app/controllers/stash_engine/admin_datasets_controller/stats.rb
+++ b/app/controllers/stash_engine/admin_datasets_controller/stats.rb
@@ -60,7 +60,7 @@ module StashEngine
 
       def datasets_with_curation_status_count(status:, only_unclaimed: false)
         query = "#{STATUS_QUERY_BASE} WHERE ser.updated_at < '#{@untouched_since}' AND ser.created_at > '#{@since}' AND seca.status = '#{status}'"
-        query += ' AND ser.current_editor_id is NULL' if only_unclaimed
+        query += ' AND (ser.current_editor_id is NULL or ser.current_editor_id = ser.user_id)' if only_unclaimed
         ApplicationRecord.connection.execute(query)&.first&.first
       end
 


### PR DESCRIPTION
Extra fix for #1098. It counted correctly when the curators were explicitly unassigned. But when a curator has never been assigned, the submitter is still the `current_editor`, and we want to count these submissions as well (they're the most common!)