### PR TITLE
Simplify merritt credentials

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'aws-sdk-s3', '~> 1.113'
 gem 'blacklight'
 gem 'bootsnap', require: false
 gem 'bootstrap', '~> 4.0'
+gem 'charlock_holmes', '~> 0.7.7'
 gem 'concurrent-ruby', '~> 1.1.10'
 gem 'daemons', '~> 1.4.1'
 gem 'database_cleaner', '~> 2.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,7 @@ GEM
     capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
+    charlock_holmes (0.7.7)
     coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -804,6 +805,7 @@ DEPENDENCIES
   capistrano-rails (~> 1.6.2)
   capybara
   capybara-screenshot
+  charlock_holmes (~> 0.7.7)
   coffee-rails (~> 5.0)
   colorize
   concurrent-ruby (~> 1.1.10)

--- a/app/mailers/stash_engine/user_mailer.rb
+++ b/app/mailers/stash_engine/user_mailer.rb
@@ -11,7 +11,7 @@ module StashEngine
       return unless @user.present? && user_email(@user).present?
 
       mail(to: user_email(@user),
-           bcc: status == 'published' ? @resource&.tenant&.campus_contacts : '',
+           bcc: @resource&.tenant&.campus_contacts,
            template_name: status,
            subject: "#{rails_env}Dryad Submission \"#{@resource.title}\"")
 
@@ -26,6 +26,7 @@ module StashEngine
       return unless @user.present? && user_email(@user).present?
 
       mail(to: user_email(@user),
+           bcc: @resource&.tenant&.campus_contacts,
            template_name: withdrawn_by_journal,
            subject: "#{rails_env}Dryad Submission \"#{@resource.title}\"")
 

--- a/app/models/stash_engine/data_file.rb
+++ b/app/models/stash_engine/data_file.rb
@@ -45,7 +45,7 @@ module StashEngine
 
       http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
         .timeout(connect: 10, read: 10).timeout(10).follow(max_hops: 2)
-        .basic_auth(user: resource.tenant.repository.username, pass: resource.tenant.repository.password)
+        .basic_auth(user: APP_CONFIG[:repository][:username], pass: APP_CONFIG[:repository][:password])
 
       r = http.get(merritt_presign_info_url)
 

--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -509,7 +509,7 @@ module StashEngine
     # Info about dataset object from Merritt. See spec/fixtures/merritt_local_id_search_response.json for an example.
     # Currently used for checking if things have gone into Merritt yet, but may be used for other purposes in the future.
     def merritt_object_info
-      repo = latest_resource.tenant.repository
+      repo = APP_CONFIG[:repository]
       collection = repo.endpoint.match(%r{[^/]+$}).to_s
       enc_doi = ERB::Util.url_encode(to_s)
       resp = HTTP.basic_auth(user: repo.username, pass: repo.password)

--- a/app/models/stash_engine/repo_queue_state.rb
+++ b/app/models/stash_engine/repo_queue_state.rb
@@ -83,7 +83,7 @@ module StashEngine
       # this is a guard against setting something completed that isn't and that will make this method fail
       return false unless available_in_merritt? # this also sets @mrt_results member variable so we don't have to redo the query again
 
-      merritt_id = "#{resource.tenant.repository.domain}/d/#{@mrt_results['ark']}"
+      merritt_id = "#{APP_CONFIG[:repository][:domain]}/d/#{@mrt_results['ark']}"
       StashEngine.repository.harvested(identifier: resource.identifier, record_identifier: merritt_id)
 
       if StashEngine::RepoQueueState.where(resource_id: resource_id, state: 'completed').count < 1

--- a/app/models/stash_engine/tenant.rb
+++ b/app/models/stash_engine/tenant.rb
@@ -65,15 +65,6 @@ module StashEngine
       "https://#{Rails.application.default_url_options[:host]}#{APP_CONFIG.stash_mount}/auth/"
     end
 
-    def sword_params
-      repository = self.repository
-      {
-        collection_uri: repository.endpoint,
-        username: repository.username,
-        password: repository.password
-      }
-    end
-
     def self.exists?(tenant_id)
       TENANT_CONFIG.key?(tenant_id)
     end

--- a/app/services/stash_engine/status_dashboard/download_service.rb
+++ b/app/services/stash_engine/status_dashboard/download_service.rb
@@ -15,7 +15,7 @@ module StashEngine
         record_status(online: false, message: 'No dataset available for download to perform test') unless identifier.present?
         resource = identifier.resources.where.not(download_uri: nil).order(:id).last
 
-        client = Stash::Repo::HttpClient.new(tenant: resource.tenant, cert_file: APP_CONFIG.ssl_cert_file).client
+        client = Stash::Repo::HttpClient.new(cert_file: APP_CONFIG.ssl_cert_file).client
         resp = client.head(resource.download_uri, follow_redirect: true)
         online = resp.code == 200
         msg = "Merritt Download service is reporting an HTTP #{resp.code}!" unless online

--- a/app/views/stash_engine/submission_queue/index.html.erb
+++ b/app/views/stash_engine/submission_queue/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Merrit submission queue</h1>
+<h1>Merritt submission queue</h1>
 <div id="status_table" data-load="<%= stash_url_helpers.url_for(controller: 'stash_engine/submission_queue', action: 'refresh_table', params: sortable_table_params, only_path: true) %>">
   <%# render partial: 'status_table' %>
   <%= image_tag 'stash_engine/spinner.gif', size: '80x60', alt: 'Loading spinner' %>

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -12,6 +12,11 @@ defaults: &DEFAULTS
     port: 443
   contact_us_uri: help@datadryad.org
   # sandbox orcid credentials
+  repository:
+    domain: https://merritt-stage.cdlib.org
+    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
+    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
+    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   orcid:
     site: https://sandbox.orcid.org/
     authorize_url: https://sandbox.orcid.org/oauth/authorize
