### PR TITLE
Refine definition of ppr_to_curation

### DIFF
--- a/app/models/stash_engine/curation_stats.rb
+++ b/app/models/stash_engine/curation_stats.rb
@@ -40,10 +40,6 @@ module StashEngine
       populate_author_versioned
     end
 
-    def rp
-      populate_ppr_to_curation
-    end
-
     private
 
     # The number processed (meaning the status changed from 'curation' to 'action_required', 'embargoed' or 'published')

--- a/app/views/stash_engine/curation_stats/index.html.erb
+++ b/app/views/stash_engine/curation_stats/index.html.erb
@@ -29,7 +29,7 @@
 	  class="c-admin-table">New Datasets to Submitted</th>
       <th title="The number of new PPR that day (so the first time we see them as 'peer_review' in the system)"
 	  class="c-admin-table">New Datasets to Peer Review</th>
-      <th title="The number released from PPR into Curation (status change from 'peer_review' to 'curation')"
+      <th title="The number released from PPR into Curation (status change to 'curation', and had previously been in PPR with no intervening 'curation')"
 	  class="c-admin-table">PPR to Curation</th>
       <th title="The number AAR'd that day (status change from 'curation' to 'action_required')"
 	  class="c-admin-table">Datasets to AAR</th>


### PR DESCRIPTION
Update calculation of the curation statistic ppr_to_curation. Instead of being a naive stat like the others, the new definition takes into account the transitions that occur most commonly when datasets are taken out of PPR.

This will count a dataset as transitioning from PPR to Curation when any of the following workflows occur:
- auto-released to curation upon receipt of journal accept notification
  - starts with PPR
  - has one or more Submitted statuses
  - eventually ends in curation
- manually released by the author
  - starts with PPR
  - goes to In progress as the author creates a new version
  - has one or more Submitted statuses
  - eventually ends in curation
- manually released by a curator
  - starts with PPR
  - goes directly to curation
  - (this is the only type of transition that was counted in the previous configuration)

To test, it is best to have no datasets that have transitioned into curation on a given day. Then, create a dataset and move it to Curation status using one of the methods listed above. In Rails console, use commands like this to verify that the dataset was found and counted:
```
s=StashEngine::CurationStats.find_or_create_by(date: '2023-02-10')
s.recalculate
s.ppr_to_curation  #should show the number of datasets that you transitioned from PPR to curation on this day
```