### PR TITLE
Add more action buttons to user dashboard for datasets in PPR

### DIFF
--- a/app/assets/stylesheets/stash_engine/ui.css
+++ b/app/assets/stylesheets/stash_engine/ui.css
@@ -8290,6 +8290,8 @@ dl.timeline div:nth-child(5n+5) dt, dl.timeline div:nth-child(5n+5) dd::before {
   -webkit-box-pack: justify;
       -ms-flex-pack: justify;
           justify-content: space-between;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
 }
 
 .t-describe__remove-button {

--- a/app/assets/stylesheets/stash_engine/ui.css
+++ b/app/assets/stylesheets/stash_engine/ui.css
@@ -8198,7 +8198,7 @@ dl.timeline div:nth-child(5n+5) dt, dl.timeline div:nth-child(5n+5) dd::before {
   padding-right: 2rem;
 }
 .c-user-datasets-list li > div:last-child {
-  width: 200px;
+  width: 30ch;
   font-size: 0.9em;
   padding-right: 10px;
 }

--- a/app/views/stash_engine/dashboard/_user_datasets.html.erb
+++ b/app/views/stash_engine/dashboard/_user_datasets.html.erb
@@ -56,7 +56,7 @@
             success-status
           <%end%>
         "><%= resource&.last_curation_activity&.readable_status %></span>
-        <div class="c-user-datasets-actions">
+        <div class="c-user-datasets-actions" style="<%= ( dataset.sort_order == 1 ? 'flex-direction: column' : '' ) %>">
           <% if resource&.last_curation_activity.status == 'in_progress' %>
             <% if resource&.dataset_in_progress_editor&.id == current_user&.id %>
               <%= button_to stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: resource.id), name: 'resume', form_class: 'o-button__inline-form', class: 'o-button__plain-text7' do %>
@@ -72,6 +72,9 @@
           <% if dataset.sort_order == 1 %>
             <%= button_to stash_url_helpers.peer_review_release_path, method: :patch, params: {stash_engine_resource: { id: resource.id }}, name: 'release', data: { confirm: 'Is this dataset ready for curation and publication?' }, form_class: 'o-button__inline-form', class: 'o-button__plain-text7' do %>
               Release for curation <i class="fa fa-paper-plane" aria-hidden="true"></i>
+            <% end %>
+            <%= button_to stash_url_helpers.metadata_entry_pages_new_version_path(resource_id: resource.id), name: 'update', form_class: 'o-button__inline-form', class: 'o-button__plain-text7', onclick: 'setLoading(event)' do %>
+              Edit new version <i class="fa fa-file" aria-hidden="true"></i>
             <% end %>
           <% end %>
           <% if ['submitted', 'action_required'].include?(resource&.last_curation_activity.status) || dataset.sort_order >= 3 %>

--- a/app/views/stash_engine/dashboard/_user_datasets.html.erb
+++ b/app/views/stash_engine/dashboard/_user_datasets.html.erb
@@ -11,6 +11,9 @@
       delete_confirm << '?'
     end 
   %>
+  <% delete_button = button_to stash_url_helpers.resource_path(resource), method: :delete, data: { confirm: delete_confirm }, name: 'delete', form_class: 'o-button__inline-form', class: 'o-button__plain-text7', title: resource&.stash_version.version > 1 ? 'Revert to previous version' : 'Delete dataset' do %>
+    <%= resource&.stash_version.version > 1 ? 'Revert' : 'Delete' %> <i class="fa fa-trash" aria-hidden="true"></i>
+  <% end %>
   <% if @datasets.index{ |d| d.sort_order == dataset.sort_order } == i %>
     <% if i > 0 %>
       </ul>
@@ -62,9 +65,7 @@
               <%= button_to stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: resource.id), name: 'resume', form_class: 'o-button__inline-form', class: 'o-button__plain-text7' do %>
                 Resume <i class="fa fa-pencil" aria-hidden="true"></i>
               <% end %>
