### PR TITLE
Use Pundit for stash_engine permissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -184,3 +184,5 @@ group :development, :test, :local_dev do
   # rspec command for spring (https://github.com/jonleighton/spring-commands-rspec)
   gem 'spring-commands-rspec'
 end
+
+gem 'pundit', '~> 2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -528,6 +528,8 @@ GEM
     public_suffix (5.0.1)
     puma (6.1.0)
       nio4r (~> 2.0)
+    pundit (2.3.0)
+      activesupport (>= 3.0.0)
     racc (1.6.2)
     rack (2.2.6.3)
     rack-attack (6.6.1)
@@ -860,6 +862,7 @@ DEPENDENCIES
   pry-rails
   pry-remote
   puma
+  pundit (~> 2.3)
   rack-attack
   rails (~> 6.1.0)
   rb-readline

--- a/app/controllers/stash_engine/admin_dataset_funders_controller.rb
+++ b/app/controllers/stash_engine/admin_dataset_funders_controller.rb
@@ -5,12 +5,12 @@ module StashEngine
     def index
       setup_paging
 
-      @rep = authorize Report.new, policy_class: AdminDatasetsFunderPolicy
-      # the AdminFundersController::Report is where most of the complicated SQL is for this
+      @rep = authorize Report.new, policy_class: AdminDatasetFunderPolicy
+      # the AdminDatasetFundersController::Report is where most of the complicated SQL is for this
 
       # WHERE conditions
       # Limit to tenant by either role or selected limit
-      @rep = policy_scope(@rep, policy_scope_class: AdminDatasetsFunderPolicy::Scope)
+      @rep = policy_scope(@rep, policy_scope_class: AdminDatasetFunderPolicy::Scope)
       @rep.add_where(arr: ['last_res.tenant_id = ?', params[:tenant]]) if params[:tenant]
 
       @rep.add_limit(offset: (@page - 1) * @page_size, rows: @page_size + 1) # add 1 to page size so it will have next page

--- a/app/controllers/stash_engine/admin_dataset_funders_controller.rb
+++ b/app/controllers/stash_engine/admin_dataset_funders_controller.rb
@@ -12,7 +12,7 @@ module StashEngine
       # WHERE conditions
       # Limit to tenant by either role or selected limit
       @rep = policy_scope(@rep, policy_scope_class: AdminDatasetFunderPolicy::Scope)
-      @rep.add_where(arr: ['last_res.tenant_id = ?', params[:tenant]]) if params[:tenant]
+      @rep.add_where(arr: ['last_res.tenant_id = ?', params[:tenant]]) if params[:tenant].present?
 
       @rep.add_limit(offset: (@page - 1) * @page_size, rows: @page_size + 1) # add 1 to page size so it will have next page
 

--- a/app/controllers/stash_engine/admin_dataset_funders_controller.rb
+++ b/app/controllers/stash_engine/admin_dataset_funders_controller.rb
@@ -1,21 +1,19 @@
 module StashEngine
   class AdminDatasetFundersController < ApplicationController
-    include SharedSecurityController
     helper SortableTableHelper
-
-    before_action :require_admin
 
     def index
       setup_paging
 
-      @rep = Report.new # the AdminFundersController::Report is where most of the complicated SQL is for this
-      @rep.add_limit(offset: (@page - 1) * @page_size, rows: @page_size + 1) # add 1 to page size so it will have next page
+      @rep = authorize Report.new, policy_class: AdminDatasetsFunderPolicy
+      # the AdminFundersController::Report is where most of the complicated SQL is for this
 
       # WHERE conditions
       # Limit to tenant by either role or selected limit
-      @role_limit = (%w[admin tenant_curator].include?(current_user.role) ? current_user.tenant_id : nil)
-      tenant_limit = @role_limit || params[:tenant]
-      @rep.add_where(arr: ['last_res.tenant_id = ?', tenant_limit]) if tenant_limit.present?
+      @rep = policy_scope(@rep, policy_scope_class: AdminDatasetsFunderPolicy::Scope)
+      @rep.add_where(arr: ['last_res.tenant_id = ?', params[:tenant]]) if params[:tenant]
+
+      @rep.add_limit(offset: (@page - 1) * @page_size, rows: @page_size + 1) # add 1 to page size so it will have next page
 
       add_funder_limit
       add_date_range

--- a/app/controllers/stash_engine/admin_dataset_funders_controller.rb
+++ b/app/controllers/stash_engine/admin_dataset_funders_controller.rb
@@ -1,6 +1,7 @@
 module StashEngine
   class AdminDatasetFundersController < ApplicationController
     helper SortableTableHelper
+    before_action :require_user_login
 
     def index
       setup_paging

--- a/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -10,7 +10,6 @@ module StashEngine
     before_action :require_admin
     before_action :setup_paging, only: [:index]
 
-    include Pundit::Authorization
     # after_action :verify_policy_scoped, only: %i[index]
 
     TENANT_IDS = Tenant.all.map(&:tenant_id)

--- a/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -5,6 +5,7 @@ module StashEngine
   class AdminDatasetsController < ApplicationController
 
     helper SortableTableHelper
+    before_action :require_user_login
     before_action :setup_paging, only: [:index]
 
     TENANT_IDS = Tenant.all.map(&:tenant_id)

--- a/app/controllers/stash_engine/application_controller.rb
+++ b/app/controllers/stash_engine/application_controller.rb
@@ -5,10 +5,13 @@ require 'uri'
 module StashEngine
   class ApplicationController < ::ApplicationController
 
+    include Pundit::Authorization
     include SharedController
     include SharedSecurityController
 
     prepend_view_path("#{Rails.application.root}/app/views")
+
+    rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
     # returns the :return_to_path set in the session or else goes back to the path supplied
     def return_to_path_or(default_path)
@@ -23,6 +26,11 @@ module StashEngine
     end
 
     private
