### PR TITLE
Methods to get zip file contents in alternate ways for items with problems

### DIFF
--- a/lib/stash/compressed/zip_info.rb
+++ b/lib/stash/compressed/zip_info.rb
@@ -173,7 +173,7 @@ module Stash
         # response.body.each do |chunk|
         remote_file = Down::Http.open(@presigned_url)
         Zip::InputStream.open(remote_file) do |io|
-          while entry = io.get_next_entry
+          while (entry = io.get_next_entry)
             file_info << { file_name: entry.name, uncompressed_size: entry.size }
             # puts "Name: #{entry.name}, Size: #{entry.size}, Compressed Size: #{entry.compressed_size}"
           end
@@ -189,7 +189,7 @@ module Stash
           arr = line.strip.split(/\s+/, 8)
           my_fn = arr[-1]
           my_size = arr[0].to_i
-          file_info << { file_name: my_fn , uncompressed_size: my_size }
+          file_info << { file_name: my_fn, uncompressed_size: my_size }
         end
         file_info
       end

--- a/lib/stash/compressed/zip_info.rb
+++ b/lib/stash/compressed/zip_info.rb
@@ -194,6 +194,18 @@ module Stash
         file_info
       end
 
+      def entries_with_fallback
+        entries = file_entries
+        raise Stash::Compressed::InvalidResponse if entries.empty?
+
+        entries
+      rescue Stash::Compressed::ZipError, Stash::Compressed::InvalidResponse
+        entries = fallback_file_entries1
+        return entries unless entries.empty?
+
+        fallback_file_entries2
+      end
+
     end
   end
 end

--- a/lib/stash/compressed/zip_info.rb
+++ b/lib/stash/compressed/zip_info.rb
@@ -201,8 +201,10 @@ module Stash
         entries
       rescue Stash::Compressed::ZipError, Stash::Compressed::InvalidResponse
         begin
-          entries = fallback_file_entries1
-          return entries unless entries.empty?
+          if size < 8e+9.to_i # 8GB and the dumb zip library writes something to disk when it streams so it fills up disk
+            entries = fallback_file_entries1
+            return entries unless entries.empty?
+          end
         rescue Zip::GPFBit3Error
           # ignore
           # this is a known issue with rubyzip

--- a/lib/stash/compressed/zip_info.rb
+++ b/lib/stash/compressed/zip_info.rb
@@ -200,8 +200,13 @@ module Stash
 
         entries
       rescue Stash::Compressed::ZipError, Stash::Compressed::InvalidResponse
-        entries = fallback_file_entries1
-        return entries unless entries.empty?
+        begin
+          entries = fallback_file_entries1
+          return entries unless entries.empty?
+        rescue Zip::GPFBit3Error
+          # ignore
+          # this is a known issue with rubyzip
+        end
 
         fallback_file_entries2
       end

--- a/lib/stash/compressed/zip_info.rb
+++ b/lib/stash/compressed/zip_info.rb
@@ -1,6 +1,8 @@
 require 'http'
 require 'stringio'
 require 'charlock_holmes/string'
+require 'zip'
+require 'down/http'
 
 module Stash
   module Compressed
@@ -162,6 +164,36 @@ module Stash
         format = (little_endian_bytes.length == 4 ? 'L<' : 'Q<')
         little_endian_bytes.unpack1(format)
       end
+
+      # this reads the whole file using rubyzip input stream
+      # but it doesn't return size of zip64s always
+      def fallback_file_entries1
+        file_info = []
+        # response = BASE_HTTP.get(@presigned_url)
+        # response.body.each do |chunk|
+        remote_file = Down::Http.open(@presigned_url)
+        Zip::InputStream.open(remote_file) do |io|
+          while entry = io.get_next_entry
+            file_info << { file_name: entry.name, uncompressed_size: entry.size }
+            # puts "Name: #{entry.name}, Size: #{entry.size}, Compressed Size: #{entry.compressed_size}"
+          end
+        end
+        file_info
+      end
+
+      # this maybe seems to do better with zip64 if java jar is installed
+      def fallback_file_entries2
+        file_info = []
+        std_out = `curl -s -L "#{@presigned_url}" | jar -tv`
+        std_out.each_line do |line|
+          arr = line.strip.split(/\s+/, 8)
+          my_fn = arr[-1]
+          my_size = arr[0].to_i
+          file_info << { file_name: my_fn , uncompressed_size: my_size }
+        end
+        file_info
+      end
+
     end
   end
 end

