### PR TITLE
Break out primary articles from other articles

### DIFF
--- a/app/views/stash_datacite/related_identifiers/_landing_related_works.html.erb
+++ b/app/views/stash_datacite/related_identifiers/_landing_related_works.html.erb
@@ -1,25 +1,11 @@
 
 <% # Article IDs %>
 
-<% article_ids = @resource.related_identifiers.where(work_type: [:article, :primary_article]).where(hidden: false).order(work_type: :desc) %>
-<% if article_ids.present? %>
-    <h3 class="o-heading__level3-related-works"><%= (article_ids.count > 1 ? "Articles" : "Article") %></h3>
-    <ul class="o-list-related">
-	<% article_ids.each do |r| %>
-	    <% bad_asterisk = ( (current_user&.limited_curator? && !r.verified?) ? ' *' : '') %>
-	    <li>
-		<% if r.work_type == 'undefined' %>
-		    This dataset <%= r.relation_name_english %>
-		    <%= display_id(type: r.related_identifier_type,
-				   my_id: r.related_identifier) %> <%= bad_asterisk %>
-		<% else %>
-		    <%= link_to r.related_identifier.ellipsisize(40), r.related_identifier, class: 'o-link__primary', title: r.related_identifier %>
-		    <%= bad_asterisk %>
-		<% end %>
-	    </li>
-	<% end %>
-    </ul>
-<% end %>
+<% prim_article_ids = @resource.related_identifiers.where(work_type: :primary_article).where(hidden: false).order(work_type: :desc) %>
+<%= render partial: 'special_article', locals: {article_ids: prim_article_ids, item_label: 'Primary article'} %>
+
+<% article_ids = @resource.related_identifiers.where(work_type: :article).where(hidden: false).order(work_type: :desc) %>
+<%= render partial: 'special_article', locals: {article_ids: article_ids, item_label: 'Article'} %>
 
 <% # All other related IDs %>
 
@@ -43,4 +29,3 @@
 	<% end %>
     </ul>
 <% end %>
-

--- a/app/views/stash_datacite/related_identifiers/_special_article.html.erb
+++ b/app/views/stash_datacite/related_identifiers/_special_article.html.erb
@@ -1,0 +1,19 @@
+<% # takes locals of article_ids and item_label (singular version of item like Article or Primary article)  %>
+<% if article_ids.present? %>
+  <h3 class="o-heading__level3-related-works"><%= item_label.pluralize(article_ids.count) %></h3>
+  <ul class="o-list-related">
+    <% article_ids.each do |r| %>
+      <% bad_asterisk = ( (current_user&.limited_curator? && !r.verified?) ? ' *' : '') %>
+      <li>
+        <% if r.work_type == 'undefined' %>
+          This dataset <%= r.relation_name_english %>
+          <%= display_id(type: r.related_identifier_type,
+                         my_id: r.related_identifier) %> <%= bad_asterisk %>
+        <% else %>
+          <%= link_to r.related_identifier.ellipsisize(40), r.related_identifier, class: 'o-link__primary', title: r.related_identifier %>
+          <%= bad_asterisk %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>


### PR DESCRIPTION
All articles on the landing page were shown together before.  This breaks out an extra heading for a primary article.

![Screenshot 2023-06-22 at 5 01 24 PM](https://github.com/CDL-Dryad/dryad-app/assets/105433/8f11030c-e963-4aa6-b2d8-41a7d837564a)
