### PR TITLE
Fixes some incorrect paths and troublehooting counter upload

### DIFF
--- a/lib/tasks/counter.rake
+++ b/lib/tasks/counter.rake
@@ -96,9 +96,9 @@ namespace :counter do
     # RAILS_ENV=production REPORT_DIR="/my/report/dir" FORCE_SUBMISSION="2021-11" bundle exec rails counter:datacite_pusher
     $stdout.sync = true
 
-    require_relative '../../../script/counter-uploader/submitted_reports'
-    require_relative '../../../script/counter-uploader/uploader'
-    require_relative '../../../script/counter-uploader/utility_methods'
+    require_relative '../../stash/script/counter-uploader/submitted_reports'
+    require_relative '../../stash/script/counter-uploader/uploader'
+    require_relative '../../stash/script/counter-uploader/utility_methods'
 
     if ENV['REPORT_DIR'].blank?
       puts 'You must set an environment varaiable for REPORT_DIR to upload to DataCite.'

--- a/stash/script/counter-uploader/uploader.rb
+++ b/stash/script/counter-uploader/uploader.rb
@@ -57,7 +57,7 @@ class Uploader
 
     resp = nil
     12.times do |i|
-      puts "  Try #{1}"
+      puts "  Try #{i}"
       resp =
         if @report_id.nil?
           @http.post(URI, body: body, headers: headers)

--- a/stash/script/counter-uploader/uploader.rb
+++ b/stash/script/counter-uploader/uploader.rb
@@ -56,7 +56,8 @@ class Uploader
     body = compress(file)
 
     resp = nil
-    12.times do
+    12.times do |i|
+      puts "  Try #{1}"
       resp =
         if @report_id.nil?
           @http.post(URI, body: body, headers: headers)
@@ -64,6 +65,9 @@ class Uploader
           @http.put("#{URI}/#{@report_id}", body: body, headers: headers)
         end
       break if resp.status.code.between?(200, 299)
+
+      puts "  Status code #{resp.status.code}"
+      puts "  Response body: \n #{resp.body}"
 
       sleep 5
     end


### PR DESCRIPTION
- Some of the `require_relative` paths were now incorrect after some refactor
- Adding a bit of output for errors.

It seems that our credentials at DataCite no longer work for uploading to their hub so trying to get updated ones from Kristian.