+
+    def user_not_authorized
+      flash[:alert] = 'You are not authorized to view this information.'
+      redirect_back(fallback_location: stash_url_helpers.dashboard_path)
+    end
 
     def display_authorization_failure
       Rails.logger.warn("Resource #{resource ? resource.id : 'nil'}: user ID is #{resource.user_id || 'nil'} but " \

--- a/app/controllers/stash_engine/application_controller.rb
+++ b/app/controllers/stash_engine/application_controller.rb
@@ -29,14 +29,14 @@ module StashEngine
 
     def user_not_authorized
       flash[:alert] = 'You are not authorized to view this information.'
-      redirect_back(fallback_location: stash_url_helpers.dashboard_path)
+      redirect_back(fallback_location: '/stash/dashboard')
     end
 
     def display_authorization_failure
       Rails.logger.warn("Resource #{resource ? resource.id : 'nil'}: user ID is #{resource.user_id || 'nil'} but " \
                         "current user is #{current_user.id || 'nil'}")
       flash[:alert] = 'You do not have permission to modify this dataset.'
-      redirect_to stash_url_helpers.dashboard_path
+      redirect_back(fallback_location: '/stash/dashboard')
     end
 
     def redirect_url_for(original_url, host, port)

--- a/app/controllers/stash_engine/curation_activity_controller.rb
+++ b/app/controllers/stash_engine/curation_activity_controller.rb
@@ -6,7 +6,7 @@ module StashEngine
 
     # GET /resources/{id}/curation_activities
     def index
-      @resource = Resource.includes(:identifier, :curation_activities).find(params[:resource_id])
+      resource = Resource.includes(:identifier, :curation_activities).find(params[:resource_id])
       @ident = resource.identifier
       @curation_activities = authorize resource.curation_activities.order(created_at: :desc), policy_class: CurationActivityPolicy
       respond_to do |format|

--- a/app/controllers/stash_engine/curation_activity_controller.rb
+++ b/app/controllers/stash_engine/curation_activity_controller.rb
@@ -1,16 +1,15 @@
 module StashEngine
   class CurationActivityController < ApplicationController
-    include SharedSecurityController
-    helper AdminDatasetsHelper
+    include Pundit::Authorization
+    after_action :verify_authorized, except: :curation_activity_params
 
-    before_action :require_limited_curator, only: :index
-    before_action :ajax_require_limited_curator, only: :status_change
+    helper AdminDatasetsHelper
 
     # GET /resources/{id}/curation_activities
     def index
-      resource = Resource.includes(:identifier, :curation_activities).find(params[:resource_id])
+      @resource = Resource.includes(:identifier, :curation_activities).find(params[:resource_id])
       @ident = resource.identifier
-      @curation_activities = resource.curation_activities.order(created_at: :desc)
+      @curation_activities = authorize resource.curation_activities.order(created_at: :desc), policy_class: CurationActivityPolicy
       respond_to do |format|
         format.html
         format.json { render json: @curation_activities }
@@ -21,9 +20,9 @@ module StashEngine
     def curation_note
       # only add to latest resource and after latest curation activity, no matter if this page is stale or whatever
       @resource = Identifier.find_by_id(params[:id]).latest_resource
-      @curation_activity = CurationActivity.create(resource_id: @resource.id, user_id: current_user.id,
-                                                   status: @resource.last_curation_activity&.status,
-                                                   note: params[:stash_engine_curation_activity][:note])
+      @curation_activity = authorize CurationActivity.create(resource_id: @resource.id, user_id: current_user.id,
+                                                             status: @resource.last_curation_activity&.status,
+                                                             note: params[:stash_engine_curation_activity][:note])
       @resource.reload
     end
 

--- a/app/controllers/stash_engine/curation_activity_controller.rb
+++ b/app/controllers/stash_engine/curation_activity_controller.rb
@@ -1,7 +1,6 @@
 module StashEngine
   class CurationActivityController < ApplicationController
-    include Pundit::Authorization
-    after_action :verify_authorized, except: :curation_activity_params
+    # after_action :verify_authorized, except: :curation_activity_params
 
     helper AdminDatasetsHelper
 

--- a/app/controllers/stash_engine/curation_activity_controller.rb
+++ b/app/controllers/stash_engine/curation_activity_controller.rb
@@ -1,7 +1,6 @@
 module StashEngine
   class CurationActivityController < ApplicationController
-    # after_action :verify_authorized, except: :curation_activity_params
-
+    before_action :require_user_login
     helper AdminDatasetsHelper
 
     # GET /resources/{id}/curation_activities

--- a/app/controllers/stash_engine/curation_stats_controller.rb
+++ b/app/controllers/stash_engine/curation_stats_controller.rb
@@ -1,7 +1,5 @@
 module StashEngine
   class CurationStatsController < ApplicationController
-    include Pundit::Authorization
-
     helper SortableTableHelper
 
     def index

--- a/app/controllers/stash_engine/curation_stats_controller.rb
+++ b/app/controllers/stash_engine/curation_stats_controller.rb
@@ -1,5 +1,6 @@
 module StashEngine
   class CurationStatsController < ApplicationController
+    before_action :require_user_login
     helper SortableTableHelper
 
     def index

--- a/app/controllers/stash_engine/curation_stats_controller.rb
+++ b/app/controllers/stash_engine/curation_stats_controller.rb
@@ -1,18 +1,17 @@
 module StashEngine
   class CurationStatsController < ApplicationController
-    before_action :require_admin
+    include Pundit::Authorization
 
-    include SharedSecurityController
     helper SortableTableHelper
 
     def index
       params.permit(:format)
 
-      @all_stats = CurationStats.all
-      @current_stats = CurationStats.where(date: 1.month.ago..Date.today).order('date DESC')
+      @all_stats = authorize CurationStats.all
+      @current_stats = authorize CurationStats.where(date: 1.month.ago..Date.today).order('date DESC')
 
-      @admin_stats = StashEngine::AdminDatasetsController::Stats.new
-      @admin_stats_3day = StashEngine::AdminDatasetsController::Stats.new(untouched_since: Time.now - 3.days)
+      @admin_stats = authorize StashEngine::AdminDatasetsController::Stats.new
+      @admin_stats_3day = authorize StashEngine::AdminDatasetsController::Stats.new(untouched_since: Time.now - 3.days)
 
       respond_to do |format|
         format.html

--- a/app/controllers/stash_engine/curation_stats_controller.rb
+++ b/app/controllers/stash_engine/curation_stats_controller.rb
@@ -8,8 +8,10 @@ module StashEngine
       @all_stats = authorize CurationStats.all
       @current_stats = authorize CurationStats.where(date: 1.month.ago..Date.today).order('date DESC')
 
-      @admin_stats = authorize StashEngine::AdminDatasetsController::Stats.new
-      @admin_stats_3day = authorize StashEngine::AdminDatasetsController::Stats.new(untouched_since: Time.now - 3.days)
+      @admin_stats = authorize StashEngine::AdminDatasetsController::Stats.new, policy_class: CurationStatsPolicy
+      @admin_stats_3day = authorize StashEngine::AdminDatasetsController::Stats.new(
+        untouched_since: Time.now - 3.days
+      ), policy_class: CurationStatsPolicy
 
       respond_to do |format|
         format.html

--- a/app/controllers/stash_engine/dashboard_controller.rb
+++ b/app/controllers/stash_engine/dashboard_controller.rb
@@ -1,6 +1,6 @@
 module StashEngine
   class DashboardController < ApplicationController
-    before_action :require_login, only: %i[show]
+    before_action :require_login, only: :show
     before_action :ensure_tenant, only: :show
 
     # apply Pundit?

--- a/app/controllers/stash_engine/dashboard_controller.rb
+++ b/app/controllers/stash_engine/dashboard_controller.rb
@@ -3,6 +3,8 @@ module StashEngine
     before_action :require_login, only: %i[show]
     before_action :ensure_tenant, only: :show
 
+    # apply Pundit?
+
     MAX_VALIDATION_TRIES = 5
 
     def show; end

--- a/app/controllers/stash_engine/frictionless_report_controller.rb
+++ b/app/controllers/stash_engine/frictionless_report_controller.rb
@@ -1,6 +1,5 @@
 module StashEngine
   class FrictionlessReportController < ApplicationController
     before_action :require_login
-    # apply Pundit?
   end
 end

--- a/app/controllers/stash_engine/frictionless_report_controller.rb
+++ b/app/controllers/stash_engine/frictionless_report_controller.rb
@@ -1,5 +1,6 @@
 module StashEngine
   class FrictionlessReportController < ApplicationController
     before_action :require_login
+    # apply Pundit?
   end
 end

--- a/app/controllers/stash_engine/generic_files_controller.rb
+++ b/app/controllers/stash_engine/generic_files_controller.rb
@@ -8,6 +8,8 @@ module StashEngine
     before_action :set_file_info, only: %i[destroy_manifest]
     before_action :ajax_require_modifiable, only: %i[destroy_manifest validate_urls presign_upload upload_complete]
 
+    # apply Pundit?
+
     helper_method :resource
 
     # this should be overridden for each specific type of file class

--- a/app/controllers/stash_engine/gmail_auth_controller.rb
+++ b/app/controllers/stash_engine/gmail_auth_controller.rb
@@ -1,10 +1,7 @@
 module StashEngine
   class GmailAuthController < ApplicationController
-    before_action :require_superuser
-
-    include SharedSecurityController
-
     def index
+      authorize %i[stash_engine gmail_auth_policy], :index?
       params.permit(:format)
 
       respond_to(&:html)

--- a/app/controllers/stash_engine/internal_data_controller.rb
+++ b/app/controllers/stash_engine/internal_data_controller.rb
@@ -1,15 +1,14 @@
 module StashEngine
   class InternalDataController < ApplicationController
-    include SharedSecurityController
-
-    before_action :require_limited_curator
+    include Pundit::Authorization
+    # after_action :verify_authorized
 
     # I don't believe the following is used except as a test, internal data list is currently in the admin datasets
     # controller with some other things on the same page.
     # GET /identifiers/:identifier_id/internal_data
     def index
       ident = Identifier.find_with_id(Resource.find_by!(id: params[:resource_id]).identifier_str)
-      @internal_data = InternalDatum.where(identifier_id: ident.identifier_id) unless ident.blank?
+      @internal_data = authorize InternalDatum.where(identifier_id: ident.identifier_id) unless ident.blank?
       respond_to do |format|
         format.html
         format.json { render json: @internal_data }
@@ -22,8 +21,8 @@ module StashEngine
       respond_to do |format|
         format.js do
           # right now, the only way to add is by ajax, UJS, so Javascript from the dataset admin area
-          InternalDatum.create(identifier_id: @identifier.id, data_type: params[:stash_engine_internal_datum][:data_type],
-                               value: params[:stash_engine_internal_datum][:value])
+          authorize InternalDatum.create(identifier_id: @identifier.id, data_type: params[:stash_engine_internal_datum][:data_type],
+                                         value: params[:stash_engine_internal_datum][:value])
           @internal_data = InternalDatum.where(identifier_id: @identifier.id)
         end
       end
@@ -31,7 +30,7 @@ module StashEngine
 
     # PUT /internal_data/:id
     def update
-      @internal_datum = InternalDatum.find(params[:id])
+      @internal_datum = authorize InternalDatum.find(params[:id])
       @identifier = @internal_datum.stash_identifier
       respond_to do |format|
         format.js do
@@ -45,7 +44,7 @@ module StashEngine
 
     # DELETE /internal_data/:id
     def destroy
-      @internal_datum = InternalDatum.find(params[:id])
+      @internal_datum = authorize InternalDatum.find(params[:id])
       @identifier_id = @internal_datum.identifier_id
       respond_to do |format|
         format.js do

--- a/app/controllers/stash_engine/internal_data_controller.rb
+++ b/app/controllers/stash_engine/internal_data_controller.rb
@@ -1,8 +1,5 @@
 module StashEngine
   class InternalDataController < ApplicationController
-    include Pundit::Authorization
-    # after_action :verify_authorized
-
     # I don't believe the following is used except as a test, internal data list is currently in the admin datasets
     # controller with some other things on the same page.
     # GET /identifiers/:identifier_id/internal_data
@@ -17,12 +14,12 @@ module StashEngine
 
     # POST /identifiers/:identifier_id/internal_data
     def create
-      @identifier = Identifier.find(params[:identifier_id])
+      @identifier = authorize Identifier.find(params[:identifier_id]), policy_class: InternalDatumPolicy
       respond_to do |format|
         format.js do
           # right now, the only way to add is by ajax, UJS, so Javascript from the dataset admin area
-          authorize InternalDatum.create(identifier_id: @identifier.id, data_type: params[:stash_engine_internal_datum][:data_type],
-                                         value: params[:stash_engine_internal_datum][:value])
+          InternalDatum.create(identifier_id: @identifier.id, data_type: params[:stash_engine_internal_datum][:data_type],
+                               value: params[:stash_engine_internal_datum][:value])
           @internal_data = InternalDatum.where(identifier_id: @identifier.id)
         end
       end

--- a/app/controllers/stash_engine/internal_data_controller.rb
+++ b/app/controllers/stash_engine/internal_data_controller.rb
@@ -3,6 +3,8 @@ module StashEngine
     # I don't believe the following is used except as a test, internal data list is currently in the admin datasets
     # controller with some other things on the same page.
     # GET /identifiers/:identifier_id/internal_data
+    before_action :require_user_login
+
     def index
       ident = Identifier.find_with_id(Resource.find_by!(id: params[:resource_id]).identifier_str)
       @internal_data = authorize InternalDatum.where(identifier_id: ident.identifier_id) unless ident.blank?

--- a/app/controllers/stash_engine/journals_controller.rb
+++ b/app/controllers/stash_engine/journals_controller.rb
@@ -1,13 +1,12 @@
 module StashEngine
   class JournalsController < ApplicationController
 
-    include SharedSecurityController
     helper SortableTableHelper
 
     def index
       params.permit(:q)
       params[:sort] = 'title' if params[:sort].blank?
-      @all_journals = Journal.all
+      @all_journals = authorize Journal.all
 
       metadata_journal_clause = 'stash_engine_journals.id IN ' \
                                 "(select distinct journal_id from stash_engine_manuscripts where created_at > '#{1.year.ago.iso8601}')"

--- a/app/controllers/stash_engine/journals_controller.rb
+++ b/app/controllers/stash_engine/journals_controller.rb
@@ -2,6 +2,7 @@ module StashEngine
   class JournalsController < ApplicationController
 
     helper SortableTableHelper
+    before_action :require_user_login
 
     def index
       params.permit(:q)

--- a/app/controllers/stash_engine/landing_controller.rb
+++ b/app/controllers/stash_engine/landing_controller.rb
@@ -9,6 +9,8 @@ module StashEngine
     before_action :require_identifier_and_resource, only: %i[show]
     protect_from_forgery(except: [:update])
 
+    # apply Pundit?
+
     # ############################################################
     # Helper methods
 

--- a/app/controllers/stash_engine/metadata_entry_pages_controller.rb
+++ b/app/controllers/stash_engine/metadata_entry_pages_controller.rb
@@ -9,6 +9,8 @@ module StashEngine
     before_action :bust_cache, only: %i[find_or_create]
     before_action :require_not_obsolete, only: %i[find_or_create]
 
+    # apply Pundit?
+
     def resource
       @resource ||= Resource.find(params[:resource_id])
     end

--- a/app/controllers/stash_engine/pages_controller.rb
+++ b/app/controllers/stash_engine/pages_controller.rb
@@ -6,45 +6,6 @@ module StashEngine
       @hostname = request.host
     end
 
-    # Utility page that closes itself
-    def close_page; end
-
-    def best_practices; end
-
-    def jounral_integration; end
-
-    def our_governance; end
-
-    def our_mission; end
-
-    def our_membership; end
-
-    def join_us; end
-
-    def our_platform; end
-
-    def our_staff; end
-
-    def pb_tombstone; end
-
-    def publishing_charges; end
-
-    def submission_process; end
-
-    def why_use; end
-
-    def code_of_conduct; end
-
-    def contact; end
-
-    # The faq controller uses the standard app layout, so the default is here.
-    # Perhaps specific views would override it in the base application.
-    def faq; end
-
-    # The about controller uses the standard app layout, so the default is here.
-    # Perhaps specific views would override it in the base application.
-    def about; end
-
     # produces a sitemap for the domain name/tenant listing the released datasets
     # TODO: change page to display all that are embargoed or published, not merritt status and cache the doc so it's not too heavy
     def sitemap

--- a/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/app/controllers/stash_engine/publication_updater_controller.rb
@@ -1,8 +1,5 @@
 module StashEngine
   class PublicationUpdaterController < ApplicationController
-    include Pundit::Authorization
-    # after_action :verify_authorized, except: :setup_paging
-
     helper SortableTableHelper
 
     before_action :setup_paging, only: [:index]

--- a/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/app/controllers/stash_engine/publication_updater_controller.rb
@@ -1,7 +1,7 @@
 module StashEngine
   class PublicationUpdaterController < ApplicationController
     helper SortableTableHelper
-
+    before_action :require_user_login
     before_action :setup_paging, only: [:index]
 
     # the admin datasets main page showing users and stats, but slightly different in scope for curators vs tenant admins

--- a/app/controllers/stash_engine/resources_controller.rb
+++ b/app/controllers/stash_engine/resources_controller.rb
@@ -9,8 +9,6 @@ module StashEngine
     before_action :update_internal_search, only: %i[upload review upload_manifest up_code up_code_manifest]
     before_action :bust_cache, only: %i[upload manifest up_code up_code_manifest review]
     before_action :require_not_obsolete, only: %i[upload manifest up_code up_code_manifest review]
-
-    include Pundit::Authorization
     # after_action :verify_authorized, only: %i[create]
 
     attr_writer :resource

--- a/app/controllers/stash_engine/resources_controller.rb
+++ b/app/controllers/stash_engine/resources_controller.rb
@@ -11,6 +11,8 @@ module StashEngine
     before_action :require_not_obsolete, only: %i[upload manifest up_code up_code_manifest review]
     # after_action :verify_authorized, only: %i[create]
 
+    # apply Pundit?
+
     attr_writer :resource
 
     def resource

--- a/app/controllers/stash_engine/resources_controller.rb
+++ b/app/controllers/stash_engine/resources_controller.rb
@@ -52,15 +52,15 @@ module StashEngine
     # POST /resources
     # POST /resources.json
     def create
-      @resource = authorize Resource.new(user_id: current_user.id, current_editor_id: current_user.id, tenant_id: current_user.tenant_id)
+      resource = authorize Resource.new(user_id: current_user.id, current_editor_id: current_user.id, tenant_id: current_user.tenant_id)
       my_id = Stash::Doi::IdGen.mint_id(resource: resource)
       id_type, id_text = my_id.split(':', 2)
       db_id_obj = Identifier.create(identifier: id_text, identifier_type: id_type.upcase, import_info: 'manuscript')
-      @resource.identifier_id = db_id_obj.id
-      @resource.save
-      @resource.fill_blank_author!
+      resource.identifier_id = db_id_obj.id
+      resource.save
+      resource.fill_blank_author!
       import_manuscript_using_params(resource) if params['journalID']
-      redirect_to stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: @resource.id)
+      redirect_to stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: resource.id)
       # TODO: stop this bad practice of catching a way overly broad error it needs to be specific
     rescue StandardError => e
       logger.error("Unable to create new resource: #{e.full_message}")

