### PR TITLE
Make rake task for importing new versions of PLoS subjects

### DIFF
--- a/lib/tasks/keywords.rake
+++ b/lib/tasks/keywords.rake
@@ -1,0 +1,31 @@
+namespace :keywords do
+  task update_plos: :environment do
+    $stdout.sync = true # keeps stdout from buffering which causes weird delays such as with tail -f
+
+    if ENV['PLOS_PATH'].blank? || ENV['RAILS_ENV'].blank?
+      puts 'Please enter the path to the PLoS keywords as the PLOS_PATH environment variable'
+      puts 'For example: PLOS_PATH="/my/path/to/plosthes.2020-1.full.tsv"'
+      puts ''
+      puts 'You can get the Excel files from https://github.com/PLOS/plos-thesaurus.'
+      puts 'then open in a program that can convert to tab separated values such as Google docs.'
+      puts '(Choose File > Download > Tab-separated values in Google docs)'
+      puts 'Excel seems to export as a mystery character set that causes UTF-8 problems, so'
+      puts 'probably best to avoid Excel for this.'
+      puts ''
+      puts 'Also be sure to set the RAILS_ENV environment variable for the correct environment'
+      puts ''
+      puts 'PLOS also has a file named plosthes.xxxx.synonyms.xlsx which are non-preferred terms'
+      puts 'and is not currently used for import, but we might reconsider that in the future if'
+      puts 'we would like a more expansive list of synonym keywords.'
+      exit
+    end
+
+    # without silencing this, all I saw was ActiveRecord SQL logging and it was hard to see the progress
+    Rails.logger.silence do
+      plos = Tasks::Keywords::Plos.new(fn: ENV['PLOS_PATH'])
+      plos.populate
+    end
+
+    puts 'Done populating PLoS keywords'
+  end
+end

--- a/lib/tasks/keywords.rake
+++ b/lib/tasks/keywords.rake
@@ -22,7 +22,7 @@ namespace :keywords do
 
     # without silencing this, all I saw was ActiveRecord SQL logging and it was hard to see the progress
     Rails.logger.silence do
-      plos = Tasks::Keywords::Plos.new(fn: ENV['PLOS_PATH'])
+      plos = Tasks::Keywords::Plos.new(fn: ENV.fetch('PLOS_PATH', nil))
       plos.populate
     end
 

--- a/lib/tasks/keywords/plos.rb
+++ b/lib/tasks/keywords/plos.rb
@@ -1,0 +1,48 @@
+module Tasks
+  module Keywords
+    class Plos
+
+      SCHEME = 'PLOS Subject Area Thesaurus'.freeze
+      SCHEME_URI = 'https://github.com/PLOS/plos-thesaurus'.freeze
+
+      def initialize(fn:)
+        @fn = fn
+        @keywords = read_keywords
+      end
+
+      def populate
+        @keywords.each_with_index do |k, idx|
+          subjs = StashDatacite::Subject.where(subject: k)
+          if subjs.count.zero?
+            # add one that doesn't exist
+            StashDatacite::Subject.create(subject: k, subject_scheme: SCHEME, scheme_URI: SCHEME_URI)
+          else
+            subjs.each do |subj|
+              next if subj.subject == k && subj.subject_scheme == SCHEME && subj.scheme_URI == SCHEME_URI
+
+              # update the existing one to the correct values, so it reflects the vocabulary it came from
+              subj.update(subject: k, subject_scheme: SCHEME, scheme_URI: SCHEME_URI)
+            end
+          end
+          puts "Processed #{idx + 1} of #{@keywords.length} keywords" if (idx + 1) % 100 == 0
+        end
+      end
+
+      private
+
+      def read_keywords
+        keywords = []
+        File.open(@fn, 'r') do |f|
+          all = f.read.strip
+          lines = all.split("\r")
+          lines.each do |line|
+            my_line = line.strip
+            keywords.push(my_line) unless my_line.start_with?("Item1\t")
+          end
+        end
+        keywords.uniq
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
The PLoS keywords/subjects we had before seemed to be mangled and the old import was out of date and hard to use.

- Get PLoS keywords
- Save the Excel file to tab separated values
- Run the script with the environment variables noted like `rails keywords:update_plos RAILS_ENV=local_dev PLOS_PATH="/Users/sfisher/Downloads/plosthes.2020-1.full.tsv"`
- Wait for it to finish

It will add subjects that don't exist and also accurately fill a better subject_scheme and scheme_URI for keywords that already exist but that don't have them filled for a value that matches a PLoS subject.  It may also correct capitalization to match the way PLoS has done it officially.

This may mean we can only autocomplete on controlled vocabularies so people don't select dumb stuff in their autocomplete in the future.