### PR TITLE
Allow journals to have multiple ISSNs

### DIFF
--- a/app/javascript/react/components/MetadataEntry/PrelimAutocomplete.jsx
+++ b/app/javascript/react/components/MetadataEntry/PrelimAutocomplete.jsx
@@ -69,7 +69,7 @@ export default function PrelimAutocomplete({
   const nameFunc = (item) => (item?.title || '');
 
   // Given a js object from list (supplyLookupList above) it returns the unique identifier
-  const idFunc = (item) => item.issn;
+  const idFunc = (item) => item.single_issn;
 
   return (
     <GenericNameIdAutocomplete

--- a/app/models/stash_api/dataset_parser.rb
+++ b/app/models/stash_api/dataset_parser.rb
@@ -96,7 +96,7 @@ module StashApi
 
     def parse_internal_data
       if @hash['publicationName'].present? && @hash['publicationISSN'].blank?
-        @hash['publicationISSN'] = StashEngine::Journal.find_by_title(@hash['publicationName'])&.issn
+        @hash['publicationISSN'] = StashEngine::Journal.find_by_title(@hash['publicationName'])&.single_issn
       end
 
       INTERNAL_DATA_FIELDS.each do |int_field|

--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -50,7 +50,7 @@ module StashEngine
         tenant_admin = (user.tenant_id if user.role == 'admin')
         with_visibility(states: %w[published embargoed],
                         tenant_id: tenant_admin,
-                        journal_issns: user.journals_as_admin.map(&:issn),
+                        journal_issns: user.journals_as_admin.map(&:single_issn),
                         funder_ids: user.funders_as_admin.map(&:funder_id),
                         user_id: user.id)
       end
@@ -254,7 +254,7 @@ module StashEngine
     def journal
       return nil if publication_issn.nil?
 
-      Journal.where(issn: publication_issn).first
+      Journal.find_by_issn(publication_issn)
     end
 
     def record_payment
@@ -609,7 +609,7 @@ module StashEngine
     def clear_payment_for_changed_journal
       return unless payment_type.present?
       return unless payment_type.include?('journal')
-      return if payment_id == journal&.issn
+      return if payment_id == journal&.single_issn
 
       self.payment_type = nil
       self.payment_id = nil

--- a/app/models/stash_engine/journal.rb
+++ b/app/models/stash_engine/journal.rb
@@ -21,9 +21,10 @@ module StashEngine
       o
     end
 
-    # Return the single ISSN that is representative of this journal, even if
-    # we are storing multiple ISSNs
+    # Return the single ISSN that is representative of this journal,
+    # even if the journal contains multiple ISSNs
     def single_issn
+      return nil unless issn.present?
       return issn.first if issn.is_a?(Array)
       return JSON.parse(issn)&.first if issn.start_with?('[')
 

--- a/app/models/stash_engine/journal.rb
+++ b/app/models/stash_engine/journal.rb
@@ -21,6 +21,15 @@ module StashEngine
       o
     end
 
+    # Return the single ISSN that is representative of this journal, even if
+    # we are storing multiple ISSNs
+    def single_issn
+      return issn.first if issn.is_a?(Array)
+      return JSON.parse(issn)&.first if issn.start_with?('[')
+
+      issn
+    end
+
     def self.find_by_title(title)
       return unless title.present?
 
@@ -34,6 +43,12 @@ module StashEngine
       journal
     end
 
+    def self.find_by_issn(issn)
+      return nil if issn.blank? || issn.size < 9
+
+      StashEngine::Journal.where("issn like '%#{issn}%'")&.first
+    end
+
     # Replace an uncontrolled journal name (typically containing '*')
     # with a controlled journal reference, using an id
     def self.replace_uncontrolled_journal(old_name:, new_id:)
@@ -42,7 +57,7 @@ module StashEngine
       idents = data.map(&:identifier_id)
       idents.each do |ident|
         puts "  converting journal for #{ident}"
-        update_journal_for_identifier(new_title: j.title, new_issn: j.issn, identifier_id: ident)
+        update_journal_for_identifier(new_title: j.title, new_issn: j.single_issn, identifier_id: ident)
       end
     end
 

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -230,7 +230,7 @@ module StashEngine
         with_visibility(states: %w[published embargoed],
                         tenant_id: tenant_admin,
                         funder_ids: user.funders_as_admin.map(&:funder_id),
-                        journal_issns: user.journals_as_admin.map(&:issn),
+                        journal_issns: user.journals_as_admin.map(&:single_issn),
                         user_id: user.id)
       end
     end

--- a/app/services/stash_engine/email_parser.rb
+++ b/app/services/stash_engine/email_parser.rb
@@ -88,10 +88,10 @@ module StashEngine
       @journal = StashEngine::Journal.where(journal_code: @hash['journal code'].downcase).first if @hash['journal code']
       return if @journal
 
-      @journal = StashEngine::Journal.where(issn: @hash['print issn']).first if @hash['print issn']
+      @journal = StashEngine::Journal.find_by_issn(@hash['print issn']) if @hash['print issn']
       return if @journal
 
-      @journal = StashEngine::Journal.where(issn: @hash['online issn']).first if @hash['online issn']
+      @journal = StashEngine::Journal.find_by_issn(@hash['online issn']) if @hash['online issn']
       return if @journal
 
       @journal = StashEngine::Journal.find_by_title(@hash['journal name']) if @hash['journal name']

--- a/app/views/stash_engine/journals/index.html.erb
+++ b/app/views/stash_engine/journals/index.html.erb
@@ -13,8 +13,8 @@ Dryad member, you will be responsible for paying the DPC as well as any overage 
       <th class="c-admin-table <%= sort_display('title') %>">
 	  <%= sortable_column_head sort_field: 'title', title: 'Title' %>
       </th>
-      <th class="c-admin-table <%= sort_display('issn') %>">
-	  <%= sortable_column_head sort_field: 'issn', title: 'ISSN' %>
+      <th class="c-admin-table %>">
+	  ISSN
       </th>
       <th class="c-admin-table <%= sort_display('allow_blackout') %>">
 	  <%= sortable_column_head sort_field: 'allow_blackout', title: 'Automatic embargo?' %>
@@ -32,7 +32,7 @@ Dryad member, you will be responsible for paying the DPC as well as any overage 
   <% @journals.each do |journal| %>
   <tr class="c-lined-table__row" id="js-dataset-row-id-<%= journal.id %>">
       <td><%= journal.title %></td>
-      <td><span style="white-space: nowrap;"><%= journal.issn %></span></td>
+      <td><span style="white-space: nowrap;"><%= journal.single_issn %></span></td>
       <td><%= journal.allow_blackout %></td>
       <td><%= journal.payment_plan_type %></td>
       <td><%= journal.top_level_org&.name %></td>

--- a/documentation/apis/journals.md
+++ b/documentation/apis/journals.md
@@ -114,7 +114,8 @@ database.
 
 IF there is no corresponding journal, create an entry for a new journal in the
 system, using a command like the the one below. Edit any
-of the relevant fields, but the most critical are `title` and `issn`.
+of the relevant fields, but the most critical are `title` and `issn`. Note that `issn` may contain
+either a single ISSN or an array of them. 
 ```
 j = StashEngine::Journal.create(title: '', issn: '',
                                 notify_contacts: ["automated-messages@datadryad.org"], allow_review_workflow: true,
@@ -314,7 +315,7 @@ To run a test:
 - Send an email to the Gmail account with the required metadata. The
   account can be journal-submit-app OR the more general
   journal-submit@datadryad.org. Note that you must use a "real" journal
-  ISSNname to match the settings in the concept above. Something like:
+  name to match the settings in the concept above. Something like:
 
 ```
 Journal Name: Molecular Ecology

--- a/lib/stash/import/crossref.rb
+++ b/lib/stash/import/crossref.rb
@@ -313,7 +313,7 @@ module Stash
         # it is likely an alternative ISSN for a journal where we have a different primary ISSN
         # (most journals have separate ISSNs for print, online, linking)
         # In that case, we will save the journal name, and look up the correct ISSN from the name.
-        return unless StashEngine::Journal.where(issn: @sm['ISSN'].first).present?
+        return unless StashEngine::Journal.find_by_issn(@sm['ISSN'].first).present?
 
         datum = StashEngine::InternalDatum.find_or_initialize_by(identifier_id: @resource.identifier.id,
                                                                  data_type: 'publicationISSN')
@@ -333,7 +333,7 @@ module Stash
         # If the publication name matches an existing journal, populate/update the ISSN
         datum = StashEngine::InternalDatum.find_or_initialize_by(identifier_id: @resource.identifier.id,
                                                                  data_type: 'publicationISSN')
-        datum.update(value: journal.issn)
+        datum.update(value: journal.single_issn)
       end
 
       def populate_title

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -11,7 +11,7 @@ namespace :dryad_migration do
       code.downcase!
       issn.chomp!
       puts "code=#{code} issn=#{issn}"
-      journal = StashEngine::Journal.where(issn: issn).first
+      journal = StashEngine::Journal.find_by_issn(issn)
       if journal
         journal.journal_code = code
         journal.save

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -550,7 +550,7 @@ namespace :identifiers do
         end
         journal_item_count = 0
         sc_report.each do |item|
-          if item['JournalISSN'] == j.issn
+          if item['JournalISSN'] == j.single_issn
             journal_item_count += 1
             sponsor_summary << [item['DOI'], j.title, item['ApprovalDate']]
           end
@@ -961,14 +961,14 @@ namespace :journals do
       end
 
       sfj = Stash::Salesforce.find(obj_type: 'Account', obj_id: sf_id)
-      if sfj['ISSN__c'] != j.issn
-        puts "Updating ISSN in SF from #{sfj['ISSN__c']} to #{j.issn}"
-        Stash::Salesforce.update(obj_type: 'Account', obj_id: sf_id, kv_hash: { ISSN__c: j.issn }) unless dry_run
+      if sfj['ISSN__c'] != j.single_issn
+        puts "Updating ISSN in SF from #{sfj['ISSN__c']} to #{j.single_issn}"
+        Stash::Salesforce.update(obj_type: 'Account', obj_id: sf_id, kv_hash: { ISSN__c: j.single_issn }) unless dry_run
       end
 
       sf_parent_id = sfj['ParentId']
       sf_parent = Stash::Salesforce.find(obj_type: 'Account', obj_id: sf_parent_id)
-      puts "SPONSOR MISMATCH for #{j.issn} -- #{j.sponsor&.name} -- #{sf_parent['Name']}" if j.sponsor&.name != sf_parent['Name']
+      puts "SPONSOR MISMATCH for #{j.single_issn} -- #{j.sponsor&.name} -- #{sf_parent['Name']}" if j.sponsor&.name != sf_parent['Name']
     end
     nil
   end

--- a/spec/factories/stash_engine/journals.rb
+++ b/spec/factories/stash_engine/journals.rb
@@ -3,7 +3,10 @@ FactoryBot.define do
   factory :journal, class: StashEngine::Journal do
 
     title { Faker::Company.industry }
-    issn { "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}" }
+    issn do
+      ["#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}",
+       "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}"]
+    end
     journal_code { Faker::Name.initials(number: 4) }
   end
 

--- a/spec/features/stash_datacite/manuscript_populate_metadata_spec.rb
+++ b/spec/features/stash_datacite/manuscript_populate_metadata_spec.rb
@@ -51,19 +51,6 @@ RSpec.feature 'Populate manuscript metadata from outside source', type: :feature
         .to_return(status: 200,
                    body: File.new(File.join(Rails.root, 'spec', 'fixtures', 'http_responses', 'crossref_response.json')),
                    headers: {})
-      stub_request(:get, 'https://api.datadryad.example.org/api/v1/journals/1742-5689')
-        .with(
-          headers: {
-            'Content-Type' => 'application/json'
-          }
-        )
-        .to_return(status: 200, body: {
-          fullName: 'Journal of The Royal Society Interface',
-          issn: '1742-5689',
-          allowReviewWorkflow: true,
-          allowEmbargo: true,
-          allowBlackout: false
-        }.to_json, headers: {})
 
       stub_request(:get, 'https://doi.org/10.1098/rsif.2017.0030').with(
         headers: { 'Host' => 'doi.org' }

--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -389,7 +389,7 @@ RSpec.feature 'Admin', type: :feature do
         res1 = create(:resource, identifier_id: ident1.id, user: @user, tenant_id: @admin.tenant_id)
         ident2 = create(:identifier)
         res2 = create(:resource, identifier_id: ident2.id, user: @user, tenant_id: @admin.tenant_id)
-        StashEngine::InternalDatum.create(identifier_id: ident1.id, data_type: 'publicationISSN', value: @journal.issn)
+        StashEngine::InternalDatum.create(identifier_id: ident1.id, data_type: 'publicationISSN', value: @journal.single_issn)
         StashEngine::InternalDatum.create(identifier_id: ident1.id, data_type: 'publicationName', value: @journal.title)
         ident1.reload
 

--- a/spec/models/stash_engine/journal_spec.rb
+++ b/spec/models/stash_engine/journal_spec.rb
@@ -5,6 +5,7 @@ module StashEngine
 
     before(:each) do
       @journal = create(:journal)
+      @journal2 = create(:journal)
     end
 
     describe '#find_by_title' do
@@ -32,6 +33,53 @@ module StashEngine
         expect(j).not_to eq(@journal)
       end
 
+    end
+
+    describe '#issn' do
+      before(:each) do
+        @issn1 = "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}"
+        @issn2 = "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}"
+        @issn3 = "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}"
+        @issn_distractor = "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}"
+      end
+
+      it 'finds by issn' do
+        @journal.update(issn: @issn1)
+        j = StashEngine::Journal.find_by_issn(@issn1)
+        expect(j).to eq(@journal)
+
+        j = StashEngine::Journal.find_by_issn(nil)
+        expect(j).to be(nil)
+
+        j = StashEngine::Journal.find_by_issn('notanumber')
+        expect(j).to be(nil)
+
+        j = StashEngine::Journal.find_by_issn(@issn_distractor)
+        expect(j).to be(nil)
+      end
+
+      it 'finds by issn when there are multiples' do
+        @journal.update(issn: [@issn1, @issn2, @issn3])
+        j = StashEngine::Journal.find_by_issn(@issn1)
+        expect(j).to eq(@journal)
+        j = StashEngine::Journal.find_by_issn(@issn2)
+        expect(j).to eq(@journal)
+        j = StashEngine::Journal.find_by_issn(@issn3)
+        expect(j).to eq(@journal)
+        j = StashEngine::Journal.find_by_issn(@issn_distractor)
+        expect(j).to be(nil)
+      end
+
+      it 'gets single_issn' do
+        @journal.update(issn: @issn1)
+        expect(@journal.single_issn).to eq(@issn1)
+
+        @journal.update(issn: [@issn2, @issn3])
+        expect(@journal.single_issn).to eq(@issn2)
+
+        @journal.update(issn: nil)
+        expect(@journal.single_issn).to be(nil)
+      end
     end
 
     describe '#will_pay?' do

--- a/spec/models/stash_engine/manuscript_spec.rb
+++ b/spec/models/stash_engine/manuscript_spec.rb
@@ -15,7 +15,7 @@ module StashEngine
 
       it 'turns a basic message into a manuscript' do
         content = "Journal Name: #{@journal.title}\n" \
-                  "Online ISSN: #{@journal.issn}\n" \
+                  "Online ISSN: #{@journal.single_issn}\n" \
                   "Article Status: accepted\n" \
                   "MS Reference Number: #{@ms_number}\n" \
                   "MS Title: #{@title}\n" \
@@ -50,7 +50,7 @@ module StashEngine
       end
 
       it 'provides an error when MS Number missing' do
-        content = "Online ISSN: #{@journal.issn}\n" \
+        content = "Online ISSN: #{@journal.single_issn}\n" \
                   "Article Status: accepted\n" \
                   "MS Title: #{@title}\n" \
                   'MS Authors: Lastname, Firstname; McOtherLastname, Somename'
@@ -62,7 +62,7 @@ module StashEngine
       end
 
       it 'provides an error when Title missing' do
-        content = "Online ISSN: #{@journal.issn}\n" \
+        content = "Online ISSN: #{@journal.single_issn}\n" \
                   "Article Status: accepted\n" \
                   "MS Reference Number: #{@ms_number}\n" \
                   'MS Authors: Lastname, Firstname; McOtherLastname, Somename'
@@ -74,7 +74,7 @@ module StashEngine
       end
 
       it 'provides an error when Author info missing' do
-        content = "Online ISSN: #{@journal.issn}\n" \
+        content = "Online ISSN: #{@journal.single_issn}\n" \
                   "Article Status: accepted\n" \
                   "MS Reference Number: #{@ms_number}\n" \
                   "MS Title: #{@title}\n"
@@ -86,7 +86,7 @@ module StashEngine
       end
 
       it 'provides an error when Article Status info missing' do
-        content = "Online ISSN: #{@journal.issn}\n" \
+        content = "Online ISSN: #{@journal.single_issn}\n" \
                   "MS Reference Number: #{@ms_number}\n" \
                   "MS Title: #{@title}\n" \
                   'MS Authors: Lastname, Firstname; McOtherLastname, Somename'

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -215,7 +215,7 @@ module StashEngine
       it 'returns true if admin for same journal' do
         journal = Journal.create(title: 'Test Journal', issn: '1234-4321')
         identifier = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI')
-        InternalDatum.create(identifier_id: identifier.id, data_type: 'publicationISSN', value: journal.issn)
+        InternalDatum.create(identifier_id: identifier.id, data_type: 'publicationISSN', value: journal.single_issn)
         resource = Resource.create(user_id: @user.id + 1, tenant_id: 'ucop', identifier_id: identifier.id)
         JournalRole.create(journal: journal, user: @user, role: 'admin')
 
@@ -432,7 +432,7 @@ module StashEngine
         journal = Journal.create(title: 'Test Journal', issn: '1234-4321')
         identifier = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI')
         identifier.update(pub_state: 'unpublished')
-        InternalDatum.create(identifier_id: identifier.id, data_type: 'publicationISSN', value: journal.issn)
+        InternalDatum.create(identifier_id: identifier.id, data_type: 'publicationISSN', value: journal.single_issn)
         resource = Resource.create(user_id: @user.id + 1, tenant_id: 'ucop', identifier_id: identifier.id)
         resource.update(file_view: false)
         JournalRole.create(journal: journal, user: @user, role: 'admin')
@@ -496,7 +496,7 @@ module StashEngine
         @resource.update(tenant_id: 'superca', meta_view: false, file_view: false)
         @user2 = StashEngine::User.create(first_name: 'Gorgonzola', last_name: 'Travesty', tenant_id: user.tenant_id, role: 'user')
         journal = Journal.create(title: 'Test Journal', issn: '1234-4321')
-        InternalDatum.create(identifier_id: @identifier.id, data_type: 'publicationISSN', value: journal.issn)
+        InternalDatum.create(identifier_id: @identifier.id, data_type: 'publicationISSN', value: journal.single_issn)
         JournalRole.create(journal: journal, user: @user2, role: 'admin')
 
         expect(@resource.may_view?(ui_user: @user2)).to be_truthy
@@ -1493,7 +1493,7 @@ module StashEngine
 
           it 'shows all resources to an admin for this journal' do
             journal = Journal.create(title: 'Test Journal', issn: '1234-4321')
-            InternalDatum.create(identifier_id: @identifier.id, data_type: 'publicationISSN', value: journal.issn)
+            InternalDatum.create(identifier_id: @identifier.id, data_type: 'publicationISSN', value: journal.single_issn)
             JournalRole.create(journal: journal, user: @user2, role: 'admin')
             resources = @identifier.resources.visible_to_user(user: @user2)
             expect(resources.count).to eq(3)

--- a/spec/requests/stash_api/datasets_controller_spec.rb
+++ b/spec/requests/stash_api/datasets_controller_spec.rb
@@ -135,7 +135,7 @@ module StashApi
                                              last_name: Faker::Name.last_name,
                                              email: Faker::Internet.email)
         @meta.add_field(field_name: 'userId', value: test_user.id)
-        @meta.add_field(field_name: 'publicationISSN', value: journal.issn)
+        @meta.add_field(field_name: 'publicationISSN', value: journal.single_issn)
         response_code = post '/api/v2/datasets', params: @meta.json, headers: default_authenticated_headers
         output = response_body_hash
         expect(response_code).to eq(201)
@@ -466,7 +466,7 @@ module StashApi
           user4 = create(:user, tenant_id: 'ucop', role: nil)
           journal = create(:journal)
           create(:journal_role, journal: journal, user: user4, role: 'admin')
-          create(:internal_datum, identifier_id: @identifiers[1].id, data_type: 'publicationISSN', value: journal.issn)
+          create(:internal_datum, identifier_id: @identifiers[1].id, data_type: 'publicationISSN', value: journal.single_issn)
           @doorkeeper_application = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
                                                                     owner_id: user4.id, owner_type: 'StashEngine::User')
           setup_access_token(doorkeeper_application: @doorkeeper_application)

--- a/spec/requests/stash_api/versions_controller_spec.rb
+++ b/spec/requests/stash_api/versions_controller_spec.rb
@@ -144,7 +144,7 @@ module StashApi
         @user2 = create(:user, tenant_id: @tenant_ids.first, role: nil)
         journal = create(:journal)
         create(:journal_role, journal: journal, user: @user2, role: 'admin')
-        create(:internal_datum, identifier_id: @identifier.id, data_type: 'publicationISSN', value: journal.issn)
+        create(:internal_datum, identifier_id: @identifier.id, data_type: 'publicationISSN', value: journal.single_issn)
         @doorkeeper_application2 = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
                                                                    owner_id: @user2.id, owner_type: 'StashEngine::User')
         access_token = get_access_token(doorkeeper_application: @doorkeeper_application2)

--- a/spec/services/stash_engine/email_parser_spec.rb
+++ b/spec/services/stash_engine/email_parser_spec.rb
@@ -48,8 +48,8 @@ module StashEngine
         journal = create(:journal)
         ms_number = "ms-#{Faker::Number.number(digits: 4)}"
         create(:internal_data, identifier_id: ident.id, data_type: 'manuscriptNumber', value: ms_number)
-        create(:internal_data, identifier_id: ident.id, data_type: 'publicationISSN', value: journal.issn)
-        content = "Online ISSN: #{journal.issn}\nMS Reference Number: #{ms_number}"
+        create(:internal_data, identifier_id: ident.id, data_type: 'publicationISSN', value: journal.single_issn)
+        content = "Online ISSN: #{journal.single_issn}\nMS Reference Number: #{ms_number}"
         parser = EmailParser.new(content: content)
         expect(parser.identifier).to eq(ident)
       end
@@ -61,13 +61,13 @@ module StashEngine
       end
 
       it 'finds journal from print ISSN' do
-        content = "Print ISSN: #{@journal.issn}"
+        content = "Print ISSN: #{@journal.single_issn}"
         parser = EmailParser.new(content: content)
         expect(parser.journal).to eq(@journal)
       end
 
       it 'finds journal from online ISSN' do
-        content = "Print ISSN: 1234-1234\nOnline ISSN: #{@journal.issn}"
+        content = "Print ISSN: 1234-1234\nOnline ISSN: #{@journal.single_issn}"
         parser = EmailParser.new(content: content)
         expect(parser.journal).to eq(@journal)
       end


### PR DESCRIPTION
Although most journals have a primary ISSN, there may be other ISSNs to distinguish print/online, to link the print/online versions, or to subsume ISSNs used by an older version of the journal. 

This update allows storing ISSNs either as a single string value (the old way) or an array of strings. No database migration is needed, because the current field already has enough space to store an array of 10 ISSNs.

This is changing the setting *only* for `Journal` objects. The `InternalData` objects will continue to use a single value, which will typically be the first ISSN found in a `Journal` object.
