### PR TITLE
Allow ISSNs to be logged

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -2,5 +2,5 @@
 
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += [
-  :password, :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+  :password, :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp
 ]


### PR DESCRIPTION
The Rails [filter_parameters](https://guides.rubyonrails.org/configuring.html#config-filter-parameters) setting is treated as a regular expression instead of an exact match. By default, Rails suppresses logging of `ssn`, which makes sense, but this also prevents logging of `publicationISSN`, which is important for debugging API interactions.

I'm removing the `ssn` setting, since it is important for us to log anything related to an ISSN. I don't expect that we will ever receive social security numbers. 