### PR TITLE
Improve sorting for reports of tiered payment plans

### DIFF
--- a/app/models/stash_engine/journal_organization.rb
+++ b/app/models/stash_engine/journal_organization.rb
@@ -6,8 +6,33 @@ module StashEngine
     # Treat the 'type' column as a string, not a single-inheritance class name
     self.inheritance_column = :_type_disabled
 
+    # journals sponsored directly by this org
     def journals_sponsored
       StashEngine::Journal.where(sponsor_id: id)
+    end
+
+    # journals sponsored at any level by this org and its children
+    def journals_sponsored_deep
+      j = StashEngine::Journal.where(sponsor_id: id)
+      orgs_included&.each do |suborg|
+        j += suborg.journals_sponsored
+      end
+      j
+    end
+
+    # All organizations that are part of this organization,
+    # at any level of hierarchy
+    def orgs_included
+      suborgs = StashEngine::JournalOrganization.where(parent_org: id)
+      return nil if suborgs.blank?
+
+      all_orgs = []
+
+      suborgs.each do |sub|
+        all_orgs << sub
+        all_orgs += sub.orgs_included if sub.orgs_included.present?
+      end
+      all_orgs
     end
   end
 end

--- a/app/views/layouts/_members_publishers.html.md
+++ b/app/views/layouts/_members_publishers.html.md
@@ -1,5 +1,5 @@
 <ul class="member-list">
-  <li>American Academy for the Advancement of Science</li>
+  <li>American Association for the Advancement of Science</li>
   <li>American Genetic Association</li>
   <li>American Geophysical Union</li>
   <li>American Medical Informatics Association</li>

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -593,10 +593,10 @@ namespace :identifiers do
     CSV.open(tiered_filename, 'w') do |csv|
       csv << %w[SponsorName JournalName Count Price]
       sponsor_summary = []
-      StashEngine::JournalOrganizations.each do |org|
+      StashEngine::JournalOrganization.all.each do |org|
         journals = org.journals_sponsored_deep
         journals.each do |j|
-          next unless j.payment_plan_type == 'TIERED'
+          next unless j.payment_plan_type == 'TIERED' && j.top_level_org == org
 
           journal_item_count = 0
           sc_report.each do |item|
@@ -607,10 +607,11 @@ namespace :identifiers do
           end
           csv << [org.name, j.title, journal_item_count, tiered_price(journal_item_count)]
         end
-        unless sponsor_summary.blank?
-          write_tiered_sponsor_summary(name: org.name, file_prefix: prefix, report_period: time_period,
-                                       table: sponsor_summary)
-        end
+        next if sponsor_summary.blank?
+
+        write_tiered_sponsor_summary(name: org.name, file_prefix: prefix, report_period: time_period,
+                                     table: sponsor_summary)
+        sponsor_summary = []
       end
     end
 

--- a/spec/models/stash_engine/journal_organization_spec.rb
+++ b/spec/models/stash_engine/journal_organization_spec.rb
@@ -9,18 +9,77 @@ module StashEngine
     end
 
     describe 'journals_sponsored' do
-      it 'returns nil when there are none' do
+      it 'returns blank when there are none' do
         expect(@org.journals_sponsored).to be_blank
       end
 
       it 'returns sponsored journals with a direct relationship' do
-        user = create(:user)
         journal = create(:journal, sponsor: @org)
-        create(:journal_role, journal: nil, journal_organization: @org, user: user, role: 'org_admin')
         expect(@org.journals_sponsored.size).to eq(1)
         expect(@org.journals_sponsored.first).to eq(journal)
       end
+    end
 
+    describe 'journals_sponsored_deep' do
+      it 'returns blank when there are none' do
+        expect(@org.journals_sponsored_deep).to be_blank
+      end
+
+      it 'returns sponsored journals with a direct relationship' do
+        journal = create(:journal, sponsor: @org)
+        found_journals = @org.journals_sponsored_deep
+        expect(found_journals.size).to eq(1)
+        expect(found_journals.first).to eq(journal)
+      end
+
+      it 'returns sponsored journals with a deep relationship' do
+        journal = create(:journal, sponsor: @org)
+        suborg = build(:journal_organization)
+        suborg.update(parent_org: @org)
+        subjournal = create(:journal, sponsor: suborg)
+        suborg2 = build(:journal_organization)
+        suborg2.update(parent_org: @org)
+        subjournal2 = create(:journal, sponsor: suborg2)
+        subsuborg = build(:journal_organization)
+        subsuborg.update(parent_org: suborg)
+        subsubjournal = create(:journal, sponsor: subsuborg)
+
+        found_journals = @org.journals_sponsored_deep
+        expect(found_journals.size).to eq(4)
+        expect(found_journals).to include(journal)
+        expect(found_journals).to include(subjournal)
+        expect(found_journals).to include(subjournal2)
+        expect(found_journals).to include(subsubjournal)
+      end
+    end
+
+    describe 'orgs_included' do
+      it 'returns blank when there are none' do
+        expect(@org.orgs_included).to be_blank
+      end
+
+      it 'returns direct sub-orgs' do
+        suborg = build(:journal_organization)
+        suborg.update(parent_org: @org)
+        found_suborgs = @org.orgs_included
+        expect(found_suborgs.size).to be(1)
+        expect(found_suborgs.first).to eq(suborg)
+      end
+
+      it 'returns deeper sub-orgs' do
+        suborg = build(:journal_organization)
+        suborg.update(parent_org: @org)
+        suborg2 = build(:journal_organization)
+        suborg2.update(parent_org: @org)
+        subsuborg = build(:journal_organization)
+        subsuborg.update(parent_org: suborg)
+
+        found_suborgs = @org.orgs_included
+        expect(found_suborgs&.size).to be(3)
+        expect(found_suborgs).to include(suborg)
+        expect(found_suborgs).to include(suborg2)
+        expect(found_suborgs).to include(subsuborg)
+      end
     end
 
   end


### PR DESCRIPTION
Update the process for navigating the sponsor relationships when calculating results for tiered payment plans (#1114). This allows both hierarchical plans (Wiley) and flat plans (AAAS). The old process would not work, because it used a bottom-up approach, with journal IDs for ordering, so the flat organization could sort between some groups of the hierarchical organization. The result would be that the hierarchical organization would end up with two separate reports.

The new process uses top-down navigation, allowing each organization to complete before processing moves on to other organizations. 

Testing this is unfortunately complex. Ensure you have at least one organization with multiple sub-organizations, where the sub-organizations sponsor journals on a tiered plan. Ensure these journals have at least one dataset published in a given month, then run reports for the month, like:
```
rails identifiers:shopping_cart_report YEAR_MONTH=2023-01
rails identifiers:tiered_journal_reports SC_REPORT=shopping_cart_report_2023-01.csv
```