### PR TITLE
When transferring ownership, transfer editorial control as well

### DIFF
--- a/app/controllers/stash_engine/metadata_entry_pages_controller.rb
+++ b/app/controllers/stash_engine/metadata_entry_pages_controller.rb
@@ -47,6 +47,7 @@ module StashEngine
                                        note: "Transferring ownership to #{current_user.name} (#{current_user.id}) using an edit code")
           @resource.curation_activities << ca
           @resource.user_id = current_user.id
+          @resource.current_editor_id = current_user.id
           @resource.save
         else
           # The user will need to login (possibly creating an


### PR DESCRIPTION
When a manuscript system transfers dataset ownership to a user, it should also transfer editorial control, in case the user changes their mind and decides not to submit the dataset, but wants to delete it. (Datasets created through the UI assign the initial editorial control to the submitter, so this is enforcing the same behavior.)

For reference, see [salesforce case 00022276](https://dryad.lightning.force.com/lightning/r/Case/5003h00000bTmQFAA0/view).