### PR TITLE
Reduce frequency of DB backup checker

### DIFF
--- a/app/services/stash_engine/status_dashboard/db_backup_service.rb
+++ b/app/services/stash_engine/status_dashboard/db_backup_service.rb
@@ -26,7 +26,7 @@ module StashEngine
           end
         end
 
-        online = last_run_date >= (Time.now - 45.minutes)
+        online = last_run_date >= (Time.now - 90.minutes)
 
         msg = "The database backup service last ran at '#{last_run_date}'. " unless online
         record_status(online: online, message: msg)


### PR DESCRIPTION
We changed database backups from every 30 minutes to every hour in #981. This aligns the status checker with that change, only throwing an alert if the last backup is more than 90 minutes old.