--- a/app/controllers/stash_engine/sessions_controller.rb
+++ b/app/controllers/stash_engine/sessions_controller.rb
@@ -12,6 +12,8 @@ module StashEngine
     before_action :callback_basics, only: %i[callback]
     before_action :orcid_preprocessor, only: [:orcid_callback] # do not go to main action if it's just a metadata set, not a login
 
+    # apply Pundit?
+
     # this is the place omniauth calls back for shibboleth logins
     def callback
       current_user.update(tenant_id: params[:tenant_id])

--- a/app/controllers/stash_engine/sessions_controller.rb
+++ b/app/controllers/stash_engine/sessions_controller.rb
@@ -7,7 +7,7 @@ module StashEngine
   class SessionsController < ApplicationController
 
     before_action :bust_cache
-    before_action :require_login_wo_tenant, only: %i[choose_sso no_partner callback sso]
+    before_action :require_user_login, only: %i[choose_sso no_partner callback sso]
     skip_before_action :verify_authenticity_token, only: %i[callback orcid_callback] # omniauth takes care of this differently
     before_action :callback_basics, only: %i[callback]
     before_action :orcid_preprocessor, only: [:orcid_callback] # do not go to main action if it's just a metadata set, not a login

--- a/app/controllers/stash_engine/shared_security_controller.rb
+++ b/app/controllers/stash_engine/shared_security_controller.rb
@@ -9,7 +9,7 @@ module StashEngine
         ]
     end
 
