### PR TITLE
Making associated journal part of full text search in SOLR

### DIFF
--- a/config/solr_config/solrconfig.xml
+++ b/config/solr_config/solrconfig.xml
@@ -134,6 +134,7 @@
         dryad_author_affiliation_id_tmi^12
         dryad_dataset_file_ext_tmi^13
         dcs_funder_tmi^14
+        dryad_related_publication_name_ti^15
       </str>
       <!-- briley 06/03/2019 - field to store the publication id that cites the dataset -->
       <str name="pf"><!-- phrase boost within result set -->
@@ -155,6 +156,7 @@
         dryad_author_affiliation_id_tmi^12
         dryad_dataset_file_ext_tmi^13
         dcs_funder_tmi^14
+        dryad_related_publication_name_ti^15
       </str>
       <bool name="facet">true</bool>
       <int name="facet.mincount">1</int>


### PR DESCRIPTION
I added the item for the publication name to the full text search.

You can test on dev and stage where I've manually updated the config and restarted SOLR.

- Go into the search area and look at the facets for journal.
- Type the text into the search text instead (use quotes around it if you want a phrase search).  Example, `"functional ecology"` on the stage server.
- You should receive search results and when you look at the facets for journal for those search results it should match (unless someone has the journal name somewhere else in the text).

While this fixes the search, I'm not sure the associated journal is all that super obvious on our landing page (aside from the listing in related works section and our data seems a bit weird on our stage machine).

At the deployment time I'll need to `scp` this one file over to the solr server manually and restart solr.