@@ -258,6 +263,11 @@ stage:
   page_error_email: [scott.fisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
   feedback_email_from: no-reply-dryad-stg@datadryad.org
   google_analytics_id: UA-145629338-3
+  repository:
+    domain: https://merritt-stage.cdlib.org
+    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
+    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
+    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
   s3:
     region: us-west-2
     bucket: dryad-s3-stg
@@ -297,6 +307,11 @@ production:
   zenodo_error_email: [sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
   helpdesk_email: help@datadryad.org
   feedback_email_from: no-reply-dryad@datadryad.org
+  repository:
+    domain: https://merritt.cdlib.org
+    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
+    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
+    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   # orcid production credentials
   orcid:
     site: https://orcid.org/

--- a/config/tenants/awri.yml
+++ b/config/tenants/awri.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "awri"
   short_name: "Australian Wine Research Institute"
   long_name: "Australian Wine Research Institute"
@@ -41,20 +36,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/clare-cgu.yml
+++ b/config/tenants/clare-cgu.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "CGU"
   short_name: "Claremont Graduate University"
   long_name: "Claremont Graduate University"
@@ -42,20 +37,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/clare-cmc.yml
+++ b/config/tenants/clare-cmc.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "CMC"
   short_name: "Claremont McKenna College"
   long_name: "Claremont McKenna College"
@@ -42,11 +37,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -58,11 +48,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/clare-cs.yml
+++ b/config/tenants/clare-cs.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "CCS-TCCS"
   short_name: "Claremont College Services (TCCS)"
   long_name: "Claremont College Services (TCCS)"
@@ -50,11 +45,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -66,11 +56,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/clare-hmc.yml
+++ b/config/tenants/clare-hmc.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "HMC"
   short_name: "Harvey Mudd College"
   long_name: "Harvey Mudd College"
@@ -42,11 +37,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -58,11 +48,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/clare-kgi.yml
+++ b/config/tenants/clare-kgi.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "KGI"
   short_name: "Keck Graduate Institute"
   long_name: "Keck Graduate Institute"
@@ -42,11 +37,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -58,11 +48,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/clare-pitzer.yml
+++ b/config/tenants/clare-pitzer.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "Pitzer"
   short_name: "Pitzer College"
   long_name: "Pitzer College"
@@ -42,11 +37,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -58,11 +48,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/clare-pomona.yml
+++ b/config/tenants/clare-pomona.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "Pomona"
   short_name: "Pomona College"
   long_name: "Pomona College"
@@ -42,11 +37,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -58,11 +48,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/clare-scripps.yml
+++ b/config/tenants/clare-scripps.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "Scripps College"
   short_name: "Scripps College"
   long_name: "Scripps College"
@@ -42,11 +37,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 demo:
   <<: *default
@@ -54,11 +44,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/colostate.yml
+++ b/config/tenants/colostate.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "colostate"
   short_name: "Colorado State University"
   long_name: "Colorado State University"
@@ -42,20 +37,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/columbia.yml
+++ b/config/tenants/columbia.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "Columbia"
   short_name: "Columbia University"
   long_name: "Columbia University in the City of New York"
@@ -43,11 +38,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -59,11 +49,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/csueb.yml
+++ b/config/tenants/csueb.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "CSUEB"
   short_name: "Cal State East Bay"
   long_name: "California State University, East Bay"
@@ -42,11 +37,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 demo:
   <<: *default
@@ -54,11 +44,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/dataone.yml
+++ b/config/tenants/dataone.yml
@@ -1,11 +1,6 @@
 # I think we need to keep UC Press and DataONE (but disabled) for the DOI metadata update info in here
 default: &default
   enabled: false
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/dataone_dash"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "DataONE"
   short_name: "DataONE"
   long_name: "DataONE"
@@ -43,11 +38,6 @@ demo:
 production:
   <<: *default
   manager_email: [""]
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/dataone_dash"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.15146"

--- a/config/tenants/dri.yml
+++ b/config/tenants/dri.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "DRI"
   short_name: "Desert Research Institute"
   long_name: "Desert Research Institute"
@@ -42,11 +37,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
@@ -55,11 +45,6 @@ production:
     strategy: shibboleth
     entity_id: http://www.okta.com/exkh1l6ocbKBRm4RB1t7
     entity_domain: www.okta.com
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/dryad.yml
+++ b/config/tenants/dryad.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "dryad"
   short_name: "Dryad"
   long_name: "Dryad Data Platform"
@@ -30,7 +25,6 @@ development: &DEVELOPMENT
   <<: *default
   #Add any items that need to override the defaults here
 
-
 local_dev:
   <<: *DEVELOPMENT
 
@@ -44,11 +38,7 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
+
 
 migration:
   <<: *default
@@ -62,11 +52,6 @@ migration:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/dryad_iptest.yml
+++ b/config/tenants/dryad_iptest.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "dryad_ip"
   short_name: "Dryad IP Address Test"
   long_name: "Dryad Data Platform IP Address Test"
@@ -32,7 +27,6 @@ development: &DEVELOPMENT
   #Add any items that need to override the defaults here
   partner_display: true
 
-
 local_dev:
   <<: *DEVELOPMENT
 
@@ -46,11 +40,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -65,11 +54,6 @@ production:
   <<: *default
   #Add any items that need to override the defaults here
   enabled: false
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/fws.yml
+++ b/config/tenants/fws.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "fws"
   short_name: "U.S. Fish & Wildlife Service"
   long_name: "U.S. Fish & Wildlife Service"
@@ -41,20 +36,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/iitism.yml
+++ b/config/tenants/iitism.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "IITISM"
   short_name: "Indian Institute of Technology Dhanbad"
   long_name: "Indian Institute of Technology Dhanbad"
@@ -42,11 +37,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -58,11 +48,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/kaust.yml
+++ b/config/tenants/kaust.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "KAUST"
   short_name: "King Abdullah University of Science and Technology"
   long_name: "King Abdullah University of Science and Technology"
@@ -44,11 +39,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -60,11 +50,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/kyotou.yml
+++ b/config/tenants/kyotou.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "kyotou"
   short_name: "Kyoto University"
   long_name: "Kyoto University"
@@ -44,11 +39,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
@@ -57,11 +47,6 @@ production:
     strategy: shibboleth
     entity_id: https://authidp1.iimc.kyoto-u.ac.jp/idp/shibboleth
     entity_domain: authidp1.iimc.kyoto-u.ac.jp
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/lbnl.yml
+++ b/config/tenants/lbnl.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "LBNL"
   short_name: "Lawrence Berkeley Lab"
   long_name: "Lawrence Berkeley National Laboratory"
@@ -43,21 +38,11 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/lbnl_dash"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
   enabled: true
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: ezid
     shoulder: "doi:10.7941/D1"

--- a/config/tenants/mq.yml
+++ b/config/tenants/mq.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "MQ"
   short_name: "Macquarie University"
   long_name: "Macquarie University"
@@ -42,20 +37,11 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
+
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/msu.yml
+++ b/config/tenants/msu.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "MSU"
   short_name: "Montana State University"
   long_name: "Montana State University"
@@ -44,20 +39,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/msu2.yml
+++ b/config/tenants/msu2.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "MSU2"
   short_name: "Michigan State University"
   long_name: "Michigan State University"
@@ -45,11 +40,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -61,11 +51,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/ncsu.yml
+++ b/config/tenants/ncsu.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "NCSU"
   short_name: "North Carolina State University"
   long_name: "North Carolina State University"
@@ -42,20 +37,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/nioo_knaw.yml
+++ b/config/tenants/nioo_knaw.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "NIOO-KNAW"
   short_name: "Nederlands Instituut voor Ecologie"
   long_name: "Netherlands Institute of Ecology (NIOO-KNAW)"
@@ -42,20 +37,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/nmsu.yml
+++ b/config/tenants/nmsu.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "NMSU"
   short_name: "New Mexico State University"
   long_name: "New Mexico State University"
@@ -45,20 +40,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/northwestern.yml
+++ b/config/tenants/northwestern.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "Northwestern"
   short_name: "Northwestern University"
   long_name: "Northwestern University"
@@ -42,20 +37,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/ohiostate.yml
+++ b/config/tenants/ohiostate.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "OSU"
   short_name: "Ohio State University"
   long_name: "The Ohio State University"
@@ -48,20 +43,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/rochester.yml
+++ b/config/tenants/rochester.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "rochester"
   short_name: "University of Rochester"
   long_name: "University of Rochester"
@@ -43,20 +38,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/rockefeller.yml
+++ b/config/tenants/rockefeller.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "rockefeller"
   short_name: "Rockefeller University"
   long_name: "The Rockefeller University"
@@ -43,20 +38,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/sheffield.yml
+++ b/config/tenants/sheffield.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "sheffield"
   short_name: "University of Sheffield"
   long_name: "The University of Sheffield"
@@ -42,20 +37,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/stanford.yml
+++ b/config/tenants/stanford.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "Stanford"
   short_name: "Stanford University"
   long_name: "Lane Medical Library, Stanford University"
@@ -47,20 +42,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/suny-buffalo.yml
+++ b/config/tenants/suny-buffalo.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UB"
   short_name: "SUNY Buffalo"
   long_name: "University at Buffalo"
@@ -42,20 +37,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/suny-buffalostate.yml
+++ b/config/tenants/suny-buffalostate.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "Buff State"
   short_name: "Buffalo State"
   long_name: "SUNY Buffalo State University"
@@ -41,20 +36,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/suny-stonybrook.yml
+++ b/config/tenants/suny-stonybrook.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "SBU"
   short_name: "SUNY Stony Brook"
   long_name: "Stony Brook University"
@@ -42,20 +37,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/suny.yml
+++ b/config/tenants/suny.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "SUNY"
   short_name: "State University of New York"
   long_name: "State University of New York"
@@ -95,11 +90,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -111,11 +101,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/sydneynsw.yml
+++ b/config/tenants/sydneynsw.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UNSW"
   short_name: "University of New South Wales, Sydney"
   long_name: "University of New South Wales, Sydney"
@@ -42,20 +37,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/ttu.yml
+++ b/config/tenants/ttu.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "TTU"
   short_name: "Texas Tech University"
   long_name: "Texas Tech University"
@@ -43,20 +38,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/ubc.yml
+++ b/config/tenants/ubc.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "ubc"
   short_name: "University of British Columbia"
   long_name: "The University of British Columbia"
@@ -42,20 +37,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/ucb.yml
+++ b/config/tenants/ucb.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UCB"
   short_name: "UC Berkeley"
   long_name: "University of California, Berkeley"
@@ -48,20 +43,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %> 
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: ezid
     shoulder: "doi:10.6078/D1"

--- a/config/tenants/ucd.yml
+++ b/config/tenants/ucd.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UCD"
   short_name: "UC Davis"
   long_name: "University of California, Davis"
@@ -49,21 +44,11 @@ stage:
   <<: *default
   #Add any items that need to override the defaults here
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %> 
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
   enabled: true
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: ezid
     shoulder: "doi:10.25338/B8"

--- a/config/tenants/uci.yml
+++ b/config/tenants/uci.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "Irvine"
   short_name: "UC Irvine"
   long_name: "University of California, Irvine"
@@ -47,20 +42,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %> 
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: ezid
     shoulder: "doi:10.7280/D1"

--- a/config/tenants/ucla.yml
+++ b/config/tenants/ucla.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UCLA"
   short_name: "UC Los Angeles"
   long_name: "University of California, Los Angeles"
@@ -49,20 +44,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %> 
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: ezid
     shoulder: "doi:10.5068/D1"

--- a/config/tenants/ucm.yml
+++ b/config/tenants/ucm.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "Merced"
   short_name: "UC Merced"
   long_name: "University of California, Merced"
@@ -44,20 +39,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %> 
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: ezid
     shoulder: "doi:10.6071/M3"

--- a/config/tenants/ucop.yml
+++ b/config/tenants/ucop.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UC"
   short_name: "UC Office of the President"
   long_name: "University of California, Office of the President"
@@ -44,20 +39,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %> 
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: ezid
     shoulder: "doi:10.18736/D6"

--- a/config/tenants/ucpress.yml
+++ b/config/tenants/ucpress.yml
@@ -1,11 +1,6 @@
 # I think we need to keep this config, though disabled in case of DOI updates.
 default: &default
   enabled: false
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UC Press"
   short_name: "UC Press"
   long_name: "University of California Press"
@@ -42,19 +37,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %> 
+ 
 
 production:
   <<: *default
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: ezid
     shoulder: "doi:10.17916/P6"

--- a/config/tenants/ucr.yml
+++ b/config/tenants/ucr.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "Riverside"
   short_name: "UC Riverside"
   long_name: "University of California, Riverside"
@@ -44,11 +39,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %> 
 
 migration:
   <<: *default
@@ -61,11 +51,7 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
+
   identifier_service:
     provider: ezid
     shoulder: "doi:10.6086/D1"

--- a/config/tenants/ucsb.yml
+++ b/config/tenants/ucsb.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UCSB"
   short_name: "UC Santa Barbara"
   long_name: "University of California, Santa Barbara"
@@ -43,11 +38,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -60,11 +50,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: ezid
     shoulder: "doi:10.25349/D9"

--- a/config/tenants/ucsc.yml
+++ b/config/tenants/ucsc.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UCSC"
   short_name: "UC Santa Cruz"
   long_name: "University of California, Santa Cruz"
@@ -44,11 +39,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -61,11 +51,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: ezid
     shoulder: "doi:10.7291/D1"

--- a/config/tenants/ucsd.yml
+++ b/config/tenants/ucsd.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UCSD"
   short_name: "UC San Diego"
   long_name: "University of California, San Diego"
@@ -48,11 +43,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %> 
 
 migration:
   <<: *default
@@ -65,11 +55,6 @@ demo:
 production:
   <<: *default
   enabled: true
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %> 
   identifier_service:
     provider: ezid
     shoulder: "doi:10.6076/D1"

--- a/config/tenants/ucsf.yml
+++ b/config/tenants/ucsf.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UCSF"
   short_name: "UC San Francisco"
   long_name: "University of California, San Francisco"
@@ -47,11 +42,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -64,11 +54,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: ezid
     shoulder: "doi:10.7272/Q6"

--- a/config/tenants/uiuc.yml
+++ b/config/tenants/uiuc.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UIUC"
   short_name: "University of Illinois Urbana-Champaign"
   long_name: "University of Illinois, Urbana-Champaign"
@@ -42,11 +37,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -58,11 +48,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/umn.yml
+++ b/config/tenants/umn.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UMN"
   short_name: "University of Minnesota"
   long_name: "University of Minnesota"
@@ -51,11 +46,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -67,11 +57,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/unm.yml
+++ b/config/tenants/unm.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UNM"
   short_name: "University of New Mexico"
   long_name: "University of New Mexico"
@@ -45,11 +40,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -61,11 +51,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/unr.yml
+++ b/config/tenants/unr.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UNR"
   short_name: "University of Nevada"
   long_name: "University of Nevada, Reno"
@@ -42,11 +37,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -58,11 +48,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/upenn.yml
+++ b/config/tenants/upenn.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "UPenn"
   short_name: "University of Pennsylvania"
   long_name: "University of Pennsylvania"
@@ -45,11 +40,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -61,11 +51,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/uri.yml
+++ b/config/tenants/uri.yml
@@ -1,11 +1,6 @@
 default: &default
   enabled: true
   my_test_config_val: <%= Rails.application.credentials[Rails.env.to_sym][:another_val] %>
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "URI"
   short_name: "University of Rhode Island"
   long_name: "The University of Rhode Island"
@@ -43,11 +38,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -59,11 +49,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/victoria.yml
+++ b/config/tenants/victoria.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "VicUni"
   short_name: "Victoria University, Melbourne"
   long_name: "Victoria University, Melbourne"
@@ -42,11 +37,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -58,11 +48,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/washington.yml
+++ b/config/tenants/washington.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "washington"
   short_name: "University of Washington"
   long_name: "University of Washington"
@@ -42,20 +37,10 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/wisc.yml
+++ b/config/tenants/wisc.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "WISC"
   short_name: "University of Wisconsin–Madison"
   long_name: "University of Wisconsin–Madison"
@@ -42,11 +37,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -58,11 +48,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/config/tenants/yale.yml
+++ b/config/tenants/yale.yml
@@ -1,10 +1,5 @@
 default: &default
   enabled: true
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   abbreviation: "YALE"
   short_name: "Yale"
   long_name: "Yale University"
@@ -43,11 +38,6 @@ local:
 stage:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryadstg_password] %>
 
 migration:
   <<: *default
@@ -59,11 +49,6 @@ demo:
 production:
   <<: *default
   #Add any items that need to override the defaults here
-  repository:
-    domain: https://merritt.cdlib.org
-    endpoint: "http://mrtsword.cdlib.org:39001/mrtsword/collection/cdl_dryad"
-    username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_username] %>
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryad_password] %>
   identifier_service:
     provider: datacite
     prefix: "10.5061"