-    def require_login_wo_tenant
+    def require_user_login
       return if current_user.present?
 
       flash[:alert] = 'You must be logged in.'

--- a/app/controllers/stash_engine/status_dashboard_controller.rb
+++ b/app/controllers/stash_engine/status_dashboard_controller.rb
@@ -5,6 +5,7 @@ module StashEngine
   class StatusDashboardController < ApplicationController
 
     include SharedController
+    before_action :require_user_login
 
     # NOTE: that this is a bit confusing since it service checks tied in from various strange places.
 
@@ -12,6 +13,7 @@ module StashEngine
     # similar model ExternalDependency in StashEngine.  It also has specific checks for the dependency in the directory
     # app/services/stash_engine/status_dashboard/<service-name>.rb that does the actual check and sets a value for it.
     def show
+      authorize StashEngine::ExternalDependency.all
       @main_documentation = 'https://confluence.ucop.edu/display/Stash/Dryad+Operations'
       @managed_dependencies = StashEngine::ExternalDependency.where(internally_managed: true).order(:name)
       @unmanaged_dependencies = StashEngine::ExternalDependency.where(internally_managed: false).order(:name)

--- a/app/controllers/stash_engine/submission_queue_controller.rb
+++ b/app/controllers/stash_engine/submission_queue_controller.rb
@@ -6,6 +6,7 @@ module StashEngine
     HOLD_SUBMISSIONS_PATH = File.expand_path(File.join(Rails.root, '..', 'hold-submissions.txt')).freeze
 
     helper SortableTableHelper
