### PR TITLE
Adding migration to store container_contents as json

### DIFF
--- a/db/migrate/20230303003530_update_generic_files_with_container_contents_json.rb
+++ b/db/migrate/20230303003530_update_generic_files_with_container_contents_json.rb
@@ -1,0 +1,5 @@
+class UpdateGenericFilesWithContainerContentsJson < ActiveRecord::Migration[6.1]
+  def change
+    add_column :stash_engine_generic_files, :container_contents, :json
+  end
+end


### PR DESCRIPTION
This is a simple change.  There is a JSON database field type for container_contents on generic file model.  I didn't think it was worth creating a new table just for this one new field.

I attempted to follow the pattern at https://www.keypup.io/blog/embedded-associations-in-rails-using-json-fields which seems like a nice way to ensure better data consistency.  I had to delete the extra classes and revert since it doesn't work with our models, maybe because we're using Single Table Inheritance (and we also have nil values some places and not every file has this set).

Data would be like:

```
[
  {
    "name": "karen.xls",
    "size": 12355
  },
  {
    "name": "scan/head.fasta",
    "size": 3873837833
  }
]
```