### PR TITLE
try to save capybara screenshots as artifacts

### DIFF
--- a/.github/workflows/rspec_features.yml
+++ b/.github/workflows/rspec_features.yml
@@ -60,6 +60,7 @@ jobs:
       run: bin/bundle exec rspec --force-color --fail-fast --format RSpec::Github::Formatter --format progress --tag ~skip spec/features/
 
     - name: Archive capybara screenshots
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v3
       with:
         name: capybara-screenshots

--- a/.github/workflows/rspec_features.yml
+++ b/.github/workflows/rspec_features.yml
@@ -58,3 +58,9 @@ jobs:
 
     - name: 'Run RSpec Feature Tests'
       run: bin/bundle exec rspec --force-color --format RSpec::Github::Formatter --format progress --tag ~skip spec/features/
+
+    - name: Archive capybara screenshots
+      uses: actions/upload-artifact@v3
+      with:
+        name: capybara-screenshots
+        path: tmp/capybara

--- a/.github/workflows/rspec_features.yml
+++ b/.github/workflows/rspec_features.yml
@@ -57,7 +57,7 @@ jobs:
       run: RAILS_ENV=test bundle exec rails webpacker:compile
 
     - name: 'Run RSpec Feature Tests'
-      run: bin/bundle exec rspec --force-color --format RSpec::Github::Formatter --format progress --tag ~skip spec/features/
+      run: bin/bundle exec rspec --force-color --fail-fast --format RSpec::Github::Formatter --format progress --tag ~skip spec/features/
 
     - name: Archive capybara screenshots
       uses: actions/upload-artifact@v3

--- a/.github/workflows/rspec_features.yml
+++ b/.github/workflows/rspec_features.yml
@@ -63,4 +63,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: capybara-screenshots
-        path: tmp/capybara
+        path: tmp/capybara/*


### PR DESCRIPTION
So that maybe we can see what those failures look like and why they're failing on github actions.

---

I think this probably works.  It's ridiculous since it was failing repeatedly and not creating artifacts from the run.  Then I found out I needed to set it so that it runs that step only on a failure condition and now it has succeeded repeatedly.  🤷‍♂️ 

This also adds the "fail fast" option so that after one failure it stops.  I figure this may be nicer for this long test so if it fails you can troubleshoot or else click the "rerun" button faster.