### PR TITLE
Make "manuscript in progress" the default 

### DIFF
--- a/app/controllers/stash_engine/resources_controller.rb
+++ b/app/controllers/stash_engine/resources_controller.rb
@@ -52,7 +52,7 @@ module StashEngine
       resource = Resource.new(user_id: current_user.id, current_editor_id: current_user.id, tenant_id: current_user.tenant_id)
       my_id = Stash::Doi::IdGen.mint_id(resource: resource)
       id_type, id_text = my_id.split(':', 2)
-      db_id_obj = Identifier.create(identifier: id_text, identifier_type: id_type.upcase)
+      db_id_obj = Identifier.create(identifier: id_text, identifier_type: id_type.upcase, import_info: 'manuscript')
       resource.identifier_id = db_id_obj.id
       resource.save
       resource.fill_blank_author!

--- a/app/javascript/react/components/MetadataEntry/PrelimArticle.jsx
+++ b/app/javascript/react/components/MetadataEntry/PrelimArticle.jsx
@@ -81,11 +81,7 @@ function PrelimArticle({
     >
       {(formik) => (
         <Form className="c-input__inline">
-          <div className="c-import__form-section">
-            <p>Please provide the following information. You may either enter the information and leave it or choose
-              to autofill your dataset based on the information you supply below.
-            </p>
-
+          <div className="c-import__form-section" style={{width: '100%'}}>
             <div className="c-input__inline">
               <div className="c-input">
                 <PrelimAutocomplete

--- a/app/javascript/react/components/MetadataEntry/PrelimManu.jsx
+++ b/app/javascript/react/components/MetadataEntry/PrelimManu.jsx
@@ -79,11 +79,7 @@ function PrelimManu({
     >
       {(formik) => (
         <Form className="c-input__inline">
-          <div className="c-import__form-section">
-            <p>Please provide the following information. You may either enter the information and leave it or choose
-              to autofill your dataset based on the information you supply below.
-            </p>
-
+          <div className="c-import__form-section" style={{width: '100%'}}>
             <div className="c-input__inline">
               <div className="c-input">
                 <PrelimAutocomplete


### PR DESCRIPTION
when starting a new item from the UI.

Also removes the weird text that tells them they don't need to import.

Leaves the default alone when not started outside the UI.  I don't see this breaking anything and I didn't find information in my email or the ticket history about why we set it to other.