### PR TITLE
update instructions for getting list of unmatched rors with crossref funders

### DIFF
--- a/documentation/sql_queries/fundref_to_ror_comparisons.md
+++ b/documentation/sql_queries/fundref_to_ror_comparisons.md
@@ -5,12 +5,18 @@
 In order to evaluate how well these identifiers map from one to the other, it's easiest to get the identifiers into 
 our database so we can join and compare them.
 
-Run a rake task like this example which will put a mapping in stash_engine_xref_funder_to_rors:
+Update the ROR database with the latest dump by running a task like this (warning takes a long
+time, like 4 hours to run):
+```bash
+RAILS_ENV=production bundle exec rails affiliation_import:update_ror_orgs
+```
+
+Download the zip and extract the json file from https://doi.org/10.5281/zenodo.6347574:
 ```bash
 RAILS_ENV=<environment> bundle exec rails affiliation_import:populate_funder_ror_mapping <path/to/ror/dump.json>
 ```
 
-After the import you can run the following query to see how items in the database map and that
+After the imports you can run the following query to see how items in the database map and that
 names seem sane where a mapping exists.
 
 ```sql
@@ -23,7 +29,7 @@ SELECT DISTINCT c.contributor_name as xref_name, x.`xref_id`, x.ror_id, r.name a
  WHERE c.identifier_type = 'crossref_funder_id' and c.contributor_type = 'funder';
 ```
 
-To see unmatched identifiers where a ror matching doesn't exist from the identifiers:
+To see unmatched identifiers where a ror matching doesn't exist for the fundref ID:
 
 ```sql
 SELECT DISTINCT c.contributor_name as xref_name, c.name_identifier_id
@@ -33,6 +39,26 @@ SELECT DISTINCT c.contributor_name as xref_name, c.name_identifier_id
  WHERE c.identifier_type = 'crossref_funder_id' and c.contributor_type = 'funder'
     AND c.name_identifier_id <> '' AND x.ror_id IS NULL;
 ```
+
+See the unmatched fundref IDs with a count of number of times they occur.  This is probably the one
+to export as CSV or similar for the ROR team to analyze and see if there are funder IDs to add:
+
+```sql
+SELECT unmatched.*, c2.num_uses FROM
+  (SELECT DISTINCT c.contributor_name as xref_name, c.name_identifier_id
+    FROM dcs_contributors c
+    LEFT JOIN stash_engine_xref_funder_to_rors x
+      ON c.name_identifier_id = x.xref_id
+   WHERE c.identifier_type = 'crossref_funder_id' and c.contributor_type = 'funder'
+      AND c.name_identifier_id <> '' AND x.ror_id IS NULL) as unmatched
+  JOIN
+  (SELECT name_identifier_id, count(name_identifier_id) num_uses
+     FROM dcs_contributors
+     GROUP BY name_identifier_id) as c2
+  ON unmatched.name_identifier_id = c2.name_identifier_id
+ORDER BY c2.num_uses DESC;
+```
+
 
 Items that are funders but don't match a fundref ID:
 

--- a/lib/tasks/affiliation_import.rake
+++ b/lib/tasks/affiliation_import.rake
@@ -101,6 +101,7 @@ namespace :affiliation_import do
 
     if ARGV.length != 1
       puts 'Please enter the path to the ROR dump json file as an argument'
+      puts 'You can get the latest dump from https://doi.org/10.5281/zenodo.6347574 (get json file for last version in zip)'
       exit
     end
 


### PR DESCRIPTION
This gives better instructions on rake tasks to use and also queries to use to compare.  I ran it again (see other ticket for a list of unmatched items).

We also have some things that use the crossreff funder url with None on the end.  IDK how these got in there.