--- a/dryad-config-example/app_config.yml
+++ b/dryad-config-example/app_config.yml
@@ -6,6 +6,11 @@ defaults: &DEFAULTS
     host: ezid.cdlib.org
     port: 443
   contact_us_uri: http://www.cdlib.org/services/uc3/contact.html
+  repository:
+    domain: https://merritt-test.example.org
+    endpoint: "https://merritt-test.example.org:39001/mrtsword/collection/cdl_dryaddev"
+    username: horsecat
+    password: MyHorseCatPassword
   orcid:
     site: https://sandbox.orcid.org/
     authorize_url: https://sandbox.orcid.org/oauth/authorize
@@ -189,7 +194,7 @@ local:
 
 test:
   <<: *DEFAULTS
-  repository: Mocks::Repository::Repository
+  # repository: Mocks::Repository::Repository
   contact_email: ["contact1@example.edu", "contact2@example.edu"]
   default_tenant: localhost
   old_dryad_url: https://api.datadryad.example.org

--- a/lib/stash/compressed/zip_info.rb
+++ b/lib/stash/compressed/zip_info.rb
@@ -1,5 +1,6 @@
 require 'http'
 require 'stringio'
+require 'charlock_holmes/string'
 
 module Stash
   module Compressed
@@ -52,7 +53,9 @@ module Stash
 
           # filename
           ss.pos += 18
