### PR TITLE
Add/update curation reports

### DIFF
--- a/app/views/stash_engine/curation_stats/index.csv.erb
+++ b/app/views/stash_engine/curation_stats/index.csv.erb
@@ -1,4 +1,4 @@
-<%= "Date,Curated,ToBeCurated,New,NewToSubmitted,NewToPPR,PPRToCuration,CurationToAAR,CurationToPublished,Embargoed,Withdrawn,AuthorRevised,AuthorVersioned" %>
+<%= "Date,Curated,QueueSize,New,NewToSubmitted,NewToPPR,PPRToCuration,CurationToAAR,CurationToPublished,Embargoed,Withdrawn,AuthorRevised,AuthorVersioned" %>
 <% @all_stats.each do |stat|
     row = [
 	formatted_date(stat.date),

--- a/app/views/stash_engine/curation_stats/index.html.erb
+++ b/app/views/stash_engine/curation_stats/index.html.erb
@@ -22,8 +22,8 @@
       <th title="Date for the activity, bounded by UTC.">Date</th>
       <th title="The number of datasets processed that day (meaning the status changed from 'curation' to 'action_required', 'embargoed', or 'published')"
 	 >Curated</th>
-      <th title="The number of datasets available for curation on that day (either entered 'curation' or 'submitted', and the author made the last change)"
-	 >To be curated</th>
+      <th title="The number of datasets available for curation on that day ('curation' or 'submitted')"
+	 >Queue Size</th>
       <th title="Total of all new submissions that day (so the first time we see them as 'submitted' or 'peer_review' in the system)"
 	 >New</th>
       <th title="The number of new datasets submitted that day (so the first time we see them as 'submitted' in the system)"


### PR DESCRIPTION
Closes https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2419 and https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2239

- Adding a rake report `curation_publication_report` that generates stats Jess wanted to present to the board. It is mostly a recombining of stats we had in other reports.
- On the curation stats page, replace the "To be curated" column with the similar but more useful "Queue size". The new value calculates the number of datasets that actually require curation on a given day, rather than the old stat that did a very complex calculation to determine the items that were "new" in the queue each day. Since this is a shift in meaning instead of a completely new stat, I kept the existing database column.
