### PR TITLE
Update Google Analytics key, add Matomo analytics

### DIFF
--- a/app/views/layouts/stash_engine/_matomo_analytics.html.erb
+++ b/app/views/layouts/stash_engine/_matomo_analytics.html.erb
@@ -1,0 +1,17 @@
+<% if Rails.env == 'production' %>
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://datadryad.matomo.cloud/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '1']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src='//cdn.matomo.cloud/datadryad.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+<% end %>

--- a/app/views/layouts/stash_engine/_matomo_analytics.html.erb
+++ b/app/views/layouts/stash_engine/_matomo_analytics.html.erb
@@ -1,4 +1,3 @@
-<% if Rails.env == 'production' %>
 <!-- Matomo -->
 <script>
   var _paq = window._paq = window._paq || [];
@@ -6,12 +5,12 @@
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
-    var u="https://datadryad.matomo.cloud/";
+    var u="https://<%= APP_CONFIG.matomo_analytics_id %>.matomo.cloud/";
     _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '1']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src='//cdn.matomo.cloud/datadryad.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+    g.async=true; g.src='//cdn.matomo.cloud/<%= APP_CONFIG.matomo_analytics_id %>.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
 <!-- End Matomo Code -->
-<% end %>
+

--- a/app/views/layouts/stash_engine/_standard_head.html.erb
+++ b/app/views/layouts/stash_engine/_standard_head.html.erb
@@ -10,6 +10,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 <%= render 'layouts/stash_engine/google_analytics' %>
+<%= render 'layouts/stash_engine/matomo_analytics' %>
 
 <%= csrf_meta_tags %>
 

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -344,7 +344,7 @@ production:
     bucket: dryad-s3-prd
     key: AKIA2KERHV5E3OITXZXC
     secret: <%= Rails.application.credentials[Rails.env.to_sym][:s3_secret] %>
-  google_analytics_id: UA-145629338-1
+  google_analytics_id: G-6CWE0T05CC
   google:
     gmail_client_id: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_id] %>
     gmail_client_secret: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_secret] %>

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -170,6 +170,7 @@ defaults: &DEFAULTS
     key: AKIA2KERHV5E3OITXZXC
     secret: <%= Rails.application.credentials[Rails.env.to_sym][:s3_secret] %>
   google_analytics_id: null
+  matomo_analytics_id: null
   google_recaptcha_sitekey: 6Lfhn5kiAAAAAIzZPQEGRa43cDJz-rNVxRcQIkU4
   google:
     gmail_client_id: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_id] %>
@@ -223,6 +224,7 @@ development: &DEVELOPMENT
   send_journal_published_notices: false
   collection_uri: http://mrtsword-stg.cdlib.org:39001/mrtsword/
   google_analytics_id: UA-145629338-2
+  matomo_analytics_id: datadryad-dev
   payments:
     service: stripe
     key: <%= Rails.application.credentials[Rails.env.to_sym][:stripe_key] %> 
@@ -263,6 +265,7 @@ stage:
   page_error_email: [scott.fisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
   feedback_email_from: no-reply-dryad-stg@datadryad.org
   google_analytics_id: UA-145629338-3
+  matomo_analytics_id: datadryad-stg
   repository:
     domain: https://merritt-stage.cdlib.org
     endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"
@@ -345,6 +348,7 @@ production:
     key: AKIA2KERHV5E3OITXZXC
     secret: <%= Rails.application.credentials[Rails.env.to_sym][:s3_secret] %>
   google_analytics_id: G-6CWE0T05CC
+  matomo_analytics_id: datadryad
   google:
     gmail_client_id: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_id] %>
     gmail_client_secret: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_secret] %>


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/1841

Update Google Analytics (production only) to use a new key for version 4.

Add parallel analytics for Matomo, using their cloud tracking system.