### PR TITLE
Removes old datacite tracker for plausible.io

### DIFF
--- a/app/views/layouts/stash_engine/_landing_head.html.erb
+++ b/app/views/layouts/stash_engine/_landing_head.html.erb
@@ -1,8 +1,0 @@
-<% if Rails.env == 'production' %>
-  <!-- Track View for counter -->
-  <!-- We don't need to include doi since in schema.org, but if not the data-doi attribute is what we'd use -->
-  <script defer
-        data-repoid="datadryad.org"
-        data-metric="view"
-        src="https://cdn.jsdelivr.net/npm/@datacite/datacite-tracker"></script>
-<% end %>

--- a/app/views/layouts/stash_engine/application.html.erb
+++ b/app/views/layouts/stash_engine/application.html.erb
@@ -3,9 +3,6 @@
 <head>
   <%= render 'layouts/stash_engine/standard_head' %>
   <%= render 'layouts/stash_engine/stash_head' %>
-  <% if controller_name == 'landing' && action_name == 'show' %>
-    <%= render 'layouts/stash_engine/landing_head' %>
-  <% end %>
   <%= content_for :head %>
 </head>
 <body class='<%= "#{controller_name}_#{action_name}" %>'>


### PR DESCRIPTION
I believe the previous tracker was put in for plausible.io and it was still present in addition to the new one we put in and that was what Kristian was seeing.

I see the console log showing tracking is happening so I think it's working.  Too bad I missed the old one still there.