### PR TITLE
Catches an error that occurs when regenerating DataCite/EZID metadata

### DIFF
--- a/lib/tasks/datacite_target.rake
+++ b/lib/tasks/datacite_target.rake
@@ -32,7 +32,7 @@ namespace :datacite_target do
 
       begin
         Tasks::DashUpdater.submit_id_metadata(stash_identifier: stash_id)
-      rescue Stash::Doi::IdGenError, ArgumentError => e
+      rescue Stash::Doi::IdGenError, ArgumentError, Net::HTTPServerException => e
         outstr = "\n#{stash_id.id}: #{stash_id.identifier}\n#{e.message}\n"
         File.write('datacite_update_errors.txt', outstr, mode: 'a')
       end

--- a/lib/tasks/datacite_target.rake
+++ b/lib/tasks/datacite_target.rake
@@ -32,7 +32,7 @@ namespace :datacite_target do
 
       begin
         Tasks::DashUpdater.submit_id_metadata(stash_identifier: stash_id)
-      rescue Stash::Doi::IdGenError, ArgumentError, Net::HTTPServerException => e
+      rescue Stash::Doi::IdGenError, ArgumentError, Net::HTTPClientException => e
         outstr = "\n#{stash_id.id}: #{stash_id.identifier}\n#{e.message}\n"
         File.write('datacite_update_errors.txt', outstr, mode: 'a')
       end


### PR DESCRIPTION
This is a case that comes from the EZID library for a dataset that has an invalid ID that tries to submit to EZID (and can be ignored).