### PR TITLE
For examining crossref funders vs ror mapping

### DIFF
--- a/app/models/stash_engine/xref_funder_to_ror.rb
+++ b/app/models/stash_engine/xref_funder_to_ror.rb
@@ -1,0 +1,5 @@
+module StashEngine
+  class XrefFunderToRor < ApplicationRecord
+    self.table_name = 'stash_engine_xref_funder_to_rors'
+  end
+end

--- a/db/migrate/20230419184528_create_xref_funder_to_rors.rb
+++ b/db/migrate/20230419184528_create_xref_funder_to_rors.rb
@@ -1,0 +1,8 @@
+class CreateXrefFunderToRors < ActiveRecord::Migration[6.1]
+  def change
+    create_table :stash_engine_xref_funder_to_rors do |t|
+      t.string :xref_id, index: true
+      t.string :ror_id, index: true
+    end
+  end
+end

--- a/documentation/sql_queries/fundref_to_ror_comparisons.md
+++ b/documentation/sql_queries/fundref_to_ror_comparisons.md
@@ -1,0 +1,35 @@
+# Crossref Funder ID to ROR comparison
+
+## Evaluating the mapping of Crossref Funder IDs to ROR IDs
+
+In order to evaluate how well these identifiers map from one to the other, it's easiest to get the identifiers into 
+our database so we can join and compare them.
+
+Run a rake task like this example which will put a mapping in stash_engine_xref_funder_to_rors:
+```bash
+RAILS_ENV=<environment> bundle exec rails affiliation_import:populate_funder_ror_mapping <path/to/ror/dump.json>
+```
+
+After the import you can run the following query to see how items in the database map and that
+names seem sane where a mapping exists.
+
+```sql
+SELECT DISTINCT c.contributor_name as xref_name, x.`xref_id`, x.ror_id, r.name as ror_name
+  FROM dcs_contributors c
+  JOIN `stash_engine_xref_funder_to_rors` x
+    ON c.name_identifier_id = x.`xref_id`
+  JOIN stash_engine_ror_orgs r
+    ON x.ror_id = r.ror_id
+ WHERE c.identifier_type = 'crossref_funder_id' and c.contributor_type = 'funder';
+```
+
+To see unmatched identifiers where a ror matching doesn't exist from the identifiers:
+
+```sql
+SELECT DISTINCT c.contributor_name as xref_name, c.name_identifier_id
+  FROM dcs_contributors c
+  LEFT JOIN stash_engine_xref_funder_to_rors x
+    ON c.name_identifier_id = x.xref_id
+ WHERE c.identifier_type = 'crossref_funder_id' and c.contributor_type = 'funder'
+    AND c.name_identifier_id <> '' AND x.ror_id IS NULL;
+```


### PR DESCRIPTION
See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2096

this includes

- a new database table
- a script to populate the xref funders and associated RORs into a table for ease of joining
- Some SQL queries to examine how well things map automatically

From examining the development database (garbage data) there were definitely some that mapped cleanly and some that didn't map.  I assume the same will be the case in production but it would be useful to get the new table and other things on production to find out (next week).

You can try the sample queries to see how things line up if you like.  I used the latest ROR dump from this month to populate the table.