### PR TITLE
Set pub_state to 'unpublished' when entering PPR

### DIFF
--- a/app/models/stash_engine/curation_activity.rb
+++ b/app/models/stash_engine/curation_activity.rb
@@ -97,7 +97,7 @@ module StashEngine
     after_create :email_orcid_invitations,
                  if: proc { |ca| ca.published? && latest_curation_status_changed? && !resource.skip_emails }
 
-    after_create :update_publication_flags, if: proc { |ca| %w[published embargoed withdrawn].include?(ca.status) }
+    after_create :update_publication_flags, if: proc { |ca| %w[published embargoed peer_review withdrawn].include?(ca.status) }
 
     after_create :update_salesforce_metadata, if: proc { |_ca|
                                                     latest_curation_status_changed? &&
@@ -287,17 +287,22 @@ module StashEngine
       case status
       when 'withdrawn'
         resource.update_columns(meta_view: false, file_view: false)
+        target_pub_state = 'withdrawn'
+      when 'peer_review'
+        target_pub_state = 'unpublished'
       when 'embargoed'
         resource.update_columns(meta_view: true, file_view: false)
+        target_pub_state = 'embargoed'
       when 'published'
         resource.update_columns(meta_view: true, file_view: true)
+        target_pub_state = 'published'
       end
 
       return if resource&.identifier.nil?
 
-      resource.identifier.update_column(:pub_state, status)
+      resource.identifier.update_column(:pub_state, target_pub_state)
 
-      return if %w[withdrawn embargoed].include?(status)
+      return if %w[withdrawn embargoed peer_review].include?(status)
 
       # find out if there were not file changes since last publication and reset file_view, if so.
       changed = false # want to see that none are changed


### PR DESCRIPTION
Improve setting of the `pub_state`. When a user's dataset is withdrawn automatically based on notification from a journal, we want the user to be able to submit the dataset to PPR again and have the review link work.

To test: 
1. Create a dataset and put it in PPR
2. As a curator, set the status to `withdrawn`. Note that the `pub_state` also goes to `withdrawn` automatically, and the sharing link stops working, which is correct.
3. As the submitter, submit a new version of the dataset and send it to PPR again.
4. Verify that `pub_state` is `unpublished`, and the sharing link works again.
