### PR TITLE
Do not dump stash_engine_container_files

### DIFF
--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -95,7 +95,7 @@ namespace :dev_ops do
     db = YAML.load(ERB.new(File.read(File.join(Rails.root, 'config', 'database.yml'))).result)[Rails.env]
     # rubocop:enable Security/YAMLLoad
     file = File.join(directory, "#{Rails.env}_#{Time.now.strftime('%H_%M')}.sql")
-    p command = 'mysqldump --opt --skip-add-locks --single-transaction --no-create-db ' \
+    p command = 'mysqldump --opt --skip-add-locks --single-transaction --no-create-db --ignore-table=dryad.stash_engine_container_files ' \
                 "-h #{db['host']} -u #{db['username']} -p#{db['password']} #{db['database']} | gzip > #{file}.gz"
     exec command
   end

--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -96,6 +96,8 @@ namespace :dev_ops do
     # rubocop:enable Security/YAMLLoad
     file = File.join(directory, "#{Rails.env}_#{Time.now.strftime('%H_%M')}.sql")
     p command = 'mysqldump --opt --skip-add-locks --single-transaction --no-create-db --ignore-table=dryad.stash_engine_container_files ' \
+                '--ignore-table=dryad.stash_engine_ror_orgs --ignore-table=dryad.stash_engine_curation_stats ' \
+                '--ignore-table=dryad.stash_engine_frictionless_reports --ignore-table=dryad.stash_engine_download_tokens ' \
                 "-h #{db['host']} -u #{db['username']} -p#{db['password']} #{db['database']} | gzip > #{file}.gz"
     exec command
   end


### PR DESCRIPTION
 since it causes the IO burst credits to go down drastically since it has lots of rows.

I am testing this out (see https://metrics.librato.com/s/public/azpakcmwd?duration=1800&source=%2Ards-uc3-dryad-prd%2A ).  On the first run, the burst credits went down from 99% to 95% after running.

The dump files are about 25% smaller.  I need to watch the credits for a day or so to see if they recover afterward or just keep going down more and more over time.  If the burst credits are depleting slowly still then we may need to look into other solutions (and may need to soon as our database grows for other reasons).