### PR TITLE
Don't update Field of Science subjects

### DIFF
--- a/lib/tasks/keywords/plos.rb
+++ b/lib/tasks/keywords/plos.rb
@@ -18,7 +18,7 @@ module Tasks
             StashDatacite::Subject.create(subject: k, subject_scheme: SCHEME, scheme_URI: SCHEME_URI)
           else
             subjs.each do |subj|
-              next if subj.subject == k && subj.subject_scheme == SCHEME && subj.scheme_URI == SCHEME_URI
+              next if subj.subject_scheme == 'fos' || (subj.subject == k && subj.subject_scheme == SCHEME && subj.scheme_URI == SCHEME_URI)
 
               # update the existing one to the correct values, so it reflects the vocabulary it came from
               subj.update(subject: k, subject_scheme: SCHEME, scheme_URI: SCHEME_URI)


### PR DESCRIPTION
Our subjects are a mess and we want to assign subjects to match the PLoS vocabulary when possible.

But don't update FOS type of subjects which are used and treated differently.