### PR TITLE
Make DataCite Tracker not cause problems with PPR download page

### DIFF
--- a/app/views/stash_engine/downloads/_download_popup.js.erb
+++ b/app/views/stash_engine/downloads/_download_popup.js.erb
@@ -41,7 +41,9 @@ $(function() {
                     if(data["status"] == 200){
                         $( "#progressbar" ).progressbar( "option", "value", 100 );
                         $("#cancel_dialog").click(); // click cancel which closes popup and does the close actions
-                        trackMetric(DataCiteTracker.MetricType.Download, { doi: '<%= @resource&.identifier&.identifier %>' });
+                        if (typeof dc_download !== 'undefined') {
+                            trackMetric(dc_download, { doi: '<%= @resource&.identifier&.identifier %>' });
+                        }
                         window.location.href = data["url"]; // navigate to URL
                     }
                 },

--- a/app/views/stash_engine/downloads/download_resource.js.erb
+++ b/app/views/stash_engine/downloads/download_resource.js.erb
@@ -8,7 +8,9 @@ function delayedEnable() {
 
 <% if @status_hash[:status] == 200 %>
   delayedEnable();
-  // trackMetric(DataCiteTracker.MetricType.Download, { doi: '<%= @resource&.identifier&.identifier %>' });
+  if (typeof dc_download !== 'undefined') {
+    trackMetric(dc_download, {doi: '<%= @resource&.identifier&.identifier %>'});
+  }
   window.location.href = "<%= raw(@status_hash[:url]) %>";
 <% elsif @status_hash[:status] == 202 %>
   <%= render partial: 'download_popup', formats: :js %>

--- a/app/views/stash_engine/downloads/download_resource.js.erb
+++ b/app/views/stash_engine/downloads/download_resource.js.erb
@@ -8,7 +8,7 @@ function delayedEnable() {
 
 <% if @status_hash[:status] == 200 %>
   delayedEnable();
-  trackMetric(DataCiteTracker.MetricType.Download, { doi: '<%= @resource&.identifier&.identifier %>' });
+  // trackMetric(DataCiteTracker.MetricType.Download, { doi: '<%= @resource&.identifier&.identifier %>' });
   window.location.href = "<%= raw(@status_hash[:url]) %>";
 <% elsif @status_hash[:status] == 202 %>
   <%= render partial: 'download_popup', formats: :js %>

--- a/app/views/stash_engine/landing/show.html.erb
+++ b/app/views/stash_engine/landing/show.html.erb
@@ -7,6 +7,7 @@
 		repoid: '<%= APP_CONFIG[:datacite_data_repo_id] %>',
 		trackLocalhost: <%= Rails.env == 'production' ? 'true' : 'false' %>,
 	});
+	let dc_download = DataCiteTracker.MetricType.Download;
 	trackMetric(DataCiteTracker.MetricType.View, { doi: '<%= @resource&.identifier&.identifier %>' });
 
 	document.addEventListener("DOMContentLoaded", function(){


### PR DESCRIPTION
See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2515

Disable the DataCite tracker on the download page, because it was preventing the PPR share links from working.

I made this change on production so the share links would work again. I did not dig deeper into *why* it was breaking.

----

sfisher comment:

@ryscher I hope you don't mind if I piggyback and update your pull request.

I found the cause of this problem and it was caused by certain libraries not being loaded and variables not defined on the PPR download page which halted execution (though both pages use the same download functionality).

By declaring a variable for one of the items and only tracking downloads if the variable exists then the PPR download page continues normally (and skips adding tracking stats for that page).

To check all the tracking works, you'll want to open the web browser javascript console and it displays a message in the console when the download starts.

There are 5 circumstances of download code, 3 possible on the landing page and 2 on the PPR download page:

- Download individual file (only on the landing page)
- Download full version which starts immediately (on landing page)
- Download full version which starts after assembly (on landing page)
- Download full version which starts immediately (on PPR page)
- Download full version which starts after assembly (on PPR page)

All on the landing page should work and display the message in the console.  All on the PPR page should work, but there will not be DataCite tracking since the variable isn't defined.

Trying to get the "assembly" dialog to show on dev is kind of tricky. This one at `/stash/dataset/doi:10.5072/FK2Z89CG75` should show if it's not cached yet. (`resource_id: 3920`)

To uncache it, you need to remove the `resource_id` entry from `stash_engine_download_tokens` and Merritt will also need to remove something from their assembled objects cache (or wait for it to expire or try a different dataset that's not cached).

I tried it out and I'm not seeing problems with the PPR download page now.