### PR TITLE
Basic file validation for JSON and XML files

### DIFF
--- a/app/javascript/react/components/FileUpload/ModalValidationReport/ModalValidationReport.jsx
+++ b/app/javascript/react/components/FileUpload/ModalValidationReport/ModalValidationReport.jsx
@@ -36,7 +36,14 @@ const ModalValidationReport = React.forwardRef(({file, clickedClose}, ref) => {
       {jsReport?.report?.stats?.errors === 10 && (
         <p>The report shows the maximum of 10 alerts. More alerts may appear if these 10 are corrected and the file is re-uploaded.</p>
       )}
-      <div id="validation_report" />
+      {typeof jsReport.report === 'string' ? (
+        <div className="error">
+          {jsReport.report}
+          <div id="validation_report" hidden />
+        </div>
+      ) : (
+        <div id="validation_report" />
+      )}
       <p>
         You can choose to proceed to the final page of the submission form without editing your file.
         At curation stage, if there are questions about how your data is presented, a curator will contact

--- a/app/javascript/react/containers/FileUpload/UploadFiles.jsx
+++ b/app/javascript/react/containers/FileUpload/UploadFiles.jsx
@@ -32,9 +32,9 @@ const Messages = {
   tooManyFiles: `You may not upload more than ${maxFiles} individual files.`,
 };
 const ValidTabular = {
-  extensions: ['csv', 'xls', 'xlsx', 'json', 'xml'],
-  mime_types: ['text/csv', 'application/vnd.ms-excel', 'text/xml', 'application/xml',
-    'application/json', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  extensions: ['csv', 'tsv', 'xls', 'xlsx', 'json', 'xml'],
+  mime_types: ['text/csv', 'text/tab-separated-values', 'application/vnd.ms-excel', 'text/xml',
+    'application/xml', 'application/json', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   ],
 };
 const upload_types = [

--- a/app/javascript/react/containers/FileUpload/UploadFiles.jsx
+++ b/app/javascript/react/containers/FileUpload/UploadFiles.jsx
@@ -32,9 +32,9 @@ const Messages = {
   tooManyFiles: `You may not upload more than ${maxFiles} individual files.`,
 };
 const ValidTabular = {
-  extensions: ['csv', 'xls', 'xlsx'],
-  mime_types: ['text/csv', 'application/vnd.ms-excel',
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  extensions: ['csv', 'xls', 'xlsx', 'json', 'xml'],
+  mime_types: ['text/csv', 'application/vnd.ms-excel', 'text/xml', 'application/xml',
+    'application/json', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   ],
 };
 const upload_types = [

--- a/app/models/stash_engine/generic_file.rb
+++ b/app/models/stash_engine/generic_file.rb
@@ -28,6 +28,8 @@ module StashEngine
     scope :tabular_files, -> {
       present_files.where(upload_content_type: 'text/csv')
         .or(present_files.where('upload_file_name LIKE ?', '%.csv'))
+        .or(present_files.where(upload_content_type: 'text/tab-separated-values'))
+        .or(present_files.where('upload_file_name LIKE ?', '%.tsv'))
         .or(present_files.where(upload_content_type: 'application/vnd.ms-excel'))
         .or(present_files.where('upload_file_name LIKE ?', '%.xls'))
         .or(present_files.where(upload_content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'))

--- a/app/models/stash_engine/generic_file.rb
+++ b/app/models/stash_engine/generic_file.rb
@@ -34,6 +34,9 @@ module StashEngine
         .or(present_files.where('upload_file_name LIKE ?', '%.xlsx'))
         .or(present_files.where(upload_content_type: 'application/json'))
         .or(present_files.where('upload_file_name LIKE ?', '%.json'))
+        .or(present_files.where(upload_content_type: 'application/xml'))
+        .or(present_files.where(upload_content_type: 'text/xml'))
+        .or(present_files.where('upload_file_name LIKE ?', '%.xml'))
     }
     enum file_state: %w[created copied deleted].to_h { |i| [i.to_sym, i] }
     enum digest_type: %w[md5 sha-1 sha-256 sha-384 sha-512].to_h { |i| [i.to_sym, i] }
@@ -173,6 +176,7 @@ module StashEngine
 
       payload = JSON.generate({
                                 download_url: url || direct_s3_presigned_url,
+                                file_mime_type: upload_content_type,
                                 callback_url: h.file_frictionless_report_url(id)
                                                .gsub('http://localhost:3000', 'https://dryad-dev.cdlib.org')
                                                .gsub(/^http:/, 'https:'),

--- a/script/py-frictionless/lambda.py
+++ b/script/py-frictionless/lambda.py
@@ -10,7 +10,7 @@ import sys
 # event json has these params passed in: download_url, callback_url, file_mime_type, token
 def lambda_handler(event, context):
   ftype = event.get("file_mime_type", '')
-  if "xml" in ftype:
+  if "/xml" in ftype:
     try:
       xmlfile = urlopen(event["download_url"])
       report = ET.parse(xmlfile)

--- a/script/py-frictionless/lambda.py
+++ b/script/py-frictionless/lambda.py
@@ -2,34 +2,57 @@ import json
 import time
 from pprint import pprint
 from frictionless import Detector, validate, validate_resource
+from urllib.request import urlopen
+import xml.etree.ElementTree as ET
 import requests
 import sys
 
-# event json has these params passed in: download_url, callback_url, token
+# event json has these params passed in: download_url, callback_url, file_mime_type, token
 def lambda_handler(event, context):
-  detector = Detector(field_missing_values="na,n/a,.,none,NA,N/A,N.A.,n.a.,-,empty,blank".split(","))
-  try:
-    report = validate(event["download_url"], "resource", detector=detector, limit_errors=10)
-  except Exception as e:
-    update(token=event["token"], status='error', report=str(e), callback=event["callback_url"] )
-    return {"status": 200, "message": "Error parsing file with Frictionless"}
+  ftype = event.get("file_mime_type", '')
+  if "xml" in ftype:
+    try:
+      xmlfile = urlopen(event["download_url"])
+      report = ET.parse(xmlfile)
+    except ET.ParseError as err:
+      # invalid XML
+      update(token=event["token"], status='issues', report=json.dumps({'report': f'XML file is invalid: {err}'}), callback=event['callback_url'])
+    # valid XML
+    update(token=event["token"], status='noissues', report=json.dumps({'report': ''}), callback=event['callback_url'])
+  if "json" in ftype:
+    try:
+      jsonfile = urlopen(event["download_url"])
+      report = json.load(jsonfile)
+    except ValueError as err:
+      # invalid JSON
+      update(token=event["token"], status='issues', report=json.dumps({'report': f'JSON file is invalid: {err}'}), callback=event['callback_url'])
+    # valid JSON
+    update(token=event["token"], status='noissues', report=json.dumps({'report': ''}), callback=event['callback_url'])
+    return report
+  else:
+    detector = Detector(field_missing_values="na,n/a,.,none,NA,N/A,N.A.,n.a.,-,empty,blank".split(","))
+    try:
+      report = validate(event["download_url"], "resource", detector=detector, limit_errors=10)
+    except Exception as e:
+      update(token=event["token"], status='error', report=str(e), callback=event["callback_url"] )
+      return {"status": 200, "message": "Error parsing file with Frictionless"}
 
-  # these errors indicate a failure by Frictionless to operate on file and are not linting results
-  if report["errors"]:
-    update(token=event["token"], status='error', report=report, callback=event["callback_url"] )
-    return {"status": 200, "message": "Error parsing file with Frictionless"}
+    # these errors indicate a failure by Frictionless to operate on file and are not linting results
+    if report["errors"]:
+      update(token=event["token"], status='error', report=report, callback=event["callback_url"] )
+      return {"status": 200, "message": "Error parsing file with Frictionless"}
 
-  lint_status = "issues" if report["tasks"][0].get("errors") else 'noissues'
-  poss_error_msg = ''
-  if lint_status == 'issues':
-    poss_error_msg = report["tasks"][0]["errors"][0].get("description", "")
+    lint_status = "issues" if report["tasks"][0].get("errors") else 'noissues'
+    poss_error_msg = ''
+    if lint_status == 'issues':
+      poss_error_msg = report["tasks"][0]["errors"][0].get("description", "")
 
-  if poss_error_msg.startswith("Data reading error"):
-    lint_status = "error"
+    if poss_error_msg.startswith("Data reading error"):
+      lint_status = "error"
 
-  update(token=event["token"], status=lint_status, report=json.dumps({'report': report}), callback=event['callback_url'])
+    update(token=event["token"], status=lint_status, report=json.dumps({'report': report}), callback=event['callback_url'])
 
-  return report
+    return report
 
 # tries to upload it to our API
 def update(token, status, report, callback):

--- a/script/py-frictionless/lambda.py
+++ b/script/py-frictionless/lambda.py
@@ -10,7 +10,7 @@ import sys
 # event json has these params passed in: download_url, callback_url, file_mime_type, token
 def lambda_handler(event, context):
   ftype = event.get("file_mime_type", '')
-  if "/xml" in ftype:
+  if ftype.endswith('/xml'):
     try:
       xmlfile = urlopen(event["download_url"])
       report = ET.parse(xmlfile)
@@ -19,7 +19,7 @@ def lambda_handler(event, context):
       update(token=event["token"], status='issues', report=json.dumps({'report': f'XML file is invalid: {err}'}), callback=event['callback_url'])
     # valid XML
     update(token=event["token"], status='noissues', report=json.dumps({'report': ''}), callback=event['callback_url'])
-  if "json" in ftype:
+  if ftype.endswith('/json'):
     try:
       jsonfile = urlopen(event["download_url"])
       report = json.load(jsonfile)


### PR DESCRIPTION
Closes https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2404, https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2048

I have added basic validation for structured data files (JSON, XML) to the lambda—not as part of frictionless validation, but through python itself. This lambda code is currently deployed on AWS for testing—I took care that the code will keep working for existing file submissions to the lambda without disruption.

I've also added frictionless validation for TSV files. In my tests these get the same validation results as CSV versions of the same files. TSV and CSV results differ slightly from XLS/XLSX versions of the same files, but are comparable.