### PR TITLE
Don't insert container file contents if there is nothing to insert

### DIFF
--- a/app/models/stash_engine/data_file.rb
+++ b/app/models/stash_engine/data_file.rb
@@ -106,7 +106,7 @@ module StashEngine
       to_insert = old_files.first.container_files.map do |container_file|
         { data_file_id: id, path: container_file.path, mime_type: container_file.mime_type, size: container_file.size }
       end
-      StashEngine::ContainerFile.insert_all(to_insert)
+      StashEngine::ContainerFile.insert_all(to_insert) unless to_insert.blank?
     end
 
     # makes list of directories with numbers. not modified for > 7 days, and whose corresponding resource has been successfully submitted


### PR DESCRIPTION
From `data_file.rb:109` add an `unless` at end of line to ignore inserting if the array is blank.

Inserting an empty array returns an error and it can be ignored.  I already put these extra 15 characters or so on production manually.  If we re-release then we'll want to include this in the release.

