### PR TITLE
Track tries analyzing compressed content and skip after 3

### DIFF
--- a/db/migrate/20230426195311_add_compressed_tries_to_generic_files.rb
+++ b/db/migrate/20230426195311_add_compressed_tries_to_generic_files.rb
@@ -1,0 +1,5 @@
+class AddCompressedTriesToGenericFiles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :stash_engine_generic_files, :compressed_try, :integer, default: 0
+  end
+end


### PR DESCRIPTION
- Adds column `compressed_try` which is an integer
- Limit query to items with less than 3 tries
- Increment when we process an item

I think this may be good enough since the errors are logged and we can look up by the file_id