-          file_name = ss.peek(file_name_length).force_encoding('utf-8')
+          file_name = ss.peek(file_name_length)
+          enc = file_name.detect_encoding[:ruby_encoding] || 'UTF-8'
+          file_name.force_encoding(enc)
 
           # forward past the file name
           ss.pos += file_name_length

--- a/lib/stash/download/version_presigned.rb
+++ b/lib/stash/download/version_presigned.rb
@@ -18,11 +18,11 @@ module Stash
         @version = @resource&.stash_version&.merritt_version
         # local_id is encoded, so later it gets double-encoded which is required by Merritt for some crazy reason
         _ignored, @local_id = @resource.merritt_protodomain_and_local_id
-        @domain = @tenant&.repository&.domain
+        @domain = APP_CONFIG[:repository][:domain]
 
         @http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
           .timeout(connect: 10, read: 10).timeout(10.seconds.to_i).follow(max_hops: 3)
-          .basic_auth(user: @tenant&.repository&.username, pass: @tenant&.repository&.password)
+          .basic_auth(user: APP_CONFIG[:repository][:username], pass: APP_CONFIG[:repository][:password])
       end
 
       def valid_resource?

--- a/lib/stash/repo/dataset_info.rb
+++ b/lib/stash/repo/dataset_info.rb
@@ -23,7 +23,7 @@ module Stash
 
         protodomain, id = @resource.merritt_protodomain_and_local_id
         url = "#{protodomain}/dm/#{id}"