+    before_action :require_user_login
 
     def index
       authorize %i[stash_engine repo_queue_state], :index?

--- a/app/controllers/stash_engine/submission_queue_controller.rb
+++ b/app/controllers/stash_engine/submission_queue_controller.rb
@@ -5,12 +5,10 @@ module StashEngine
 
     HOLD_SUBMISSIONS_PATH = File.expand_path(File.join(Rails.root, '..', 'hold-submissions.txt')).freeze
 
-    include SharedSecurityController
     helper SortableTableHelper
 
-    before_action :require_superuser
-
     def index
+      authorize %i[stash_engine repo_queue_state], :index?
       # When the page first loads, the index view lays out the basic framework, but the
       # table starts empty, and it is immediately populated by refresh_table. So there is
       # no actual work to do in the index method.
@@ -21,7 +19,7 @@ module StashEngine
       params[:sort] = 'updated_at' if params[:sort].blank?
       ord = helpers.sortable_table_order(whitelist:
                                            %w[resource_id state hostname updated_at])
-      @queue_rows = RepoQueueState.latest_per_resource.where.not(state: 'completed').order(ord)
+      @queue_rows = authorize RepoQueueState.latest_per_resource.where.not(state: 'completed').order(ord)
       @queued_count = RepoQueueState.latest_per_resource.where(state: 'enqueued').count
       @server_held_count = RepoQueueState.latest_per_resource.where(state: 'rejected_shutting_down')
         .where(hostname: StashEngine.repository.class.hostname).count
