### PR TITLE
Make three keywords (subjects) required

### DIFF
--- a/app/javascript/react/components/MetadataEntry/Keywords.jsx
+++ b/app/javascript/react/components/MetadataEntry/Keywords.jsx
@@ -50,7 +50,7 @@ function Keywords({
 
   return (
     <div className="c-keywords">
-      <label className="c-input__label" id="label_keyword_ac" htmlFor="keyword_ac">Keywords:</label>
+      <label className="c-input__label required" id="label_keyword_ac" htmlFor="keyword_ac">Keywords:</label>
         &nbsp;&nbsp;Adding keywords improves the findability of your dataset. E.g. scientific names, method type
 
       <div id="js-keywords__container" className="c-keywords__container c-keywords__container--has-blur">

--- a/app/models/stash_datacite/resource/dataset_validations.rb
+++ b/app/models/stash_datacite/resource/dataset_validations.rb
@@ -9,6 +9,8 @@ require 'stash/aws/s3'
 include StashEngine::ApplicationHelper
 # rubocop:enable Style/MixinUsage
 
+# rubocop:disable Metrics/ClassLength
+
 module StashDatacite
   module Resource
 
@@ -138,7 +140,7 @@ module StashDatacite
         if @resource.subjects.non_fos.count < 3 && @resource.identifier.created_at > subjects_require_date
           return ErrorItem.new(message: 'Fill in at least three {keywords}',
                                page: metadata_page(@resource),
-                               ids: ["keyword_ac"])
+                               ids: ['keyword_ac'])
         end
         []
       end
@@ -308,3 +310,5 @@ module StashDatacite
     end
   end
 end
+
+# rubocop:enable Metrics/ClassLength

--- a/app/models/stash_datacite/resource/dataset_validations.rb
+++ b/app/models/stash_datacite/resource/dataset_validations.rb
@@ -136,7 +136,7 @@ module StashDatacite
       end
 
       def subjects
-        subjects_require_date = '2023-05-31'
+        subjects_require_date = '2023-06-07'
         if @resource.subjects.non_fos.count < 3 && @resource.identifier.created_at > subjects_require_date
           return ErrorItem.new(message: 'Fill in at least three {keywords}',
                                page: metadata_page(@resource),

--- a/app/models/stash_datacite/resource/dataset_validations.rb
+++ b/app/models/stash_datacite/resource/dataset_validations.rb
@@ -64,6 +64,7 @@ module StashDatacite
         err << research_domain
         err << funder
         err << abstract
+        err << subjects
 
         err << s3_error_uploads
         err << url_error_validating
@@ -128,6 +129,16 @@ module StashDatacite
           return ErrorItem.new(message: 'Fill in a {research domain}',
                                page: metadata_page(@resource),
                                ids: ["fos_subjects__#{@resource.id}"])
+        end
+        []
+      end
+
+      def subjects
+        subjects_require_date = '2023-05-31'
+        if @resource.subjects.non_fos.count < 3 && @resource.identifier.created_at > subjects_require_date
+          return ErrorItem.new(message: 'Fill in at least three {keywords}',
+                               page: metadata_page(@resource),
+                               ids: ["keyword_ac"])
         end
         []
       end

--- a/spec/features/stash_datacite/dataset_versioning_spec.rb
+++ b/spec/features/stash_datacite/dataset_versioning_spec.rb
@@ -365,6 +365,7 @@ RSpec.feature 'DatasetVersioning', type: :feature do
   def update_dataset(curator: false)
     # Add a value to the dataset, submit it and then mock a successful submission
     navigate_to_metadata
+    3.times { fill_in_keyword }
     all('[id^=instit_affil_]').last.set('test institution')
     page.send_keys(:tab)
     page.has_css?('.use-text-entered')

--- a/spec/features/stash_datacite/review_dataset_spec.rb
+++ b/spec/features/stash_datacite/review_dataset_spec.rb
@@ -140,6 +140,7 @@ RSpec.feature 'ReviewDataset', type: :feature do
       page.send_keys(:tab)
       page.has_css?('.use-text-entered')
       all(:css, '.use-text-entered').each { |i| i.set(true) }
+      3.times { fill_in_keyword }
       navigate_to_review
       agree_to_everything
       fill_in 'user_comment', with: Faker::Lorem.sentence

--- a/spec/features/stash_engine/admin_spec.rb
+++ b/spec/features/stash_engine/admin_spec.rb
@@ -152,6 +152,7 @@ RSpec.feature 'Admin', type: :feature do
         page.send_keys(:tab)
         page.has_css?('.use-text-entered')
         all(:css, '.use-text-entered').each { |i| i.set(true) }
+        3.times { fill_in_keyword }
         add_required_data_files
         click_link 'Review and submit'
         agree_to_everything

--- a/spec/features/stash_engine/curation_activity_spec.rb
+++ b/spec/features/stash_engine/curation_activity_spec.rb
@@ -220,6 +220,7 @@ RSpec.feature 'CurationActivity', type: :feature do
         page.send_keys(:tab)
         page.has_css?('.use-text-entered')
         all(:css, '.use-text-entered').each { |i| i.set(true) }
+        3.times { fill_in_keyword }
         add_required_data_files
         navigate_to_review
         agree_to_everything

--- a/spec/fixtures/stash_api/metadata.rb
+++ b/spec/fixtures/stash_api/metadata.rb
@@ -22,6 +22,7 @@ module Fixtures
         add_author
         add_research_domain
         add_funder
+        add_keywords
       end
 
       def make_minimal_ordered_authors
@@ -32,6 +33,7 @@ module Fixtures
         add_author(order: 1)
         add_author(order: 0)
         add_research_domain
+        add_keywords
       end
 
       def add_field(field_name:, value: nil)

--- a/spec/models/stash_datacite/dataset_validations_spec.rb
+++ b/spec/models/stash_datacite/dataset_validations_spec.rb
@@ -15,6 +15,7 @@ module StashDatacite
                           author_email: @user.email,
                           author_orcid: @user.orcid,
                           resource_id: @resource.id)
+        @resource.subjects << [create(:subject), create(:subject), create(:subject)]
         create(:data_file, resource: @resource)
         @readme = create(:data_file, resource: @resource, upload_file_name: 'README.md')
         create(:data_file, resource: @resource)

--- a/spec/requests/stash_api/datasets_controller_spec.rb
+++ b/spec/requests/stash_api/datasets_controller_spec.rb
@@ -865,6 +865,7 @@ module StashApi
           @res.update(data_files: [create(:data_file, file_state: 'copied'),
                                    create(:data_file, file_state: 'copied', upload_file_name: 'README.md')])
           @res.authors.first.update(author_orcid: @super_user.orcid)
+          @res.subjects << [create(:subject), create(:subject), create(:subject)]
           @ca = create(:curation_activity, resource: @res, status: 'peer_review')
         end
 

--- a/spec/support/helpers/dataset_helper.rb
+++ b/spec/support/helpers/dataset_helper.rb
@@ -53,6 +53,7 @@ module DatasetHelper
     page.has_css?('.use-text-entered')
     all(:css, '.use-text-entered').each { |i| i.set(true) }
     fill_in_tinymce(field: 'abstract', content: Faker::Lorem.paragraph)
+    3.times { fill_in_keyword }
   end
 
   def add_required_data_files
@@ -80,6 +81,11 @@ module DatasetHelper
     choose('choose_published')
     fill_in 'publication', with: name
     fill_in 'primary_article_doi', with: doi
+  end
+
+  def fill_in_keyword(keyword: Faker::Creature::Animal.name)
+    fill_in 'keyword_ac', with: keyword
+    page.send_keys(:tab)
   end
 
   def fill_in_author


### PR DESCRIPTION
- Adds a validation for at least 3 normal subjects (keywords)
- Add required css class
- Adds capybara action to fill keywords
- Finds places that required fields were failing in capybara tests and fix them
- Find additional failures because of keywords and fix tests

(Running all the slow tests and fixing the tests is what took a looong time with these changes.)

In order to test you can either change the code `subjects_require_date = '2023-06-07'` to a date in the past or else change the `@resource.identifier.created_at` to a date in the future past this cutoff.

I had the date set in the past to run all the tests and find and fix all the failures.

The ticket for this mentions adding to the search landing page, but they're already there. They are also already available as a search facet.

![Screenshot 2023-06-01 at 4 33 54 PM](https://github.com/CDL-Dryad/dryad-app/assets/105433/9c8a3f3e-0598-4dfd-9a3a-283ba5477d92)

![Screenshot 2023-06-01 at 4 34 19 PM](https://github.com/CDL-Dryad/dryad-app/assets/105433/6bcab9df-bb5a-46a9-beaf-7dfb318b17f2)

Possibly confusing since we call them `keywords` in the entry and landing page and the search calls them `Subjects`.  They are stored as DataCite subjects no mater what they're called.  We can revise terminology to be consistent if we wish.