-        client = HttpClient.new(tenant: tenant).client
+        client = HttpClient.new.client
         timeouts(client)
         resp = client.get(url, follow_redirect: true)
         return nil unless resp.http_header.status_code == 200

--- a/lib/stash/repo/http_client.rb
+++ b/lib/stash/repo/http_client.rb
@@ -12,7 +12,7 @@ module Stash
       attr_accessor :client
 
       # pass in the tenant so that it can set all the stuff it needs for domains and basic auth, pass in a special cert file if needed
-      def initialize(tenant:, cert_file: nil)
+      def initialize(cert_file: nil)
         @client = HTTPClient.new
 
         # this callback allows following redirects from http to https, otherwise it will not
@@ -22,7 +22,7 @@ module Stash
 
         # ran into problems like https://github.com/nahi/httpclient/issues/181 so forcing basic auth
         @client.force_basic_auth = true
-        @client.set_basic_auth(nil, tenant.repository.username, tenant.repository.password)
+        @client.set_basic_auth(nil, APP_CONFIG[:repository][:username], APP_CONFIG[:repository][:password])
 
         # TODO: remove this once Merritt has fixed their certs on their stage server.
         @client.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE # TODO: remove for extra security once Merritt gets real certs

--- a/lib/stash/repo/repository.rb
+++ b/lib/stash/repo/repository.rb
@@ -42,7 +42,7 @@ module Stash
       # for discovery.
       # @param resource [StashEngine::Resource] the resource
       # @param record_identifier [String] the harvested record identifier (repository- or protocol-dependent)
-      def download_uri_for(resource:, record_identifier:) # rubocop:disable Lint/UnusedMethodArgument
+      def download_uri_for(record_identifier:) # rubocop:disable Lint/UnusedMethodArgument
         raise NoMethodError, "#{self.class} should override #download_uri_for to determine the download URI"
       end
 
@@ -121,7 +121,7 @@ module Stash
       private
 
       def get_download_uri(resource, record_identifier)
-        download_uri_for(resource: resource, record_identifier: record_identifier)
+        download_uri_for(record_identifier: record_identifier)
       rescue StandardError => e
         raise ArgumentError, "Unable to determine download URI for resource #{resource.id} from record identifier #{record_identifier}: #{e}"
       end

--- a/lib/tasks/compressed/info.rb
+++ b/lib/tasks/compressed/info.rb
@@ -7,7 +7,7 @@ module Tasks
         entries =
           if db_file.upload_file_name.downcase.end_with?('.zip')
             Stash::Compressed::ZipInfo.new(presigned_url: db_file.merritt_s3_presigned_url).file_entries
-          elsif db_file.downcase.upload_file_name.downcase.end_with?('.tar.gz', '.tgz')
+          elsif db_file.upload_file_name.downcase.end_with?('.tar.gz', '.tgz')
             Stash::Compressed::TarGz.new(presigned_url: db_file.merritt_s3_presigned_url).file_entries
           else
             raise Stash::Compressed::Error, "Unknown file type for #{db_file.upload_file_name}"

--- a/spec/lib/stash/doi/datacite_gen_spec.rb
+++ b/spec/lib/stash/doi/datacite_gen_spec.rb
@@ -20,7 +20,7 @@ module Stash
 
         describe :post_metadata do
           it 'creates a successful sandbox post request to DataCite' do