@@ -46,7 +44,8 @@ module StashEngine
 
       resource_ids.each do |res_id|
         # clear out all the previous queue states and start with just the first set to 'rejected_shutting_down'
-        RepoQueueState.where(resource_id: res_id).each_with_index do |rqs, idx|
+        @states = authorize RepoQueueState.where(resource_id: res_id)
+        @states.each_with_index do |rqs, idx|
           if idx == 0
             rqs.update(state: 'rejected_shutting_down', hostname: StashEngine.repository.class.hostname) # set up for a re-starting state
           else
@@ -62,6 +61,7 @@ module StashEngine
     private
 
     def enqueue_submissions(resource_ids:)
+      authorize %i[stash_engine repo_queue_state], :index?
       resource_ids.each do |res_id|
         StashEngine.repository.submit(resource_id: res_id)
       end

--- a/app/controllers/stash_engine/user_admin_controller.rb
+++ b/app/controllers/stash_engine/user_admin_controller.rb
@@ -4,7 +4,7 @@ module StashEngine
   class UserAdminController < ApplicationController
 
     helper SortableTableHelper
-
+    before_action :require_user_login
     before_action :load_user, only: %i[email_popup role_popup tenant_popup journals_popup set_role set_tenant set_email user_profile]
     before_action :setup_paging, only: %i[index]
 

--- a/app/controllers/stash_engine/user_admin_controller.rb
+++ b/app/controllers/stash_engine/user_admin_controller.rb
@@ -3,10 +3,8 @@ require 'kaminari'
 module StashEngine
   class UserAdminController < ApplicationController
 
-    include SharedSecurityController
     helper SortableTableHelper
 
-    before_action :require_superuser
     before_action :load_user, only: %i[email_popup role_popup tenant_popup journals_popup set_role set_tenant set_email user_profile]
     before_action :setup_paging, only: %i[index]
 
@@ -22,7 +20,7 @@ module StashEngine
         params[:direction] = 'desc'
       end
 
-      @users = User.all
+      @users = authorize User.all
 
       @users = @users.where('tenant_id = ?', params[:tenant_id]) if params[:tenant_id].present?
 
@@ -91,6 +89,7 @@ module StashEngine
     end
 
     def merge_popup
+      authorize %i[stash_engine user]
       selected_users = params['selected_users'].split(',')
 
       if selected_users.size == 2
@@ -102,6 +101,7 @@ module StashEngine
     end
 
     def merge
+      authorize %i[stash_engine user]
       user1 = StashEngine::User.find(params['user1'])
       user2 = StashEngine::User.find(params['user2'])
       user1.merge_user!(other_user: user2)
@@ -132,7 +132,7 @@ module StashEngine
     end
 
     def load_user
-      @user = User.find(params[:id])
+      @user = authorize User.find(params[:id]), :load_user?
     end
 
     def setup_ds_status_facets

--- a/app/controllers/stash_engine/zenodo_queue_controller.rb
+++ b/app/controllers/stash_engine/zenodo_queue_controller.rb
@@ -2,6 +2,7 @@ module StashEngine
   class ZenodoQueueController < ApplicationController
 
     helper SortableTableHelper
+    before_action :require_user_login
 
     ALLOWED_SORT = %w[id identifier_id resource_id state updated_at copy_type size error_info].freeze
     ALLOWED_ORDER = %w[asc desc].freeze

--- a/app/controllers/stash_engine/zenodo_queue_controller.rb
+++ b/app/controllers/stash_engine/zenodo_queue_controller.rb
@@ -23,6 +23,7 @@ module StashEngine
     SQL
 
     def index
+      authorize %i[stash_engine zenodo_copy]
       sort = (ALLOWED_SORT & [params[:sort]]).first || 'identifier_id'
       order = (ALLOWED_ORDER & [params[:direction]]).first || 'asc'
       sql = <<~SQL
@@ -30,7 +31,7 @@ module StashEngine
         WHERE state != "finished"
         ORDER BY #{sort} #{order};
       SQL
-      @zenodo_copies = authorize ZenodoCopy.find_by_sql(sql)
+      @zenodo_copies = ZenodoCopy.find_by_sql(sql)
     end
 
     def item_details

--- a/app/models/stash_engine/user.rb
+++ b/app/models/stash_engine/user.rb
@@ -65,6 +65,10 @@ module StashEngine
       role == 'tenant_curator' || role == 'admin'
     end
 
+    def admin?
+      role == 'admin' || limited_curator? || journals_as_admin.present? || funders_as_admin.present?
+    end
+
     # this role and higher permission
     def curator?
       role == 'superuser' || role == 'curator' || role == 'tenant_curator'

--- a/app/models/stash_engine/user.rb
+++ b/app/models/stash_engine/user.rb
@@ -61,6 +61,10 @@ module StashEngine
       role == 'superuser'
     end
 
+    def tenant_limited?
+      role == 'tenant_curator' || role == 'admin'
+    end
+
     # this role and higher permission
     def curator?
       role == 'superuser' || role == 'curator' || role == 'tenant_curator'

--- a/app/policies/stash_engine/admin_dataset_funder_policy.rb
+++ b/app/policies/stash_engine/admin_dataset_funder_policy.rb
@@ -1,5 +1,5 @@
 module StashEngine
-  class AdminDatasetsFunderPolicy < ApplicationPolicy
+  class AdminDatasetFunderPolicy < ApplicationPolicy
     def index?
       user.admin?
     end

