### PR TITLE
Zenodo will not publish unchanged files

### DIFF
--- a/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -26,7 +26,7 @@ module Stash
       def self.standard_request(method, url, **args)
         retries = 0
 
-        # the zenodo copy so we can log all the requests to the database
+        # the zenodo copy so we can log all the requests to the database, zd_id is just to enable logging
         zen_copy = (StashEngine::ZenodoCopy.where(id: args[:zc_id]).first if args[:zc_id])
         args.delete(:zc_id)
 

--- a/lib/stash/zenodo_software/copier.rb
+++ b/lib/stash/zenodo_software/copier.rb
@@ -31,6 +31,7 @@ module Stash
     }.with_indifferent_access.freeze
 
     class Copier
+      ZC = Stash::ZenodoReplicate::ZenodoConnection
 
       # This is just a convenience method for manually testing without going through delayed_job, but may be useful
       # as a utility manually submit sometime in the future.
@@ -161,6 +162,10 @@ module Stash
         @deposit.update_metadata(dataset_type: @dataset_type, doi: @copy.software_doi)
         @deposit.publish if @resource.send(@resource_method).present_files.count > 0 # do not actually publish unless there are files
         @copy.update(state: 'finished', error_info: nil)
+      rescue Stash::ZenodoReplicate::ZenodoError => e
+        if e.message.include?('Validation error') && e.message.include?('files must differ from all previous versions')
+          revert_to_previous_version
+        end
       end
 
       # no files are changing, but a previous version should always exist
@@ -221,6 +226,30 @@ module Stash
       def submitted_before?
         !@previous_copy.nil?
       end
+
+      # this takes a deposit that hasn't changed and makes it the same deposition as the previous version to make Zenodo happy
+      def revert_to_previous_version
+        prev_res = @deposit.resource.previous_resource
+        prev_copy = prev_res.zenodo_copies.where(copy_type: @copy.copy_type).first
+        curr_deposition_id = @copy.deposition_id
+
+
+        # now set the information for these copy records to be the same deposition and software_doi as the previous version
+        @resource.zenodo_copies.where('copy_type like ?', "#{@dataset_type}%").each do |copy|
+          copy.update(deposition_id: prev_copy.deposition_id, software_doi: prev_copy.software_doi, note: 'no changes in this version')
+        end
+
+        # Delete an existing unpublished deposition resource. Note, only unpublished depositions may be deleted.
+        # DELETE /api/deposit/depositions/:id
+        # return code: 201 Created -- see https://developers.zenodo.org/#delete
+        ZC.standard_request(:delete, "#{ZC.base_url}/api/deposit/depositions/#{curr_deposition_id}", zc_id: @zc_id)
+
+        # also need to fix the related work since the deposition_id is changed
+        StashDatacite::RelatedIdentifier.set_latest_zenodo_relations(resource: @resource)
+
+        @copy.update(state: 'finished', error_info: 'Reverted to previous version because no files ultimately changed in this version.')
+      end
+
     end
   end
 end

--- a/lib/stash/zenodo_software/copier.rb
+++ b/lib/stash/zenodo_software/copier.rb
@@ -163,9 +163,7 @@ module Stash
         @deposit.publish if @resource.send(@resource_method).present_files.count > 0 # do not actually publish unless there are files
         @copy.update(state: 'finished', error_info: nil)
       rescue Stash::ZenodoReplicate::ZenodoError => e
-        if e.message.include?('Validation error') && e.message.include?('files must differ from all previous versions')
-          revert_to_previous_version
-        end
+        revert_to_previous_version if e.message.include?('Validation error') && e.message.include?('files must differ from all previous versions')
       end
 
       # no files are changing, but a previous version should always exist
@@ -232,7 +230,6 @@ module Stash
         prev_res = @deposit.resource.previous_resource
         prev_copy = prev_res.zenodo_copies.where(copy_type: @copy.copy_type).first
         curr_deposition_id = @copy.deposition_id
-
 
         # now set the information for these copy records to be the same deposition and software_doi as the previous version
         @resource.zenodo_copies.where('copy_type like ?', "#{@dataset_type}%").each do |copy|

--- a/spec/lib/stash/zenodo_software/copier_spec.rb
+++ b/spec/lib/stash/zenodo_software/copier_spec.rb
@@ -369,18 +369,20 @@ module Stash
               # resource 2 has a software and a software_publish copy, also.
               @zc.update(state: 'finished')
               @zc2 = create(:zenodo_copy, resource: @resource, identifier: @resource.identifier, copy_type: 'software_publish',
-                            deposition_id: @zc.deposition_id, state: 'finished', software_doi: "10.meow/zenodo.#{@zc.deposition_id}")
+                                          deposition_id: @zc.deposition_id, state: 'finished', software_doi: "10.meow/zenodo.#{@zc.deposition_id}")
 
               @resource2 = create(:resource, identifier: @resource.identifier)
               @zc3 = create(:zenodo_copy, resource: @resource2, identifier: @resource2.identifier, copy_type: 'software',
-                            deposition_id: @zc2.deposition_id + 1, state: 'finished', software_doi: "10.meow/zenodo.#{@zc.deposition_id + 1}")
+                                          deposition_id: @zc2.deposition_id + 1, state: 'finished',
+                                          software_doi: "10.meow/zenodo.#{@zc.deposition_id + 1}")
               @zc4 = create(:zenodo_copy, resource: @resource2, identifier: @resource2.identifier, copy_type: 'software_publish',
-                            deposition_id: @zc2.deposition_id + 1, state: 'finished', software_doi: "10.meow/zenodo.#{@zc.deposition_id + 1}" )
+                                          deposition_id: @zc2.deposition_id + 1, state: 'finished',
+                                          software_doi: "10.meow/zenodo.#{@zc.deposition_id + 1}")
               @zsc = Stash::ZenodoSoftware::Copier.new(copy_id: @zc4.id)
 
               @stub = stub_request(:delete, "https://sandbox.zenodo.org/api/deposit/depositions/#{@zc2.deposition_id + 1}?" \
-                'access_token=ThisIsAFakeToken').
-                to_return(status: 201, body: "", headers: {})
+                                            'access_token=ThisIsAFakeToken')
+                .to_return(status: 201, body: '', headers: {})
             end
 
             it 'reverts to a previous version' do


### PR DESCRIPTION
Sometimes people edit the files (software, supplemental) that they try to send to zenodo such as deleting files and then re-adding the same files again.  Zenodo will not accept these submissions as another version, even if metadata changed over time.

We don't really know until we publish again if the files at zenodo will change and we try to replicated each version's changes as they come in.  We only know upon publication if we can have a new version at zenodo or not.

If files haven't changed then we just revert all the latest copy "changes" to match the previous deposit at zenodo since we can't add another version.

To test:

1. Add some software (or supplemental) files and publish.
2. Make some more versions, such as not making up your mind and removing a file in one version and then re-adding the file you removed in another subsequent version.
3. Publish the dataset again.
4. It should finish successfully and if you look at zenodo after publication, it should have reverted the new deposition ID and software doi in the ZenodoCopies table to be the same as the previous one.  It should also have removed the in-progress version from the zenodo site.

This should save us from having to correct this problem manually when it happens a few times a month or so.