-            repo = @resource.tenant.repository
+            repo = APP_CONFIG[:repository]
             stub_request(:post, 'https://mds.test.datacite.org/metadata')
               .with(headers: { 'Authorization' => ActionController::HttpAuthentication::Basic
                                                       .encode_credentials(repo.username, repo.password),
@@ -33,7 +33,7 @@ module Stash
           end
 
           it 'creates a successful post request to DataCite' do
-            repo = @resource.tenant.repository
+            repo = APP_CONFIG[:repository]
             stub_request(:post, 'https://mds.datacite.org/metadata')
               .with(headers: { 'Authorization' => ActionController::HttpAuthentication::Basic
                                                       .encode_credentials(repo.username, repo.password),
@@ -47,7 +47,7 @@ module Stash
 
         describe :put_doi do
           it 'creates a successful sandbox put request to DataCite' do
-            repo = @resource.tenant.repository
+            repo = APP_CONFIG[:repository]
             bare_id = @resource.identifier.identifier
             stub_request(:put, "https://mds.test.datacite.org/doi/#{bare_id}")
               .with(headers: { 'Authorization' => ActionController::HttpAuthentication::Basic
@@ -61,7 +61,7 @@ module Stash
 
           it 'creates a successful put request to DataCite' do
             bare_id = @resource.identifier.identifier
-            repo = @resource.tenant.repository
+            repo = APP_CONFIG[:repository]
             stub_request(:put, "https://mds.datacite.org/doi/#{bare_id}")
               .with(headers: { 'Authorization' => ActionController::HttpAuthentication::Basic
                                                       .encode_credentials(repo.username, repo.password),
@@ -77,7 +77,7 @@ module Stash
         describe :get_doi do
           it 'creates a successful sandbox get request to DataCite' do
             bare_id = @resource.identifier.identifier
-            repo = @resource.tenant.repository
+            repo = APP_CONFIG[:repository]
             stub_request(:get, "https://mds.test.datacite.org/doi/#{bare_id}")
               .with(headers: { 'Authorization' => ActionController::HttpAuthentication::Basic
                                                       .encode_credentials(repo.username, repo.password),
@@ -89,7 +89,7 @@ module Stash
 
           it 'creates a successful get request to DataCite' do
             bare_id = @resource.identifier.identifier
-            repo = @resource.tenant.repository
+            repo = APP_CONFIG[:repository]
             stub_request(:get, "https://mds.datacite.org/doi/#{bare_id}")
               .with(headers: { 'Authorization' => ActionController::HttpAuthentication::Basic
                                                       .encode_credentials(repo.username, repo.password),

--- a/spec/lib/stash/download/file_presigned_spec.rb
+++ b/spec/lib/stash/download/file_presigned_spec.rb
@@ -26,7 +26,7 @@ module Stash
           @stubby = stub_request(:get, @data_file.merritt_presign_info_url)
             .with(
               headers: {
-                'Authorization' => 'Basic c3Rhc2hfc3VibWl0dGVyOmNvcnJlY3TigItob3JzZeKAi2JhdHRlcnnigItzdGFwbGU=',
+                'Authorization' => 'Basic aG9yc2VjYXQ6TXlIb3JzZUNhdFBhc3N3b3Jk',
                 'Host' => 'merritt-fake.cdlib.org'
               }
             )
@@ -50,7 +50,7 @@ module Stash
           stub_request(:get, @data_file.merritt_presign_info_url)
             .with(
               headers: {
-                'Authorization' => 'Basic c3Rhc2hfc3VibWl0dGVyOmNvcnJlY3TigItob3JzZeKAi2JhdHRlcnnigItzdGFwbGU=',
+                'Authorization' => 'Basic aG9yc2VjYXQ6TXlIb3JzZUNhdFBhc3N3b3Jk',
                 'Host' => 'merritt-fake.cdlib.org'
               }
             )

--- a/spec/lib/stash/download/version_presigned_spec.rb
+++ b/spec/lib/stash/download/version_presigned_spec.rb
@@ -61,13 +61,6 @@ module Stash
           expect(@vp.valid_resource?).to be_falsey
         end
 
-        it 'is false if domain is blank' do
-          allow(@resource).to receive(:tenant)
-            .and_return({ repository: { domain: nil }.to_ostruct }.to_ostruct)
-          @vp = VersionPresigned.new(resource: @resource)
-          expect(@vp.valid_resource?).to be_falsey
-        end
-
         it 'is false if local_id is blank' do
           allow(@resource).to receive(:merritt_protodomain_and_local_id).and_return(['', nil])
           @vp = VersionPresigned.new(resource: @resource)

--- a/spec/models/stash-merritt/merritt_helper_spec.rb
+++ b/spec/models/stash-merritt/merritt_helper_spec.rb
@@ -13,12 +13,6 @@ module Stash
 
         @title = 'A Zebrafish Model for Studies on Esophageal Epithelial Biology'
         @request_host = 'example.org'
-
-        @sword_params = {
-          collection_uri: 'https://example.org/sword/my_collection',
-          username: 'elvis',
-          password: 'presley'
-        }.freeze
       end
 
       before(:each) do
@@ -43,7 +37,6 @@ module Stash
         allow(@tenant).to receive(:tenant_id).and_return('dataone')
         allow(@tenant).to receive(:short_name).and_return('DataONE')
         allow(@tenant).to receive(:full_url) { |path| "https://stash-dev.example.edu/#{path}" }
-        allow(@tenant).to receive(:sword_params).and_return(@sword_params)
         allow(StashEngine::Tenant).to receive(:find).with('dataone').and_return(@tenant)
 
         stash_wrapper = Stash::Wrapper::StashWrapper.parse_xml(File.read('spec/data/archive/stash-wrapper.xml'))
@@ -94,6 +87,19 @@ module Stash
               upload.save
             end
             allow(@resource).to receive(:upload_type).and_return(:manifest)
+          end
+
+          describe :sword_params do
+            it 'returns the Stash::Sword::Client parameter hash' do
+              @package = Stash::Merritt::ObjectManifestPackage.new(resource: @resource)
+              @helper = MerrittHelper.new(package: @package)
+              expected = {
+                collection_uri: 'https://merritt-test.example.org:39001/mrtsword/collection/cdl_dryaddev',
+                username: 'horsecat',
+                password: 'MyHorseCatPassword'
+              }
+              expect(@helper.sword_params).to eq(expected)
+            end
           end
 
           describe 'create' do

--- a/spec/models/stash-merritt/repository_spec.rb
+++ b/spec/models/stash-merritt/repository_spec.rb
@@ -98,7 +98,7 @@ module Stash
 
       describe :download_uri_for do
         it 'determines the download URI' do
-          expected_uri = 'http://merritt.cdlib.org/d/ark%3A%2F99999%2Ffk43f5119b'
+          expected_uri = 'https://merritt-test.example.org/d/ark%3A%2F99999%2Ffk43f5119b'
           actual_uri = repo.download_uri_for(record_identifier: record_identifier)
           expect(actual_uri).to eq(expected_uri)
         end
@@ -106,7 +106,7 @@ module Stash
 
       describe :update_uri_for do
         it 'determines the update URI' do
-          expected_uri = 'http://uc3-mrtsword-prd.cdlib.org:39001/mrtsword/edit/dataone_dash/doi%3A10.15146%2FR3RG6G'
+          expected_uri = 'https://merritt-test.example.org:39001/mrtsword/edit/cdl_dryaddev/doi%3A10.15146%2FR3RG6G'
           actual_uri = repo.update_uri_for(resource: resource, record_identifier: record_identifier)
           expect(actual_uri).to eq(expected_uri)
         end
@@ -120,8 +120,8 @@ module Stash
           neuter_curation_callbacks!
           repo.harvested(identifier: @identifier, record_identifier: @record_identifier)
           @resource.reload
-          expect(@resource.download_uri).to eq('http://merritt.cdlib.org/d/ark%3A%2F99999%2Ffk43f5119b')
-          expect(@resource.update_uri).to eq('http://uc3-mrtsword-prd.cdlib.org:39001/mrtsword/edit/dataone_dash/doi%3A10.15146%2FR3RG6G')
+          expect(@resource.download_uri).to eq('https://merritt-test.example.org/d/ark%3A%2F99999%2Ffk43f5119b')
+          expect(@resource.update_uri).to eq('https://merritt-test.example.org:39001/mrtsword/edit/cdl_dryaddev/doi%3A10.15146%2FR3RG6G')
           expect(@resource.current_state).to eq('submitted')
         end
       end

--- a/spec/models/stash-merritt/repository_spec.rb
+++ b/spec/models/stash-merritt/repository_spec.rb
@@ -99,7 +99,7 @@ module Stash
       describe :download_uri_for do
         it 'determines the download URI' do
           expected_uri = 'http://merritt.cdlib.org/d/ark%3A%2F99999%2Ffk43f5119b'
-          actual_uri = repo.download_uri_for(resource: resource, record_identifier: record_identifier)
+          actual_uri = repo.download_uri_for(record_identifier: record_identifier)
           expect(actual_uri).to eq(expected_uri)
         end
       end

--- a/spec/models/stash/repo/repository_spec.rb
+++ b/spec/models/stash/repo/repository_spec.rb
@@ -70,7 +70,7 @@ module Stash
 
       describe :download_uri_for do
         it 'is abstract' do
-          expect { repo.download_uri_for(resource: resource, record_identifier: 'ark:/1234/567') }.to raise_error(NoMethodError)
+          expect { repo.download_uri_for(record_identifier: 'ark:/1234/567') }.to raise_error(NoMethodError)
         end
       end
 

--- a/spec/models/stash_engine/data_file_spec.rb
+++ b/spec/models/stash_engine/data_file_spec.rb
@@ -158,7 +158,7 @@ module StashEngine
         stub_request(:get, 'https://merritt.example.com/api/presign-file/ark:%2F12345%2F38568/1/producer%2Ffoo.bar?no_redirect=true')
           .with(
             headers: {
-              'Authorization' => 'Basic bWFydGlua2E6MTIzOTg3eHVycA==',
+              'Authorization' => 'Basic aG9yc2VjYXQ6TXlIb3JzZUNhdFBhc3N3b3Jk',
               'Host' => 'merritt.example.com'
             }
           )
@@ -170,7 +170,7 @@ module StashEngine
         stub_request(:get, 'https://merritt.example.com/api/presign-file/ark:%2F12345%2F38568/1/producer%2Ffoo.bar?no_redirect=true')
           .with(
             headers: {
-              'Authorization' => 'Basic bWFydGlua2E6MTIzOTg3eHVycA==',
+              'Authorization' => 'Basic aG9yc2VjYXQ6TXlIb3JzZUNhdFBhc3N3b3Jk',
               'Host' => 'merritt.example.com'
             }
           )
@@ -186,7 +186,7 @@ module StashEngine
         stub_request(:get, "https://merritt.example.com/api/presign-file/ark:%2F12345%2F38568/1/producer%2F#{str}?no_redirect=true")
           .with(
             headers: {
-              'Authorization' => 'Basic bWFydGlua2E6MTIzOTg3eHVycA==',
+              'Authorization' => 'Basic aG9yc2VjYXQ6TXlIb3JzZUNhdFBhc3N3b3Jk',
               'Host' => 'merritt.example.com'
             }
           )

--- a/spec/models/stash_engine/identifier_spec.rb
+++ b/spec/models/stash_engine/identifier_spec.rb
@@ -1058,7 +1058,7 @@ module StashEngine
     describe '#merritt_object_info' do
 
       it 'returns merritt info for a record that exists' do
-        stub_request(:get, 'https://merritt-stage.cdlib.org/api/cdl_dryaddev/local_id_search?terms=doi:10.123/456')
+        stub_request(:get, 'https://merritt-test.example.org/api/cdl_dryaddev/local_id_search?terms=doi:10.123/456')
           .with(
             headers: {
               'Accept' => 'application/json'
@@ -1076,7 +1076,7 @@ module StashEngine
       end
 
       it "returns nothing for a merritt record that doesn't exist" do
-        stub_request(:get, 'https://merritt-stage.cdlib.org/api/cdl_dryaddev/local_id_search?terms=doi:10.123/456')
+        stub_request(:get, 'https://merritt-test.example.org/api/cdl_dryaddev/local_id_search?terms=doi:10.123/456')
           .with(
             headers: {
               'Accept' => 'application/json'
@@ -1088,7 +1088,7 @@ module StashEngine
       end
 
       it 'returns nothing when merritt is having some problems' do
-        stub_request(:get, 'https://merritt-stage.cdlib.org/api/cdl_dryaddev/local_id_search?terms=doi:10.123/456')
+        stub_request(:get, 'https://merritt-test.example.org/api/cdl_dryaddev/local_id_search?terms=doi:10.123/456')
           .with(
             headers: {
               'Accept' => 'application/json'

--- a/spec/models/stash_engine/tenant_spec.rb
+++ b/spec/models/stash_engine/tenant_spec.rb
@@ -40,7 +40,6 @@ module StashEngine
         tenant = Tenant.find('dataone')
         expect(tenant.tenant_id).to eq('dataone')
         expect(tenant.long_name).to eq('DataONE')
-        expect(tenant.repository.domain).to eq('http://merritt.repository.domain.here')
         expect(tenant.identifier_service.prefix).to eq('10.5072')
         expect(tenant.authentication.strategy).to eq('author_match')
         # not going to check all since we've already tried that in initialize and not needed
@@ -50,7 +49,6 @@ module StashEngine
         tenant = Tenant.find_by_long_name('Dryad Data Platform')
         expect(tenant.tenant_id).to eq('dryad')
         expect(tenant.long_name).to eq('Dryad Data Platform')
-        expect(tenant.repository.domain).to eq('http://merritt.repository.domain.here')
         expect(tenant.identifier_service.prefix).to eq('10.5072')
         expect(tenant.authentication.strategy).to eq('none')
         # not going to check all since we've already tried that in initialize and not needed
@@ -79,18 +77,6 @@ module StashEngine
         tenant = Tenant.find('ucop')
         login_path = tenant.shibboleth_login_path
         expect(login_path).to eq('https://localhost/Shibboleth.sso/Login?target=https%3A%2F%2Flocalhost%2Fstash%2Fauth%2Fshibboleth%2Fcallback&entityID=urn%3Amace%3Aincommon%3Aucop.edu')
-      end
-    end
-
-    describe :sword_params do
-      it 'returns the Stash::Sword::Client parameter hash' do
-        tenant = Tenant.find('ucop')
-        expected = {
-          collection_uri: 'http://merritt.repository.domain.here/mrtsword/collection/dash_cdl',
-          username: 'submitter.username',
-          password: 'submitter.password'
-        }
-        expect(tenant.sword_params).to eq(expected)
       end
     end
 

--- a/spec/models/stash_engine/tenant_spec.rb
+++ b/spec/models/stash_engine/tenant_spec.rb
@@ -10,11 +10,6 @@ module StashEngine
       expect(tenant.long_name).to eq('University of Exemplia')
       expect(tenant.default_license).to eq('cc_by')
       expect(tenant.stash_logo_after_tenant).to eq(true)
-      expect(repo.type).to eq('exemplum')
-      expect(repo.domain).to eq('http://repo-dev.example.edu')
-      expect(repo.endpoint).to eq('http://repo-dev.example.edu:39001/sword/collection/stash')
-      expect(repo.username).to eq('stash_submitter')
-      expect(repo.password).to eq('correct​horse​battery​staple')
       ident = tenant.identifier_service
       expect(ident.shoulder).to eq('doi:10.5072/5555')
       expect(ident.account).to eq('DRYAD.CDL')

--- a/spec/models/stash_engine/tenant_spec.rb
+++ b/spec/models/stash_engine/tenant_spec.rb
@@ -10,7 +10,6 @@ module StashEngine
       expect(tenant.long_name).to eq('University of Exemplia')
       expect(tenant.default_license).to eq('cc_by')
       expect(tenant.stash_logo_after_tenant).to eq(true)
-      repo = tenant.repository
       expect(repo.type).to eq('exemplum')
       expect(repo.domain).to eq('http://repo-dev.example.edu')
       expect(repo.endpoint).to eq('http://repo-dev.example.edu:39001/sword/collection/stash')

--- a/stash/stash-merritt/lib/stash/merritt/merritt_helper.rb
+++ b/stash/stash-merritt/lib/stash/merritt/merritt_helper.rb
@@ -23,6 +23,20 @@ module Stash
         resource.save!
       end
 
+      # class method
+      def self.sword_params
+        {
+          collection_uri: APP_CONFIG[:repository][:endpoint],
+          username: APP_CONFIG[:repository][:username],
+          password: APP_CONFIG[:repository][:password]
+        }
+      end
+
+      # instance method
+      def sword_params
+        self.class.sword_params
+      end
+
       private
 
       def resource
@@ -38,7 +52,7 @@ module Stash
       end
 
       def merritt_client
-        @merritt_client ||= Stash::Deposit::Client.new(logger: logger, **tenant.sword_params)
+        @merritt_client ||= Stash::Deposit::Client.new(logger: logger, **sword_params)
       end
 
       def do_create

--- a/stash/stash-merritt/lib/stash/merritt/repository.rb
+++ b/stash/stash-merritt/lib/stash/merritt/repository.rb
@@ -14,32 +14,19 @@ module Stash
       end
 
       def download_uri_for(resource:, record_identifier:)
-        merritt_host = merritt_host_for(resource)
+        merritt_host = APP_CONFIG[:repository][:domain]
         ark = ark_from(record_identifier)
         "#{merritt_host}/d/#{ERB::Util.url_encode(ark)}"
       end
 
       def update_uri_for(resource:, record_identifier:) # rubocop:disable Lint/UnusedMethodArgument
-        sword_endpoint = sword_endpoint_for(resource)
+        sword_endpoint = APP_CONFIG[:repository][:endpoint]
         doi = resource.identifier_str
         edit_uri_base = sword_endpoint.sub('/collection/', '/edit/')
         "#{edit_uri_base}/#{ERB::Util.url_encode(doi)}"
       end
 
       private
-
-      def merritt_host_for(resource)
-        repo_params_for(resource).domain
-      end
-
-      def sword_endpoint_for(resource)
-        repo_params_for(resource).endpoint
-      end
-
-      def repo_params_for(resource)
-        tenant = resource.tenant
-        tenant.repository
-      end
 
       def ark_from(record_identifier)
         ark_match_data = record_identifier && record_identifier.match(ARK_PATTERN)

--- a/stash/stash-merritt/lib/stash/merritt/repository.rb
+++ b/stash/stash-merritt/lib/stash/merritt/repository.rb
@@ -13,7 +13,7 @@ module Stash
         SubmissionJob.new(resource_id: resource_id, url_helpers: url_helpers)
       end
 
-      def download_uri_for(resource:, record_identifier:)
+      def download_uri_for(record_identifier:)
         merritt_host = APP_CONFIG[:repository][:domain]
         ark = ark_from(record_identifier)
         "#{merritt_host}/d/#{ERB::Util.url_encode(ark)}"

--- a/stash/stash-merritt/lib/stash/merritt/submission_job.rb
+++ b/stash/stash-merritt/lib/stash/merritt/submission_job.rb
@@ -86,7 +86,7 @@ module Stash
         msg << if (update_uri = resource.update_uri)
                  "posting update to #{update_uri}"
                else
-                 "posting new object to #{resource.tenant.sword_params[:collection_uri]}"
+                 "posting new object to #{Stash::Merritt::MerrittHelper.sword_params[:collection_uri]}"
                end
         msg << " (tenant: #{resource.tenant_id})"
       end


### PR DESCRIPTION
This moves all the duplicated individual Merritt credentials out of each tenant since all is in the same collection these days.  Moves into the APP_CONFIG instead and cleans up lots of tenant files, refactoring of code and updates to tests.

To test:
- Submisisons to Merritt still work
- Downloads still work
- Copying to Zenodo still works

BTW, this can wait until the next sprint release if we like and no reason we have to rush it in.


