### PR TITLE
tar.gz mitigation of unparseable items from Ruby tar libraries

### DIFF
--- a/lib/stash/compressed/tar_gz.rb
+++ b/lib/stash/compressed/tar_gz.rb
@@ -62,7 +62,7 @@ module Stash
 
         # example output from tar -ztv
         # -rwxr-xr-x  0 tracyh staff     422 Jun  1  2011 dppdiv_1.0b/bootstrap.sh
-        stdout, stderr, status = Open3.capture3("curl -s -L \"#{@presigned_url}\" | tar -ztv")
+        stdout, stderr, _status = Open3.capture3("curl -s -L \"#{@presigned_url}\" | tar -ztv")
 
         stdout.each_line do |line|
           arr = line.strip.split(/\s+/, 9)

--- a/lib/stash/compressed/tar_gz.rb
+++ b/lib/stash/compressed/tar_gz.rb
@@ -71,6 +71,7 @@ module Stash
           file_info << { file_name: my_fn, uncompressed_size: my_size }
         end
         raise Stash::Compressed::InvalidResponse, stderr if stdout.empty? && stderr.present?
+
         file_info
       end
 

--- a/lib/stash/compressed/tar_gz.rb
+++ b/lib/stash/compressed/tar_gz.rb
@@ -1,5 +1,6 @@
 require 'http'
 require 'rubygems/package'
+require 'open3'
 
 # test with files 14139 and 14140
 # df = StashEngine::DataFile.find(14139)
@@ -45,14 +46,41 @@ module Stash
             end
           end
           file_info
-        rescue HTTP::Error => e
+        rescue HTTP::Error, ArgumentError => e # ArgumentError is from Ruby tar library
+          Rails.logger.error("Error caught attempt #{attempts} -- #{e.message}")
           sleep sleep_time
           if (attempts += 1) < tries
-            Rails.logger.error("Error getting tar.gz file from S3 -- retrying: #{e.message}")
             retry
           end
           raise(e)
         end
+      end
+
+      def fallback_file_entries
+        file_info = []
+        # Open3.capture3 info at https://www.honeybadger.io/blog/capturing-stdout-stderr-from-shell-commands-via-ruby/
+
+        # example output from tar -ztv
+        # -rwxr-xr-x  0 tracyh staff     422 Jun  1  2011 dppdiv_1.0b/bootstrap.sh
+        stdout, stderr, status = Open3.capture3("curl -s -L \"#{@presigned_url}\" | tar -ztv")
+
+        stdout.each_line do |line|
+          arr = line.strip.split(/\s+/, 9)
+          my_fn = arr[-1]
+          my_size = arr[4].to_i
+          file_info << { file_name: my_fn, uncompressed_size: my_size }
+        end
+        raise Stash::Compressed::InvalidResponse, stderr if stdout.empty? && stderr.present?
+        file_info
+      end
+
+      def entries_with_fallback
+        entries = file_entries(sleep_time: 5, tries: 1)
+        raise Stash::Compressed::InvalidResponse if entries.empty?
+
+        entries
+      rescue Stash::Compressed::InvalidResponse, ArgumentError
+        fallback_file_entries
       end
     end
   end

--- a/lib/stash/compressed/zip_info.rb
+++ b/lib/stash/compressed/zip_info.rb
@@ -182,7 +182,10 @@ module Stash
         file_info
       end
 
-      # this maybe seems to do better with zip64 if java jar is installed
+      # this maybe seems to do better with zip64 if java jar is installed.  I would use zipinfo but it
+      # doesn't work with piping input and only displays help output rather than parsing the zip file.
+      # I believe the only way to use zipinfo is to write the file to disk and then run zipinfo on it
+      # which would take up lots of disk space for items that are large zip files.
       def fallback_file_entries2
         file_info = []
         stdout, stderr, _status = Open3.capture3("curl -s -L \"#{@presigned_url}\" | jar -tv")
@@ -192,7 +195,10 @@ module Stash
           my_size = arr[0].to_i
           file_info << { file_name: my_fn, uncompressed_size: my_size }
         end
+        # I don't know if the following does much since jar doesn't seem to always give good error messages like zipinfo
+        # and instead just gives blank output for many items it can't really parse.
         raise Stash::Compressed::ZipError, stderr if stdout.empty? && stderr.present?
+
         file_info
       end
 

--- a/lib/stash/compressed/zip_info.rb
+++ b/lib/stash/compressed/zip_info.rb
@@ -63,7 +63,6 @@ module Stash
           # try to make UTF-8 and in the rare case it fails then make bad characters into question marks
           file_name = file_name.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
 
-
           # forward past the file name
           ss.pos += file_name_length
 

--- a/lib/stash/compressed/zip_info.rb
+++ b/lib/stash/compressed/zip_info.rb
@@ -60,6 +60,10 @@ module Stash
           enc = file_name.detect_encoding[:ruby_encoding] || 'UTF-8'
           file_name.force_encoding(enc)
 
+          # try to make UTF-8 and in the rare case it fails then make bad characters into question marks
+          file_name = file_name.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
+
+
           # forward past the file name
           ss.pos += file_name_length
 

--- a/lib/tasks/compressed/info.rb
+++ b/lib/tasks/compressed/info.rb
@@ -11,7 +11,8 @@ module Tasks
             zip_info = Stash::Compressed::ZipInfo.new(presigned_url: db_file.merritt_s3_presigned_url)
             zip_info.entries_with_fallback
           elsif db_file.upload_file_name.downcase.end_with?('.tar.gz', '.tgz')
-            Stash::Compressed::TarGz.new(presigned_url: db_file.merritt_s3_presigned_url).file_entries
+            tar_gz_info = Stash::Compressed::TarGz.new(presigned_url: db_file.merritt_s3_presigned_url)
+            tar_gz_info.entries_with_fallback
           else
             raise Stash::Compressed::Error, "Unknown file type for #{db_file.upload_file_name}"
           end


### PR DESCRIPTION
This changes a few things and seems to be picking up more of the problem items.

- Defers to the Linux tar utility if Ruby's tar library can't handle the truth.
- Uses Open3.Capture3 to get better information from standard error so it gets logged with better information about what went wrong when possible.
- (for zips) sets the file name encoding it thinks it should be (from detection library) but then converts it to UTF-8 equivalents and and replaces sketchy characters with question marks so that MySQL and ActiveRecord don't barf (which happened on a few records before).

There are still some zip files that may not be able to be read without downloading a giant file and using a whole lot of disk space.

I'll add a different pull request for tracking error items better in the database.

