### PR TITLE
prevent multiple email addresses in submission api

### DIFF
--- a/app/models/stash_api/dataset_parser.rb
+++ b/app/models/stash_api/dataset_parser.rb
@@ -141,7 +141,7 @@ module StashApi
       a = StashEngine::Author.new(
         author_first_name: json_author[:firstName],
         author_last_name: json_author[:lastName],
-        author_email: json_author[:email],
+        author_email: parse_email(json_author[:email]),
         author_orcid: json_author[:orcid] || @previous_orcids["#{json_author[:firstName]} #{json_author[:lastName]}"],
         resource_id: @resource.id,
         author_order: json_author[:order] || nil
@@ -186,6 +186,19 @@ module StashApi
       return unless @resource.resource_type.blank?
 
       StashDatacite::ResourceType.create(resource_type_general: 'dataset', resource_type: 'dataset', resource_id: @resource.id)
+    end
+
+    private def parse_email(email_string)
+      # is it an email with display name and brackets like "Bob Jones <bob.jones@example.org>"-- then suck email out
+      matches = email_string&.match(/<(.+?@.+?)>/)
+      return matches[1] if matches
+
+      # if comma or semicolon
+      parts = email_string&.split(/[;,]/)
+      return parts[0]&.strip if parts && parts.length > 1
+
+      # otherwise, pass through unchanged
+      email_string
     end
 
   end

--- a/app/models/stash_api/version/metadata/authors.rb
+++ b/app/models/stash_api/version/metadata/authors.rb
@@ -12,7 +12,7 @@ module StashApi
             {
               firstName: a.author_first_name,
               lastName: a.author_last_name,
-              email: parse_email(a.author_email),
+              email: a.author_email,
               affiliation: a.try(:affiliation).try(:smart_name),
               affiliationROR: a.try(:affiliation).try(:ror_id),
               orcid: a.author_orcid,

--- a/app/models/stash_api/version/metadata/authors.rb
+++ b/app/models/stash_api/version/metadata/authors.rb
@@ -12,7 +12,7 @@ module StashApi
             {
               firstName: a.author_first_name,
               lastName: a.author_last_name,
-              email: a.author_email,
+              email: parse_email(a.author_email),
               affiliation: a.try(:affiliation).try(:smart_name),
               affiliationROR: a.try(:affiliation).try(:ror_id),
               orcid: a.author_orcid,

--- a/spec/models/stash_api/dataset_parser_spec.rb
+++ b/spec/models/stash_api/dataset_parser_spec.rb
@@ -111,7 +111,7 @@ module StashApi
       end
 
       it 'reduces emails to one for format of "display name <my@email>"' do
-        emails = Array.new(2){|_i| Faker::Internet.email }
+        emails = Array.new(2) { |_i| Faker::Internet.email }
         @basic_metadata = {
           'authors' => [
             {
@@ -130,7 +130,7 @@ module StashApi
       end
 
       it 'reduces emails to one when more are jammed in with commas or semicolons' do
-        emails = Array.new(2){|_i| Faker::Internet.email }
+        emails = Array.new(2) { |_i| Faker::Internet.email }
         @basic_metadata = {
           'authors' => [
             {


### PR DESCRIPTION
Also handles displayname <email@domain> style.

The regex for displayname is pretty loose (just looks for values with an at sign somewhere inside angle brackets) but I think it's good enough and a lot more readable than something extra complicated.

Also strips whitespace if multiple standard emails jammed into one.

Otherwise returns the input as pass through.