-              <%= button_to stash_url_helpers.resource_path(resource), method: :delete, data: { confirm: delete_confirm }, name: 'delete', form_class: 'o-button__inline-form', class: 'o-button__plain-text7', title: resource&.stash_version.version > 1 ? 'Revert to previous version' : 'Delete dataset' do %>
-                <%= resource&.stash_version.version > 1 ? 'Revert' : 'Delete' %> <i class="fa fa-trash" aria-hidden="true"></i>
-              <% end %>
+              <%= delete_button %>
             <% elsif resource&.dataset_in_progress_editor.present? %>
               Dataset being edited by <%= resource.dataset_in_progress_editor.name %>
             <% end %>
@@ -78,6 +79,9 @@
             <%= button_to stash_url_helpers.metadata_entry_pages_new_version_path(resource_id: resource.id), name: 'update', form_class: 'o-button__inline-form', class: 'o-button__plain-text7', onclick: 'setLoading(event)' do %>
               Create new version <i class="fa fa-pencil" aria-hidden="true"></i>
             <% end %>
+          <% end %>
+          <% if dataset.sort_order == 1 %>
+            <%= delete_button %>
           <% end %> 
         </div>
       </div>

--- a/app/views/stash_engine/dashboard/_user_datasets.html.erb
+++ b/app/views/stash_engine/dashboard/_user_datasets.html.erb
@@ -56,7 +56,7 @@
             success-status
           <%end%>
         "><%= resource&.last_curation_activity&.readable_status %></span>
-        <div class="c-user-datasets-actions" style="<%= ( dataset.sort_order == 1 ? 'flex-direction: column' : '' ) %>">
+        <div class="c-user-datasets-actions">
           <% if resource&.last_curation_activity.status == 'in_progress' %>
             <% if resource&.dataset_in_progress_editor&.id == current_user&.id %>
               <%= button_to stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: resource.id), name: 'resume', form_class: 'o-button__inline-form', class: 'o-button__plain-text7' do %>
@@ -73,13 +73,10 @@
             <%= button_to stash_url_helpers.peer_review_release_path, method: :patch, params: {stash_engine_resource: { id: resource.id }}, name: 'release', data: { confirm: 'Is this dataset ready for curation and publication?' }, form_class: 'o-button__inline-form', class: 'o-button__plain-text7' do %>
               Release for curation <i class="fa fa-paper-plane" aria-hidden="true"></i>
             <% end %>
-            <%= button_to stash_url_helpers.metadata_entry_pages_new_version_path(resource_id: resource.id), name: 'update', form_class: 'o-button__inline-form', class: 'o-button__plain-text7', onclick: 'setLoading(event)' do %>
-              Edit new version <i class="fa fa-file" aria-hidden="true"></i>
-            <% end %>
           <% end %>
-          <% if ['submitted', 'action_required'].include?(resource&.last_curation_activity.status) || dataset.sort_order >= 3 %>
+          <% if ['submitted', 'action_required'].include?(resource&.last_curation_activity.status) || dataset.sort_order == 1 || dataset.sort_order >= 3 %>
             <%= button_to stash_url_helpers.metadata_entry_pages_new_version_path(resource_id: resource.id), name: 'update', form_class: 'o-button__inline-form', class: 'o-button__plain-text7', onclick: 'setLoading(event)' do %>
-              Create new version <i class="fa fa-file" aria-hidden="true"></i>
+              Create new version <i class="fa fa-pencil" aria-hidden="true"></i>
             <% end %>
           <% end %> 
         </div>

--- a/ui-library/scss/_datasets.scss
+++ b/ui-library/scss/_datasets.scss
@@ -24,7 +24,7 @@
 		  }
 
 		  &:last-child {
-		    width: 200px;
+		    width: 30ch;
 		    font-size: .9em;
 		    padding-right: 10px; 
 		  }

--- a/ui-library/scss/_datasets.scss
+++ b/ui-library/scss/_datasets.scss
@@ -105,5 +105,6 @@
   .c-user-datasets-actions {
 	  display: flex;
 	  justify-content: space-between;
+    flex-wrap: wrap;
 	}
 }


### PR DESCRIPTION
See #2594 .

IDK if this is the very perfect fix, but it was formatting the larger buttons squished up side by side so, just for this section, styled it as`flex-direction:column`.  I tried some other stuff first, but this seemed the easiest way to put this extra edit button back in below.

Also called it "Edit new version" since it sounds like they are oriented toward editing their datasets and the new version is a side effect of editing.  We can make it "Create new version" to be the same if you want, though (it's the same action).