--- a/lib/tasks/compressed/info.rb
+++ b/lib/tasks/compressed/info.rb
@@ -1,3 +1,5 @@
+require 'stash/compressed'
+
 module Tasks
   module Compressed
     module Info
@@ -6,7 +8,8 @@ module Tasks
       def self.files(db_file:)
         entries =
           if db_file.upload_file_name.downcase.end_with?('.zip')
-            Stash::Compressed::ZipInfo.new(presigned_url: db_file.merritt_s3_presigned_url).file_entries
+            zip_info = Stash::Compressed::ZipInfo.new(presigned_url: db_file.merritt_s3_presigned_url)
+            zip_info.entries_with_fallback
           elsif db_file.upload_file_name.downcase.end_with?('.tar.gz', '.tgz')
             Stash::Compressed::TarGz.new(presigned_url: db_file.merritt_s3_presigned_url).file_entries
           else

--- a/spec/lib/stash/compressed/zip_info_spec.rb
+++ b/spec/lib/stash/compressed/zip_info_spec.rb
@@ -231,6 +231,37 @@ module Stash
         end
       end
 
+      describe '#fallback_file_entries1' do
+        it 'gives correct file entries for zip32' do
+          file_string = File.binread('spec/fixtures/zipfiles/test_zip.zip')
+          stub_request(:get, 'https://example.com/zipfile.zip')
+            .with(headers: { 'Host' => 'example.com' })
+            .to_return(status: 200, body: file_string,
+                       headers: { 'Content-Type' => 'application/zip' })
+
+          zi = Stash::Compressed::ZipInfo.new(presigned_url: 'https://example.com/zipfile.zip')
+          fe = zi.fallback_file_entries1
+          expect(fe.first[:file_name]).to eq('Screen Shot 2022-12-09 at 12.17.31 PM.png')
+          expect(fe.first[:uncompressed_size]).to eq(68_742)
+        end
+      end
+
+      describe '#fallback_file_entries2' do
+        # there isn't a good way to mock this since it's outside of rails network libraries w/ curl
+        # but tested manually
+        xit 'gives correct file entries for zip32' do
+          file_string = File.binread('spec/fixtures/zipfiles/test_zip.zip')
+          stub_request(:get, 'https://example.com/zipfile.zip')
+            .with(headers: { 'Host' => 'example.com' })
+            .to_return(status: 200, body: file_string,
+                       headers: { 'Content-Type' => 'application/zip' })
+
+          zi = Stash::Compressed::ZipInfo.new(presigned_url: 'https://example.com/zipfile.zip')
+          fe = zi.fallback_file_entries2
+          expect(fe.first[:file_name]).to eq('Screen Shot 2022-12-09 at 12.17.31 PM.png')
+          expect(fe.first[:uncompressed_size]).to eq(68_742)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I added a couple of fallbacks that read the entire file and try to get the contents from the full stream.  IDK if they're much more reliable but could maybe be used if needed.

The two methods:
- fallback_file_entries1
- fallback_file_entries2

Example:
```
$ rails c -e production

df = StashEngine::DataFile.find(412283)
zip_info = Stash::Compressed::ZipInfo.new(presigned_url: df.merritt_s3_presigned_url)
zip_info.file_entries
zip_info.fallback_file_entries1
zip_info.fallback_file_entries2
```

Output should be pretty much the same for all 3 on average files except fallbacks don't give compressed_size information.  Maybe there are some edge cases where one will give output that others can't.