### PR TITLE
redirect to not encode slash, even though Geoblacklight encodes on it from search to landing page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -247,6 +247,11 @@ Rails.application.routes.draw do
     get 'editor', to: 'pages#editor'
     get 'web_crawling', to: 'pages#web_crawling'
     get 'about', to: 'pages#who_we_are'
+
+    # redirect the urls with an encoded forward slash in the identifier to a URL that DataCite expects for matching their tracker
+    # All our identifiers seem to have either /dryad or /FK2 or /[A-Z]\d in them, replaces the first occurrence of %2F with /
+    get 'dataset/*id', to: redirect{ |params| "/stash/dataset/#{params[:id].sub('%2F', '/') }"}, status: 302,
+        constraints: { id: /\S+\d%2F(dryad|FK2|[A-Z]\d)\S+/ }
     get 'dataset/*id', to: 'landing#show', as: 'show', constraints: { id: /\S+/ }
     get 'landing/citations/:identifier_id', to: 'landing#citations', as: 'show_citations'
     get '404', to: 'pages#app_404', as: 'app_404'


### PR DESCRIPTION
Redirect Geoblacklight URLs which (pretty much correctly) encode a slash in the middle of an identifier (%2F).

But DataCite doesn't normalize URLs or handle the equivalency, so we need to unencode and redirect to the page without this internal identifer slash encoded.

I think we may ask DataCite to do some more normalization and equivalency checking on DOIs (handle http/https/encoded) since I suspect we will not be the only people who might run into these issues and they could ease the transition for others.

Easier to do this than to customize geoblacklight more , finding the correct code and possibly breaking future updates in that library.