--- a/app/policies/stash_engine/admin_datasets_funder_policy.rb
+++ b/app/policies/stash_engine/admin_datasets_funder_policy.rb
@@ -1,0 +1,26 @@
+module StashEngine
+  class AdminDatasetsFunderPolicy < ApplicationPolicy
+    def index?
+      user.admin?
+    end
+
+    class Scope
+      def initialize(user, scope)
+        @user = user
+        @scope = scope
+      end
+
+      def resolve
+        if @user.tenant_limited?
+          @scope.add_where(arr: ['last_res.tenant_id = ?', @user.tenant_id])
+        else
+          @scope
+        end
+      end
+
+      private
+
+      attr_reader :user, :scope
+    end
+  end
+end

--- a/app/policies/stash_engine/admin_datasets_policy.rb
+++ b/app/policies/stash_engine/admin_datasets_policy.rb
@@ -1,6 +1,10 @@
 module StashEngine
   class AdminDatasetsPolicy < ApplicationPolicy
 
+    def index?
+      user.admin?
+    end
+
     class Scope
       def initialize(user, scope, params)
         @user = user

--- a/app/policies/stash_engine/admin_datasets_policy.rb
+++ b/app/policies/stash_engine/admin_datasets_policy.rb
@@ -1,0 +1,36 @@
+module StashEngine
+  class AdminDatasetsPolicy
+    attr_reader :user, :datasets
+
+    def initialize(user, datasets)
+      @user = user
+      @datasets = datasets
+    end
+
+    class Scope
+      def initialize(user, scope, params)
+        @user = user
+        @scope = scope
+        @params = params
+      end
+
+      def resolve
+        if @user.tenant_limited?
+          @scope.where(**@params, tenant: @user.tenant)
+        elsif @user.limited_curator?
+          @scope.where(**@params)
+        elsif @user.journals_as_admin.present?
+          @scope.where(**@params, journals: @user.journals_as_admin.map(&:title))
+        elsif @user.funders_as_admin.present?
+          @scope.where(**@params, funders: @user.funders_as_admin.map(&:funder_id))
+        else
+          false
+        end
+      end
+
+      private
+
+      attr_reader :user, :scope
+    end
+  end
+end

--- a/app/policies/stash_engine/admin_datasets_policy.rb
+++ b/app/policies/stash_engine/admin_datasets_policy.rb
@@ -1,11 +1,5 @@
 module StashEngine
-  class AdminDatasetsPolicy
-    attr_reader :user, :datasets
-
-    def initialize(user, datasets)
-      @user = user
-      @datasets = datasets
-    end
+  class AdminDatasetsPolicy < ApplicationPolicy
 
     class Scope
       def initialize(user, scope, params)

--- a/app/policies/stash_engine/application_policy.rb
+++ b/app/policies/stash_engine/application_policy.rb
@@ -1,0 +1,53 @@
+module StashEngine
+  class ApplicationPolicy
+    attr_reader :user, :resouce
+
+    def initialize(user, resource)
+      @user = user
+      @record = resource
+    end
+
+    def index?
+      false
+    end
+
+    def show?
+      false
+    end
+
+    def create?
+      false
+    end
+
+    def new?
+      create?
+    end
+
+    def update?
+      false
+    end
+
+    def edit?
+      update?
+    end
+
+    def destroy?
+      false
+    end
+
+    class Scope
+      def initialize(user, scope)
+        @user = user
+        @scope = scope
+      end
+
+      def resolve
+        raise NotImplementedError, "You must define #resolve in #{self.class}"
+      end
+
+      private
+
+      attr_reader :user, :scope
+    end
+  end
+end

--- a/app/policies/stash_engine/curation_activity_policy.rb
+++ b/app/policies/stash_engine/curation_activity_policy.rb
@@ -1,11 +1,5 @@
 module StashEngine
-  class CurationActivityPolicy
-    attr_reader :user, :resource
-
-    def initialize(user, resource)
-      @user = user
-      @resource = resource
-    end
+  class CurationActivityPolicy < ApplicationPolicy
 
     def index?
       @user.limited_curator?

--- a/app/policies/stash_engine/curation_activity_policy.rb
+++ b/app/policies/stash_engine/curation_activity_policy.rb
@@ -1,0 +1,19 @@
+module StashEngine
+  class CurationActivityPolicy
+    attr_reader :user, :resource
+
+    def initialize(user, resource)
+      @user = user
+      @resource = resource
+    end
+
+    def index?
+      @user.limited_curator?
+    end
+
+    def curation_note?
+      @user.limited_curator?
+    end
+
+  end
+end

--- a/app/policies/stash_engine/curation_stats_policy.rb
+++ b/app/policies/stash_engine/curation_stats_policy.rb
@@ -1,0 +1,15 @@
+module StashEngine
+  class CurationStatsPolicy
+    attr_reader :user, :stats
+
+    def initialize(user, stats)
+      @user = user
+      @stats = stats
+    end
+
+    def index?
+      @user.admin?
+    end
+
+  end
+end

--- a/app/policies/stash_engine/curation_stats_policy.rb
+++ b/app/policies/stash_engine/curation_stats_policy.rb
@@ -1,11 +1,5 @@
 module StashEngine
-  class CurationStatsPolicy
-    attr_reader :user, :stats
-
-    def initialize(user, stats)
-      @user = user
-      @stats = stats
-    end
+  class CurationStatsPolicy < ApplicationPolicy
 
     def index?
       @user.admin?

--- a/app/policies/stash_engine/external_dependency_policy.rb
+++ b/app/policies/stash_engine/external_dependency_policy.rb
@@ -1,0 +1,9 @@
+module StashEngine
+  class ExternalDependencyPolicy < ApplicationPolicy
+
+    def show?
+      @user.superuser?
+    end
+
+  end
+end

--- a/app/policies/stash_engine/gmail_auth_policy.rb
+++ b/app/policies/stash_engine/gmail_auth_policy.rb
@@ -1,0 +1,14 @@
+module StashEngine
+  class GmailAuthPolicy < ApplicationPolicy
+    attr_reader :user
+
+    def initialize(user, _record)
+      super
+      @user = user
+    end
+
+    def index?
+      user.superuser?
+    end
+  end
+end

