### PR TITLE
Base view only on what users select

### DIFF
--- a/app/javascript/react/components/MetadataEntry/PrelimInfo.jsx
+++ b/app/javascript/react/components/MetadataEntry/PrelimInfo.jsx
@@ -13,13 +13,7 @@ function PrelimInfo(
   const csrf = document.querySelector("meta[name='csrf-token']")?.getAttribute('content');
 
   let tempVal;
-  if (msid?.value) {
-    tempVal = 'manuscript';
-  } else if (related_identifier) {
-    tempVal = 'published';
-  } else {
-    tempVal = importInfo;
-  }
+  tempVal = importInfo;
 
   const [acText, setAcText] = useState(publication_name?.value || '');
   const [acID, setAcID] = useState(publication_issn?.value || '');

--- a/app/javascript/react/components/MetadataEntry/PrelimInfo.jsx
+++ b/app/javascript/react/components/MetadataEntry/PrelimInfo.jsx
@@ -12,8 +12,7 @@ function PrelimInfo(
 ) {
   const csrf = document.querySelector("meta[name='csrf-token']")?.getAttribute('content');
 
-  let tempVal;
-  tempVal = importInfo;
+  const tempVal = importInfo;
 
   const [acText, setAcText] = useState(publication_name?.value || '');
   const [acID, setAcID] = useState(publication_issn?.value || '');


### PR DESCRIPTION
See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2583 .

I don't really consider this a bug since it is intended behavior in that that it overrides the view setting if the user has entered data to ensure they can see the data they entered.  But I made it so it only shows the one they select now, so they can hide the data they entered if they want.  🤷‍♂️ 

Overall, the UI we got as a design for this has a few problems.

- Radio buttons mean only one can be selected and active but the design allows both manuscript and article to be filled and saved, so radio buttons aren't really an appropriate UI paradigm for that.  Likely just two different (perhaps collapsing) forms for both or tabs serve that need better.
- The entry serves the purpose of both saving article doi information and doing an autofill of all info into the dataset if they click that button. They may also accidentally overwrite their data by replacing it from the article or manuscript. The interaction is a bit odd and confusing, imo.
- One related work gets filled up here and others get filled at the bottom of the form.  I suppose there is nothing absolutely wrong with that, but feels redundant to have two different forms for much the same purpose.  Seems like we could be more consistent and it could be simplified.
- I suppose it's weird that they're marked as required, but they're only required if part of the form is filled for manuscript or article then the other part should be too.
- Also, couldn't we just make them *not* required and get rid of the "other or no article" option and people can just ignore them (which they can, anyway).

But we've lived with it the way it is for a while and it mostly works.  I'm not thinking fixes for this area are really rising to much of an urgent need.

