### PR TITLE
Encoding of + signs not working

### DIFF
--- a/lib/stash/compressed/s3_size.rb
+++ b/lib/stash/compressed/s3_size.rb
@@ -1,6 +1,9 @@
 module Stash
   module Compressed
     module S3Size
+      BASE_HTTP = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
+                      .timeout(connect: 30, read: 180, write: 180).follow(max_hops: 10)
+
       # size and calc_size are the same as in ZipInfo maybe split into a base class or module
       def size
         @size ||= calc_size
@@ -8,7 +11,7 @@ module Stash
 
       def calc_size
         # the presigned URLs are only authorized as get requests, not head, so must do GET for size
-        http = HTTP.headers('Range' => 'bytes=0-0').get(@presigned_url)
+        http = BASE_HTTP.headers('Range' => 'bytes=0-0').get(@presigned_url)
         raise Stash::Compressed::InvalidResponse, "Status code #{http.code} returned for GET range 0-0 for #{@presigned_url}" if http.code > 399
 
         info = http.headers['Content-Range']

--- a/lib/stash/compressed/s3_size.rb
+++ b/lib/stash/compressed/s3_size.rb
@@ -2,7 +2,7 @@ module Stash
   module Compressed
     module S3Size
       BASE_HTTP = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
-                      .timeout(connect: 30, read: 180, write: 180).follow(max_hops: 10)
+        .timeout(connect: 30, read: 180, write: 180).follow(max_hops: 10)
 
       # size and calc_size are the same as in ZipInfo maybe split into a base class or module
       def size

--- a/lib/stash/compressed/tar_gz.rb
+++ b/lib/stash/compressed/tar_gz.rb
@@ -32,7 +32,7 @@ module Stash
         begin
           file_info = []
           # streams the response body in chunks
-          response = HTTP.get(@presigned_url)
+          response = BASE_HTTP.get(@presigned_url)
 
           raise HTTP::Error, "Bad status code #{response&.status&.code}" unless response.status.ok?
 

--- a/lib/stash/compressed/zip_info.rb
+++ b/lib/stash/compressed/zip_info.rb
@@ -128,7 +128,7 @@ module Stash
 
       def fetch(start:, length:)
         the_end = start + length - 1
-        http = HTTP.headers('Range' => "bytes=#{start}-#{the_end}").get(@presigned_url)
+        http = BASE_HTTP.headers('Range' => "bytes=#{start}-#{the_end}").get(@presigned_url)
         raise Stash::Compressed::InvalidResponse if http.code > 399
 
         http.body.to_s


### PR DESCRIPTION
This turned out to be the default HTTP.rb url normalizer again.  Changed it out for a better one.  Also added  a rake task for testing an individual file that has errored.

You can see items that didn't work and now do at https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2424 .

Example to test population:

`RAILS_ENV=production rails compressed:update_one 3868`