### PR TITLE
Change case of repoid

### DIFF
--- a/app/views/stash_engine/landing/show.html.erb
+++ b/app/views/stash_engine/landing/show.html.erb
@@ -4,7 +4,7 @@
 <script data-autotrack="false" src="https://cdn.jsdelivr.net/npm/@datacite/datacite-tracker"></script>
 <script>
 	const { trackMetric } = DataCiteTracker.Tracker({
-		repoid: '<%= APP_CONFIG[:datacite_data_repo_id] %>',
+		repoId: '<%= APP_CONFIG[:datacite_data_repo_id] %>',
 		trackLocalhost: <%= Rails.env == 'production' ? 'true' : 'false' %>,
 	});
 	let dc_download = DataCiteTracker.MetricType.Download;


### PR DESCRIPTION
Kristian had emailed and said they still were not tracking because we had put `repoid` in our code rather than `repoId`.  It looks like we got this from their sample code which also had the capitalization set incorrectly.  They've also since corrected their sample code.