### PR TITLE
Improve ISSN handling for journal administrators in API

### DIFF
--- a/app/controllers/stash_api/datasets_controller.rb
+++ b/app/controllers/stash_api/datasets_controller.rb
@@ -556,7 +556,7 @@ module StashApi
 
       unless @user.role == 'superuser' ||
              params['userId'].to_i == @user.id || # or it is your own user
-             @user.journals_as_admin&.map(&:issn)&.include?(params['dataset']['publicationISSN']) # or you admin the target journal
+             @user.journals_as_admin&.map(&:issn_array)&.flatten&.include?(params['dataset']['publicationISSN']) # or you admin the target journal
         render json: { error: 'Unauthorized: only superusers and journal administrators may set a specific user' }.to_json, status: 401
         false
       end

--- a/app/models/stash_engine/journal.rb
+++ b/app/models/stash_engine/journal.rb
@@ -32,6 +32,15 @@ module StashEngine
       issn
     end
 
+    # Return an array of ISSNs, even if the journal contains a single ISSN
+    def issn_array
+      return nil unless issn.present?
+      return issn if issn.is_a?(Array)
+      return JSON.parse(issn) if issn.start_with?('[')
+
+      [issn]
+    end
+
     def self.find_by_title(title)
       return unless title.present?
 

--- a/documentation/apis/embedded_submission.md
+++ b/documentation/apis/embedded_submission.md
@@ -99,7 +99,7 @@ A sample call using the [sample dataset file](sample_dataset.json), with results
   "curationStatus": "In Progress",
   "lastModificationDate": "2020-10-02",
   "visibility": "restricted",
-  "userId": 37182,
+  "userId": "0000-0003-0597-4085",
   "license": "https://creativecommons.org/publicdomain/zero/1.0/",
   "editLink": "/stash/edit/doi%3A10.7959%2Fdryad.83bk3jc0"
   }

--- a/spec/models/stash_engine/journal_spec.rb
+++ b/spec/models/stash_engine/journal_spec.rb
@@ -80,6 +80,17 @@ module StashEngine
         @journal.update(issn: nil)
         expect(@journal.single_issn).to be(nil)
       end
+
+      it 'gets issn_array' do
+        @journal.update(issn: @issn1)
+        expect(@journal.issn_array).to eq([@issn1])
+
+        @journal.update(issn: [@issn2, @issn3])
+        expect(@journal.issn_array).to eq([@issn2, @issn3])
+
+        @journal.update(issn: nil)
+        expect(@journal.issn_array).to be(nil)
+      end
     end
 
     describe '#will_pay?' do


### PR DESCRIPTION
Journal administrators complained that they did not have the permissions to submit datasets for their journal. The root cause of this problem was the API failing to properly decode an array of ISSNs when computing permissions.

This PR adds a new method to the Journal model, `issn_array`, which forces the ISSNs to be returned in an array (rather than a string that looks like an array), so it can be more easily handled by the code that calculates permissions.