### PR TITLE
uninitialized constant for compressed error fix (compressed files)

### DIFF
--- a/lib/stash/compressed.rb
+++ b/lib/stash/compressed.rb
@@ -1,5 +1,6 @@
 module Stash
   module Compressed
+    class Error < StandardError; end
     Dir.glob(File.expand_path('compressed/*.rb', __dir__)).each(&method(:require))
   end
 end

--- a/lib/stash/compressed/s3_size.rb
+++ b/lib/stash/compressed/s3_size.rb
@@ -1,6 +1,9 @@
 module Stash
   module Compressed
     module S3Size
+      BASE_HTTP = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
+        .timeout(connect: 30, read: 180, write: 180).follow(max_hops: 10)
+
       # size and calc_size are the same as in ZipInfo maybe split into a base class or module
       def size
         @size ||= calc_size
@@ -8,7 +11,7 @@ module Stash
 
       def calc_size
         # the presigned URLs are only authorized as get requests, not head, so must do GET for size
-        http = HTTP.headers('Range' => 'bytes=0-0').get(@presigned_url)
+        http = BASE_HTTP.headers('Range' => 'bytes=0-0').get(@presigned_url)
         raise Stash::Compressed::InvalidResponse, "Status code #{http.code} returned for GET range 0-0 for #{@presigned_url}" if http.code > 399
 
         info = http.headers['Content-Range']

--- a/lib/stash/compressed/tar_gz.rb
+++ b/lib/stash/compressed/tar_gz.rb
@@ -32,7 +32,7 @@ module Stash
         begin
           file_info = []
           # streams the response body in chunks
-          response = HTTP.get(@presigned_url)
+          response = BASE_HTTP.get(@presigned_url)
 
           raise HTTP::Error, "Bad status code #{response&.status&.code}" unless response.status.ok?
 

--- a/lib/tasks/compressed/info.rb
+++ b/lib/tasks/compressed/info.rb
@@ -5,9 +5,9 @@ module Tasks
       # maps into container_contents format, using appropriate compressed processor, eliminates directory entries and returns array of hashes
       def self.files(db_file:)
         entries =
-          if db_file.upload_file_name.end_with?('.zip')
+          if db_file.upload_file_name.downcase.end_with?('.zip')
             Stash::Compressed::ZipInfo.new(presigned_url: db_file.merritt_s3_presigned_url).file_entries
-          elsif db_file.upload_file_name.end_with?('.tar.gz') || db_file.upload_file_name.end_with?('.tgz')
+          elsif db_file.downcase.upload_file_name.downcase.end_with?('.tar.gz', '.tgz')
             Stash::Compressed::TarGz.new(presigned_url: db_file.merritt_s3_presigned_url).file_entries
           else
             raise Stash::Compressed::Error, "Unknown file type for #{db_file.upload_file_name}"


### PR DESCRIPTION
- Adds error constant that didn't exist
- Make file extension case insensitive, even though traditionally most extensions are lowercase