### PR TITLE
Makes URLs https for doi registration

### DIFF
--- a/lib/stash/doi/id_gen.rb
+++ b/lib/stash/doi/id_gen.rb
@@ -53,7 +53,7 @@ module Stash
       end
 
       def landing_page_url
-        @landing_page_url ||= Rails.application.routes.url_helpers.show_url(resource.identifier_str)
+        @landing_page_url ||= Rails.application.routes.url_helpers.show_url(resource.identifier_str)&.gsub(%r{^http://}, 'https://')
       end
 
       def initialize(resource:)


### PR DESCRIPTION
https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2564

The URL generation in Rails is always off since we have a wonky setup where Apache handles all the https and puma sees all traffic as http since it's reverse proxied to it that way.  Therefore, when rails creates URLs they're created as http.

Normally it's not a big deal since we have a redirect to https.  But it seems like the URL route generator doesn't create the https URLs here.

I guess this has become a bigger deal with the new counter tracking at DataCite.  Not sure if all URLs are this way but I think maybe they are.

We'll have to regenerate and resend the metadata to datacite.