### PR TITLE
Removes duplicate subjects and leaves the Field of Science alone

### DIFF
--- a/app/controllers/stash_engine/metadata_entry_pages_controller.rb
+++ b/app/controllers/stash_engine/metadata_entry_pages_controller.rb
@@ -23,6 +23,8 @@ module StashEngine
 
     # GET/POST/PUT  /generals/find_or_create
     def find_or_create
+      @resource&.purge_duplicate_subjects!
+
       return unless @resource.submitted? # create a new version if this is a submitted version
 
       redirect_to(stash_url_helpers.metadata_entry_pages_new_version_path(resource_id: params[:resource_id]))

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -858,7 +858,7 @@ module StashEngine
     end
 
     def purge_duplicate_subjects!
-      text_subj = subjects.non_fos.order(:subject).map{|s| s.subject&.downcase }.compact
+      text_subj = subjects.non_fos.order(:subject).map { |s| s.subject&.downcase }.compact
 
       dups = []
       text_subj.each_with_index do |s, idx|

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -773,6 +773,45 @@ module StashEngine
       end
     end
 
+    describe '#purge_duplicate_subjects!' do
+      before(:each) do
+        @resource = create(:resource)
+      end
+
+      it "purges duplicate subjects" do
+        @resource.subjects << create(:subject, subject: 'AARDVARKS')
+        @resource.subjects << create(:subject, subject: 'Aardvarks')
+        @resource.subjects << create(:subject, subject: 'aardvarks')
+        starting_size = @resource.subjects.count
+        @resource.purge_duplicate_subjects!
+        expect(@resource.reload.subjects.count).to eq(starting_size - 2)
+      end
+
+      it "doesn't purge FOS subjects" do
+        existing_fos = @resource.subjects.fos.first
+        @resource.subjects << create(:subject, subject: existing_fos.subject) # this one doesn't have fos subject_scheme set
+        @resource.subjects << create(:subject, subject: existing_fos.subject)
+        starting_size = @resource.subjects.count
+        @resource.purge_duplicate_subjects!
+        @resource.reload
+        expect(@resource.subjects.count).to eq(starting_size - 1) # only purges one
+        expect(@resource.subjects.fos.count).to eq(1) # still has the one FOS subject
+        expect(@resource.subjects.non_fos.where(subject: existing_fos.subject).count).to eq(1) # still has that subject in non-FOS, also
+      end
+
+      it "prefers to purge non-controlled vocab subjects over ones with vocabulary" do
+        existing_subj = @resource.subjects.non_fos.first
+        @resource.subjects << create(:subject, subject: existing_subj.subject, subject_scheme: 'gumma')
+        starting_size = @resource.subjects.count
+        @resource.purge_duplicate_subjects!
+        @resource.reload
+        expect(@resource.subjects.count).to eq(starting_size - 1) # only purges one
+        left_subject = @resource.subjects.where(subject: existing_subj.subject)
+        expect(left_subject.count).to eq(1) # still has that subject
+        expect(left_subject.first.subject_scheme).to eq('gumma') # it kept the one with a subject scheme
+      end
+    end
+
     describe 'resource state' do
       attr_reader :resource
       attr_reader :state

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -778,7 +778,7 @@ module StashEngine
         @resource = create(:resource)
       end
 
-      it "purges duplicate subjects" do
+      it 'purges duplicate subjects' do
         @resource.subjects << create(:subject, subject: 'AARDVARKS')
         @resource.subjects << create(:subject, subject: 'Aardvarks')
         @resource.subjects << create(:subject, subject: 'aardvarks')
@@ -799,7 +799,7 @@ module StashEngine
         expect(@resource.subjects.non_fos.where(subject: existing_fos.subject).count).to eq(1) # still has that subject in non-FOS, also
       end
 
-      it "prefers to purge non-controlled vocab subjects over ones with vocabulary" do
+      it 'prefers to purge non-controlled vocab subjects over ones with vocabulary' do
         existing_subj = @resource.subjects.non_fos.first
         @resource.subjects << create(:subject, subject: existing_subj.subject, subject_scheme: 'gumma')
         starting_size = @resource.subjects.count


### PR DESCRIPTION
- method to remove duplicate subjects (unassociate them)
- tests for removal
  - Ignore FOS since it's treated differently and not like a normal subject
  - Prefer to remove a subject without a controlled vocab than one with one

The ticket for this #2467 was vague on details, when or how this happens.  I put a call into the editing screen load (find or create) since I think that should catch duplicates if the import does them as was speculated.

It does something different now and maybe the problem is fixed, not really sure since there were no steps telling how to replicate the problem. 🤷‍♂️ 