### PR TITLE
Fixing problems with the issn not saving to the database

### DIFF
--- a/app/javascript/react/components/MetadataEntry/PrelimAutocomplete.jsx
+++ b/app/javascript/react/components/MetadataEntry/PrelimAutocomplete.jsx
@@ -69,7 +69,7 @@ export default function PrelimAutocomplete({
   const nameFunc = (item) => (item?.title || '');
 
   // Given a js object from list (supplyLookupList above) it returns the unique identifier
-  const idFunc = (item) => item.single_issn;
+  const idFunc = (item) => item.issn;
 
   return (
     <GenericNameIdAutocomplete


### PR DESCRIPTION
Didn't save when when autocompleting.  Some other process seemed to fill it in if going to another tab (from textual match?).

Before when I looked at my log output after autocompleting it only saved the form without an ID.  Now saves the form with the ID and you can see the query in logs like:

```
  StashEngine::InternalDatum Update (90.6ms)  UPDATE `stash_engine_internal_data` SET `stash_engine_internal_data`.`value` = '0363-6445', `stash_engine_internal_data`.`updated_at` = '2023-07-06 19:37:41' WHERE `stash_engine_internal_data`.`id` = 6175
```

It looks like the identifier field info for selecting it from the autocomplete list got changed to 'single_issn' (which appears to be a ruby function) rather than `issn` which is what the Name/ID json results list returns.  There were also some javascript key errors in React without it acting as a key. 