### PR TITLE
Prefill journal info and import manuscript using URL parameters

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -464,7 +464,7 @@ Rails.application.routes.draw do
   get '/themes/Dryad/images/:image', to: redirect('/images/%{image}')
   get '/themes/Dryad/images/dryadLogo.png', to: redirect('/images/logo_dryad.png')
   get '/themes/Mirage/docs/:doc', to: redirect('/docs/%{doc}.%{format}')
-  get '/submit', to: redirect("/stash/resources/new")
+  get '/submit', to: redirect { |params, request| "/stash/resources/new?#{request.params.to_query}" }
   
   # Routing to redirect old Dryad landing pages to the correct location
   # Regex based on https://www.crossref.org/blog/dois-and-matching-regular-expressions/ but a little more restrictive specific to old dryad


### PR DESCRIPTION
I thought this issue had been fixed. Instead, the feature had never been finished, and the many tickets filed over the years had been removed from the board with the assumption that it was working. Grrrr.

Related tickets include:
- https://github.com/CDL-Dryad/dryad-product-roadmap/issues/456
- https://github.com/CDL-Dryad/dryad-product-roadmap/issues/534
- https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1815
- https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2230
- https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2231

To test:
- Find a Manuscript in the database. If you don't have one, it's best to copy the metadata hash from another instance of Dryad. Otherwise you will need to follow the complicated process of creating and processing an email as described in https://github.com/CDL-Dryad/dryad-app/blob/main/documentation/apis/journals.md
- Determine the Journal associated with the Manuscript and its `journal_code`
- Construct a URL that looks like this: `http://<server_name>/submit?journalID=<journal_code>&manu=<manuscript_number>`
- When you resolve the URL, it should create a new dataset, fill in the journal's name, and prefill any metadata from the Manuscript object.