### PR TITLE
Updates Subject keyword functionality

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -83,7 +83,7 @@ class CatalogController < ApplicationController
     # config.add_facet_field Settings.FIELDS.CREATOR, :label => 'Author', :limit => 8
     # config.add_facet_field 'dc_type_s', label: 'Type', limit: 8
     # config.add_facet_field Settings.FIELDS.PUBLISHER, label: 'Institution', limit: 8
-    config.add_facet_field Settings.FIELDS.SUBJECT, label: 'Subject Area', limit: 8
+    config.add_facet_field Settings.FIELDS.SUBJECT, label: 'Subject keyword', limit: 8
     config.add_facet_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Geographical Location', limit: 8
     config.add_facet_field Settings.FIELDS.PART_OF, label: 'Collection', limit: 8
     config.add_facet_field Settings.FIELDS.RELATED_PUBLICATION_NAME, label: 'Journal', limit: 8
@@ -136,8 +136,8 @@ class CatalogController < ApplicationController
                                                        itemprop: 'description', helper_method: :render_value_as_truncate_abstract
     # config.add_show_field Settings.FIELDS.PUBLISHER, label: 'Institution', itemprop: 'publisher'
     config.add_show_field Settings.FIELDS.PART_OF, label: 'Collection', itemprop: 'isPartOf'
-    config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Geographical Location(s)', itemprop: 'spatial', link_to_search: true
-    config.add_show_field Settings.FIELDS.SUBJECT, label: 'Subject Area(s)', itemprop: 'keywords', link_to_search: true
+    config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Geographical location(s)', itemprop: 'spatial', link_to_search: true
+    config.add_show_field Settings.FIELDS.SUBJECT, label: 'Subject keyword(s)', itemprop: 'keywords', link_to_search: true
     config.add_show_field Settings.FIELDS.TEMPORAL, label: 'Year', itemprop: 'temporal'
     config.add_show_field Settings.FIELDS.PROVENANCE, label: 'Held by', link_to_search: true
     config.add_show_field Settings.FIELDS.RELATED_PUBLICATION_NAME, label: 'Journal', itemprop: 'related_publication_name'

--- a/app/controllers/latest_controller.rb
+++ b/app/controllers/latest_controller.rb
@@ -55,8 +55,8 @@ class LatestController < ApplicationController
     config.add_show_field 'dc_description_s', label: 'Description', itemprop: 'description', helper_method: :render_value_as_truncate_abstract
     config.add_show_field 'dc_publisher_s', label: 'Institution', itemprop: 'publisher'
     config.add_show_field 'dct_isPartOf_sm', label: 'Collection', itemprop: 'isPartOf'
-    config.add_show_field 'dct_spatial_sm', label: 'Geographical Location(s)', itemprop: 'spatial', link_to_search: true
-    config.add_show_field 'dc_subject_sm', label: 'Subject Area(s)', itemprop: 'keywords', link_to_search: true
+    config.add_show_field 'dct_spatial_sm', label: 'Geographical location(s)', itemprop: 'spatial', link_to_search: true
+    config.add_show_field 'dc_subject_sm', label: 'Subject keyword(s)', itemprop: 'keywords', link_to_search: true
     config.add_show_field 'dct_temporal_sm', label: 'Year', itemprop: 'temporal'
     config.add_show_field 'dct_provenance_s', label: 'Held by', link_to_search: true
     config.add_show_field 'dryad_related_publication_name_s', label: 'Journal', itemprop: 'related_publication_name'

--- a/app/controllers/stash_datacite/subjects_controller.rb
+++ b/app/controllers/stash_datacite/subjects_controller.rb
@@ -39,7 +39,7 @@ module StashDatacite
       if params[:term].blank?
         render json: nil
       else
-        @subjects = Subject.order(:subject).non_fos.where('subject LIKE ?', "%#{params[:term]}%").limit(40)
+        @subjects = Subject.order(:subject).non_fos.where('scheme_URI IS NOT NULL').where('subject LIKE ?', "%#{params[:term]}%").limit(40)
         render json: @subjects.map { |i| { id: i.id, name: i.subject } }
       end
     end

--- a/app/javascript/react/components/MetadataEntry/Keywords.jsx
+++ b/app/javascript/react/components/MetadataEntry/Keywords.jsx
@@ -50,7 +50,7 @@ function Keywords({
 
   return (
     <div className="c-keywords">
-      <label className="c-input__label required" id="label_keyword_ac" htmlFor="keyword_ac">Keywords:</label>
+      <label className="c-input__label required" id="label_keyword_ac" htmlFor="keyword_ac">Subject keywords:</label>
         &nbsp;&nbsp;Adding keywords improves the findability of your dataset. E.g. scientific names, method type
 
       <div id="js-keywords__container" className="c-keywords__container c-keywords__container--has-blur">

--- a/app/views/stash_datacite/subjects/_show.html.erb
+++ b/app/views/stash_datacite/subjects/_show.html.erb
@@ -1,5 +1,5 @@
 <% unless subjects.nil? || subjects.length < 1 %>
-    <h3 class="o-heading__level2">Keywords</h3>
+    <h3 class="o-heading__level2">Subject keywords</h3>
     <div class="<%= 'highlight' if highlight %>">  
 	<p><%= subjects.map(&:subject).join(", ") %></p>
     </div>

--- a/app/views/stash_engine/dashboard/preparing_to_submit.html.erb
+++ b/app/views/stash_engine/dashboard/preparing_to_submit.html.erb
@@ -13,7 +13,7 @@
     <ul>
       <li>Dataset title—be as descriptive as possible</li>
       <li>Full names of all dataset co-authors</li>
-      <li>Keywords for the dataset (use discipline-specific controlled vocabularies whenever possible)</li>
+      <li>Subject keywords for the dataset (use discipline-specific controlled vocabularies whenever possible)</li>
       <li>Abstract (description) describing the dataset you are submitting</li>
       <li>Description of the methods used to collect the data</li>
       <li>Citations to associated materials, including grant numbers, publications using the dataset, and other related datasets</li>

--- a/app/views/stash_engine/landing/_sidebar.html.erb
+++ b/app/views/stash_engine/landing/_sidebar.html.erb
@@ -33,7 +33,7 @@
 </div>
 
 <div class="c-sidebox" id="keyword_section">
-  <h2 class="c-sidebox__heading">Keywords</h2>
+  <h2 class="c-sidebox__heading">Subject keywords</h2>
   <div id="show_subjects"
        data-load="<%= metadata_url_helpers.subjects_landing_path(resource_id: @resource.id, format: :js) %>">
     <%= image_tag 'stash_engine/spinner.gif', size: '80x60', alt: 'Loading spinner' %>

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -28,7 +28,7 @@ en:
       institution: 'Institution'
       data_type: 'Data type'
       placename: 'Placename'
-      subject: 'Subject'
+      subject: 'Subject keyword'
       publication: 'Journal'
       version: ''
     tools:


### PR DESCRIPTION
1. Changes the varying terminology (sometimes Keywords, sometimes Subjects) to be Subject keyword(s).
2. Changes the autocomplete so that it will only complete items from controlled vocabularies (mostly PLoS right now, but we could dump some additional in in like LC subjects or something else that people like).

I hope this makes it so people don't follow each other off a cliff when one person jumps off first and others blindly follow in the autocomplete.  I hope the controlled vocabularies are better formatted and have better terms.