--- a/app/policies/stash_engine/internal_datum_policy.rb
+++ b/app/policies/stash_engine/internal_datum_policy.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module StashEngine
+  class InternalDatumPolicy
+    attr_reader :user, :internal_data
+
+    def initialize(user, internal_data)
+      @user = user
+      @internal_data = internal_data
+    end
+
+    def index?
+      @user.limited_curator?
+    end
+
+    def create?
+      @user.limited_curator?
+    end
+
+    def new?
+      create?
+    end
+
+    def update?
+      @user.limited_curator?
+    end
+
+    def edit?
+      update?
+    end
+
+    def destroy?
+      @user.limited_curator?
+    end
+
+  end
+end

--- a/app/policies/stash_engine/internal_datum_policy.rb
+++ b/app/policies/stash_engine/internal_datum_policy.rb
@@ -1,13 +1,5 @@
-# frozen_string_literal: true
-
 module StashEngine
-  class InternalDatumPolicy
-    attr_reader :user, :internal_data
-
-    def initialize(user, internal_data)
-      @user = user
-      @internal_data = internal_data
-    end
+  class InternalDatumPolicy < ApplicationPolicy
 
     def index?
       @user.limited_curator?

--- a/app/policies/stash_engine/journal_policy.rb
+++ b/app/policies/stash_engine/journal_policy.rb
@@ -1,0 +1,9 @@
+module StashEngine
+  class JournalPolicy < ApplicationPolicy
+
+    def index?
+      @user.limited_curator? && !@user.tenant_limited?
+    end
+
+  end
+end

--- a/app/policies/stash_engine/proposed_change_policy.rb
+++ b/app/policies/stash_engine/proposed_change_policy.rb
@@ -1,13 +1,5 @@
-# frozen_string_literal: true
-
 module StashEngine
-  class ProposedChangePolicy
-    attr_reader :user, :change
-
-    def initialize(user, change)
-      @user = user
-      @change = change
-    end
+  class ProposedChangePolicy < ApplicationPolicy
 
     def index?
       @user.limited_curator?

--- a/app/policies/stash_engine/proposed_change_policy.rb
+++ b/app/policies/stash_engine/proposed_change_policy.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module StashEngine
+  class ProposedChangePolicy
+    attr_reader :user, :change
+
+    def initialize(user, change)
+      @user = user
+      @change = change
+    end
+
+    def index?
+      @user.limited_curator?
+    end
+
+    def update?
+      @user.limited_curator?
+    end
+
+    def edit?
+      update?
+    end
+
+    def destroy?
+      @user.limited_curator?
+    end
+
+  end
+end

--- a/app/policies/stash_engine/repo_queue_state_policy.rb
+++ b/app/policies/stash_engine/repo_queue_state_policy.rb
@@ -1,0 +1,17 @@
+module StashEngine
+  class RepoQueueStatePolicy < ApplicationPolicy
+
+    def index?
+      @user.superuser?
+    end
+
+    def refresh_table?
+      @user.superuser?
+    end
+
+    def graceful_start?
+      @user.superuser?
+    end
+
+  end
+end

--- a/app/policies/stash_engine/resource_policy.rb
+++ b/app/policies/stash_engine/resource_policy.rb
@@ -1,0 +1,47 @@
+module StashEngine
+  class ResourcePolicy
+    attr_reader :user, :resource
+
+    def initialize(user, resource)
+      @user = user
+      @resource = resource
+    end
+
+    def create?
+      @user.present?
+    end
+
+    def new?
+      create?
+    end
+
+    # def update?
+    #  @user = @resource.current_editor_id
+    # end
+
+    # def edit?
+    #  update?
+    # end
+
+    class Scope
+      def initialize(user, scope)
+        @user = user
+        @scope = scope
+      end
+
+      def resolve
+        if @user.limited_curator?
+          @scope.all
+        elsif @user.journals_as_admin.present? || @user.funders_as_admin.present?
+          @scope.where(admin_for_this_item?)
+        else
+          @scope.where(user_id: @user.user_id)
+        end
+      end
+
+      private
+
+      attr_reader :user, :scope
+    end
+  end
+end

--- a/app/policies/stash_engine/resource_policy.rb
+++ b/app/policies/stash_engine/resource_policy.rb
@@ -1,11 +1,5 @@
 module StashEngine
-  class ResourcePolicy
-    attr_reader :user, :resource
-
-    def initialize(user, resource)
-      @user = user
-      @resource = resource
-    end
+  class ResourcePolicy < ApplicationPolicy
 
     def create?
       @user.present?

--- a/app/policies/stash_engine/user_policy.rb
+++ b/app/policies/stash_engine/user_policy.rb
@@ -1,0 +1,19 @@
+module StashEngine
+  class UserPolicy < ApplicationPolicy
+    def index?
+      @user.superuser?
+    end
+
+    def load_user?
+      @user.superuser?
+    end
+
+    def merge_popup?
+      @user.superuser?
+    end
+
+    def merge?
+      @user.superuser?
+    end
+  end
+end

--- a/app/policies/stash_engine/zenodo_copy_policy.rb
+++ b/app/policies/stash_engine/zenodo_copy_policy.rb
@@ -1,0 +1,24 @@
+module StashEngine
+  class ZenodoCopyPolicy < ApplicationPolicy
+
+    def index?
+      @user.superuser?
+    end
+
+    def item_details?
+      @user.superuser?
+    end
+
+    def identifier_details?
+      @user.superuser?
+    end
+
+    def resubmit_job?
+      @user.superuser?
+    end
+
+    def set_errored?
+      @user.superuser?
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2498

This currently applies the Pundit gem to stash_engine, and uses it in place of previous `before_action`s where the current_user's role drove the permission settings. It's also used in a couple spots for scoping (showing only particular records from a set based on user role).

There are other variables that come into play for permissions—session information, whether the resource "is modifiable", among others—We should also use Pundit for these settings but that is somewhat more complicated. I have added comments to files where we might do this in future.