### PR TITLE
changes to pub updater as in 2259

### DIFF
--- a/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/app/controllers/stash_engine/publication_updater_controller.rb
@@ -4,35 +4,36 @@ module StashEngine
     before_action :require_user_login
     before_action :setup_paging, only: [:index]
 
-    CONCAT_FOR_SEARCH = <<~SQL
-        JOIN
-         (SELECT sepc2.id,
-          CONCAT_WS(' ',
-            sepc2.publication_doi,
-            sepc2.publication_issn,
-            sepc2.publication_name,
-            sepc2.title,
-            sei2.identifier,
-            ser2.title) AS big_text
-        FROM `stash_engine_proposed_changes` sepc2
-          INNER JOIN `stash_engine_identifiers` sei2
-            ON sei2.id = sepc2.identifier_id
-          INNER JOIN `stash_engine_resources` ser2
-            ON ser2.`id` = sei2.`latest_resource_id`
-       ) search_table
-        ON search_table.id = stash_engine_proposed_changes.id
+    CONCAT_FOR_SEARCH = <<~SQL.freeze
+       JOIN
+        (SELECT sepc2.id,
+         CONCAT_WS(' ',
+           sepc2.publication_doi,
+           sepc2.publication_issn,
+           sepc2.publication_name,
+           sepc2.title,
+           sei2.identifier,
+           ser2.title) AS big_text
+       FROM `stash_engine_proposed_changes` sepc2
+         INNER JOIN `stash_engine_identifiers` sei2
+           ON sei2.id = sepc2.identifier_id
+         INNER JOIN `stash_engine_resources` ser2
+           ON ser2.`id` = sei2.`latest_resource_id`
+      ) search_table
+       ON search_table.id = stash_engine_proposed_changes.id
     SQL
 
+    # rubocop:disable Metrics/AbcSize
     # the admin datasets main page showing users and stats, but slightly different in scope for curators vs tenant admins
     def index
-      proposed_changes = authorize StashEngine::ProposedChange #.includes(identifier: :latest_resource)
+      proposed_changes = authorize StashEngine::ProposedChange # .includes(identifier: :latest_resource)
         .joins(identifier: :latest_resource).where(approved: false, rejected: false).select('stash_engine_proposed_changes.*')
 
       if params[:list_search].present?
         proposed_changes = proposed_changes.joins(CONCAT_FOR_SEARCH)
 
         keys = params[:list_search].split(/\s+/).map(&:strip)
-        proposed_changes = proposed_changes.where((['search_table.big_text LIKE ?'] * keys.size).join(' AND '), *keys.map{ |key| "%#{key}%" })
+        proposed_changes = proposed_changes.where((['search_table.big_text LIKE ?'] * keys.size).join(' AND '), *keys.map { |key| "%#{key}%" })
       end
 
       params[:sort] = 'score' if params[:sort].blank?
@@ -59,6 +60,7 @@ module StashEngine
         end
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     def update
       respond_to do |format|

--- a/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/app/controllers/stash_engine/publication_updater_controller.rb
@@ -4,10 +4,37 @@ module StashEngine
     before_action :require_user_login
     before_action :setup_paging, only: [:index]
 
+    CONCAT_FOR_SEARCH = <<~SQL
+        JOIN
+         (SELECT sepc2.id,
+          CONCAT_WS(' ',
+            sepc2.publication_doi,
+            sepc2.publication_issn,
+            sepc2.publication_name,
+            sepc2.title,
+            sei2.identifier,
+            ser2.title) AS big_text
+        FROM `stash_engine_proposed_changes` sepc2
+          INNER JOIN `stash_engine_identifiers` sei2
+            ON sei2.id = sepc2.identifier_id
+          INNER JOIN `stash_engine_resources` ser2
+            ON ser2.`id` = sei2.`latest_resource_id`
+       ) search_table
+        ON search_table.id = stash_engine_proposed_changes.id
+    SQL
+
     # the admin datasets main page showing users and stats, but slightly different in scope for curators vs tenant admins
     def index
-      proposed_changes = authorize StashEngine::ProposedChange.includes(identifier: :resources)
-        .joins(identifier: :resources).where(approved: false, rejected: false)
+      proposed_changes = authorize StashEngine::ProposedChange #.includes(identifier: :latest_resource)
+        .joins(identifier: :latest_resource).where(approved: false, rejected: false).select('stash_engine_proposed_changes.*')
+
+      if params[:list_search].present?
+        proposed_changes = proposed_changes.joins(CONCAT_FOR_SEARCH)
+
+        keys = params[:list_search].split(/\s+/).map(&:strip)
+        proposed_changes = proposed_changes.where((['search_table.big_text LIKE ?'] * keys.size).join(' AND '), *keys.map{ |key| "%#{key}%" })
+      end
+
       params[:sort] = 'score' if params[:sort].blank?
       params[:direction] = 'desc' if params[:direction].blank?
 

--- a/app/helpers/stash_engine/publication_updater_helper.rb
+++ b/app/helpers/stash_engine/publication_updater_helper.rb
@@ -27,6 +27,11 @@ module StashEngine
       resource.identifier.internal_data.where(data_type: data_type).first&.value || 'Not available'
     end
 
+    def fetch_related_primary_article(resource:)
+      prim_art = resource.related_identifiers.primary_article.first
+      ( prim_art ? prim_art&.related_identifier : 'Not available' )
+    end
+
     def fetch_related_identifier_metadata(resource:, related_identifier_type:, relation_type:)
       return nil unless resource.present? && related_identifier_type.present? && relation_type.present?
 

--- a/app/helpers/stash_engine/publication_updater_helper.rb
+++ b/app/helpers/stash_engine/publication_updater_helper.rb
@@ -37,15 +37,24 @@ module StashEngine
     def existing_authors(resource:)
       return nil unless resource.present?
 
-      resource.authors&.map(&:author_full_name)&.uniq&.sort { |a, b| a <=> b }&.join('<br>')
+      temp_authors =  resource.authors&.map(&:author_full_name)&.uniq
+      output_authors(authors: temp_authors)
     end
 
     def proposed_authors(json:)
       return nil unless json.present?
 
-      JSON.parse(json)&.map { |a| "#{a['family']}, #{a['given']}" }&.uniq&.sort { |a, b| a <=> b }&.join('<br>')
+      temp_authors = JSON.parse(json)&.map { |a| "#{a['family']}, #{a['given']}" }&.uniq
+      output_authors(authors: temp_authors)
+
     rescue JSON::ParserError
       nil
+    end
+
+    def output_authors(authors:)
+      return authors[0..2]&.sort { |a, b| a <=> b } + [ 'et al.' ] if authors.length > 3
+
+      authors&.sort { |a, b| a <=> b }
     end
 
   end

--- a/app/helpers/stash_engine/publication_updater_helper.rb
+++ b/app/helpers/stash_engine/publication_updater_helper.rb
@@ -29,7 +29,16 @@ module StashEngine
 
     def fetch_related_primary_article(resource:)
       prim_art = resource.related_identifiers.primary_article.first
-      ( prim_art ? prim_art&.related_identifier : 'Not available' )
+      return 'Not available' unless prim_art.present?
+      id_str = prim_art&.related_identifier
+
+      my_match =  id_str.match(%r{/(10\..+)})
+      # extract the doi in a bare format to match the json for the other
+      if my_match.present?
+        my_match[1]
+      else
+        id_str
+      end
     end
 
     def fetch_related_identifier_metadata(resource:, related_identifier_type:, relation_type:)

--- a/app/helpers/stash_engine/publication_updater_helper.rb
+++ b/app/helpers/stash_engine/publication_updater_helper.rb
@@ -30,9 +30,10 @@ module StashEngine
     def fetch_related_primary_article(resource:)
       prim_art = resource.related_identifiers.primary_article.first
       return 'Not available' unless prim_art.present?
+
       id_str = prim_art&.related_identifier
 
-      my_match =  id_str.match(%r{/(10\..+)})
+      my_match = id_str.match(%r{/(10\..+)})
       # extract the doi in a bare format to match the json for the other
       if my_match.present?
         my_match[1]
@@ -51,7 +52,7 @@ module StashEngine
     def existing_authors(resource:)
       return nil unless resource.present?
 
-      temp_authors =  resource.authors&.map(&:author_full_name)&.uniq
+      temp_authors = resource.authors&.map(&:author_full_name)&.uniq
       output_authors(authors: temp_authors)
     end
 
@@ -60,13 +61,12 @@ module StashEngine
 
       temp_authors = JSON.parse(json)&.map { |a| "#{a['family']}, #{a['given']}" }&.uniq
       output_authors(authors: temp_authors)
-
     rescue JSON::ParserError
       nil
     end
 
     def output_authors(authors:)
-      return authors[0..2]&.sort { |a, b| a <=> b } + [ 'et al.' ] if authors.length > 3
+      return authors[0..2]&.sort { |a, b| a <=> b }&. + ['et al.'] if authors.length > 3
 
       authors&.sort { |a, b| a <=> b }
     end

--- a/app/helpers/stash_engine/publication_updater_helper.rb
+++ b/app/helpers/stash_engine/publication_updater_helper.rb
@@ -15,7 +15,7 @@ module StashEngine
         <td class="c-proposed-change-table__column-mergeable">
           #{new_val.present? ? new_val : 'Not available'}
           <div class="c-proposed-change-table__column-mergeable-icon">
-            <em class="fa fa-arrow-down"></em>
+            <em class="fa fa-arrow-up"></em>
           </div>
         </td>
       HTML

--- a/app/models/stash_engine/proposed_change.rb
+++ b/app/models/stash_engine/proposed_change.rb
@@ -22,10 +22,8 @@ module StashEngine
       return false if current_user.blank? || !current_user.is_a?(StashEngine::User)
 
       cr = Stash::Import::Crossref.from_proposed_change(proposed_change: self)
-      existing_title = identifier.latest_resource&.title
-      resource = cr.populate_resource!
-      # We don't acvtually want to update the dataset title in this scenario
-      resource.update(title: existing_title) unless resource.title == existing_title
+      resource = cr.populate_pub_update!
+
       add_metadata_updated_curation_note(cr.class.name.downcase.split('::').last, resource)
       update(approved: true, user_id: current_user.id)
       true

--- a/app/views/stash_engine/publication_updater/_current_metadata.html.erb
+++ b/app/views/stash_engine/publication_updater/_current_metadata.html.erb
@@ -7,5 +7,5 @@
 <td><%= existing_pubissn %></td>
 <td><%= existing_pubdoi %></td>
 <td><%= formatted_date(resource.publication_date) %></td>
-<td><%= existing_authors(resource: resource).html_safe %></td>
+<td><%= existing_authors(resource: resource)&.join('<br/>')&.html_safe %></td>
 <td>&nbsp;</td>

--- a/app/views/stash_engine/publication_updater/_proposed_change_line.html.erb
+++ b/app/views/stash_engine/publication_updater/_proposed_change_line.html.erb
@@ -1,8 +1,7 @@
 <%
   existing_pubname = fetch_identifier_metadata(resource: resource, data_type: 'publicationName')
   existing_pubissn = fetch_identifier_metadata(resource: resource, data_type: 'publicationISSN')
-  existing_pubdoi = fetch_related_identifier_metadata(resource: resource, related_identifier_type: 'doi',
-                                                      relation_type: 'cites')
+  existing_pubdoi = fetch_related_identifier_metadata(resource: resource, related_identifier_type: 'doi', relation_type: 'cites')
 %>
 <tr class="c-lined-table__row" id="current_<%= proposed_change.id %>">
   <%= render partial: 'current_metadata', locals: { resource: resource, existing_pubdoi: existing_pubdoi, existing_pubissn: existing_pubissn, existing_pubname: existing_pubname } %>

--- a/app/views/stash_engine/publication_updater/_proposed_change_line.html.erb
+++ b/app/views/stash_engine/publication_updater/_proposed_change_line.html.erb
@@ -1,7 +1,7 @@
 <%
   existing_pubname = fetch_identifier_metadata(resource: resource, data_type: 'publicationName')
   existing_pubissn = fetch_identifier_metadata(resource: resource, data_type: 'publicationISSN')
-  existing_pubdoi = fetch_related_identifier_metadata(resource: resource, related_identifier_type: 'doi', relation_type: 'cites')
+  existing_pubdoi = fetch_related_primary_article(resource: resource)
 %>
 <tr class="c-lined-table__row" id="current_<%= proposed_change.id %>">
   <%= render partial: 'current_metadata', locals: { resource: resource, existing_pubdoi: existing_pubdoi, existing_pubissn: existing_pubissn, existing_pubname: existing_pubname } %>

--- a/app/views/stash_engine/publication_updater/_proposed_metadata.html.erb
+++ b/app/views/stash_engine/publication_updater/_proposed_metadata.html.erb
@@ -17,7 +17,7 @@
 <%= render_column(old_val: existing_pubissn, new_val: proposed_change.publication_issn).html_safe %>
 <%= render_column(old_val: existing_pubdoi, new_val: proposed_change.publication_doi).html_safe %>
 <td><%= formatted_date(proposed_change.publication_date).present? ? formatted_date(proposed_change.publication_date) : 'Not available' %></td>
-<td><%= proposed_authors(json: proposed_change.authors).html_safe %></td>
+<td><%= proposed_authors(json: proposed_change.authors)&.join('<br/>')&.html_safe %></td>
 
 <td class="c-proposed-change-table__column-centered" title="Dryad score (<%= proposed_change.provenance.capitalize %> score)">
   <%= proposed_change.score&.round(2) %><br>(<%= proposed_change.provenance_score&.round(2) || 'DOI match' %>)

--- a/app/views/stash_engine/publication_updater/index.csv.erb
+++ b/app/views/stash_engine/publication_updater/index.csv.erb
@@ -1,0 +1,42 @@
+<% columns = [
+  'dataset title',
+  'dataset publication entered',
+  'dataset issn entered',
+  'dataset primary article doi',
+  'dataset publication date',
+  'dataset authors',
+  'possible publication title',
+  'possible publication name',
+  'possible publication issn',
+  'possible publication doi',
+  'possible publication date',
+  'possible publication authors',
+  'match score 1',
+  'match score 2' ]
+-%><%= columns.join(',') %>
+<%
+  @proposed_changes.each do |proposed_change|
+  resource = @resources.select{ |r| r.identifier_id == proposed_change.identifier_id }.first
+  next if resource.blank?
+
+  existing_pubname = fetch_identifier_metadata(resource: resource, data_type: 'publicationName')
+  existing_pubissn = fetch_identifier_metadata(resource: resource, data_type: 'publicationISSN')
+  existing_pubdoi = fetch_related_primary_article(resource: resource)
+
+  row = [ resource.title,
+          existing_pubname,
+          existing_pubissn,
+          existing_pubdoi,
+          formatted_date(resource.publication_date),
+          existing_authors(resource: resource)&.join('; '),
+          proposed_change.title,
+          proposed_change.publication_name,
+          proposed_change.publication_issn,
+          proposed_change.publication_doi,
+          ( formatted_date(proposed_change.publication_date).present? ? formatted_date(proposed_change.publication_date) : 'Not available' ),
+          proposed_authors(json: proposed_change.authors)&.join(';'),
+          proposed_change.score&.round(2),
+          proposed_change.provenance_score&.round(2) || 'DOI match'
+  ]
+-%><%= row.to_csv(row_sep: nil).html_safe %>
+<% end -%>

--- a/app/views/stash_engine/publication_updater/index.html.erb
+++ b/app/views/stash_engine/publication_updater/index.html.erb
@@ -14,7 +14,7 @@
 
     <div class="o-admin-form-pair">
       <label for="list_search">Search:</label>
-      <%= text_field_tag 'list_search', params[:list_search], {size: 30, class: 'c-input__text'} %>
+      <%= text_field_tag 'list_search', params[:list_search], {size: 30, class: 'c-input__text', placeholder: 'Search words (all are required)'} %>
     </div>
 
     <%= form.submit "Submit", class: "o-button__submit" %>
@@ -64,6 +64,9 @@
       </tbody>
     </table>
   </div>
+
+  <%= link_to 'Get Comma Separated Values (CSV) for import into Excel',
+              stash_url_helpers.publication_updater_path(sortable_table_params.merge(format: :csv)) %>
   <div id="proposed-change-dialog" class="o-admin-dialog">Processing your request ...</div>
 
   <div class="c-space-paginator">

--- a/app/views/stash_engine/publication_updater/index.html.erb
+++ b/app/views/stash_engine/publication_updater/index.html.erb
@@ -67,7 +67,7 @@
 
   <%= link_to 'Get Comma Separated Values (CSV) for import into Excel',
               stash_url_helpers.publication_updater_path(sortable_table_params.merge(format: :csv)) %>
-  <div id="proposed-change-dialog" class="o-admin-dialog">Processing your request ...</div>
+  <div id="proposed-change-dialog" class="o-admin-dialog" style="display: none">Processing your request ...</div>
 
   <div class="c-space-paginator">
     <%= paginate @proposed_changes, params: { page_size: @page_size, show_all: false } %>

--- a/app/views/stash_engine/publication_updater/index.html.erb
+++ b/app/views/stash_engine/publication_updater/index.html.erb
@@ -9,6 +9,19 @@
   <p>The first row in a group represents the existing information we have for the dataset. The second row of tthe group represents the proposed changes (highlighted in blue). Clicking the <em>'Accept'</em> button will transfer the proposed changes in 'blue' to the dataset. Clicking <em>'Reject'</em> will cancel the proposed changes</p>
   <p>The publication updater will try to match a dataset's publication DOI (if available). If Crossref finds a match for the DOI then the 'Scores' column will display `1 (DOI match)`. In the event that no publication DOI was available, the publication updater will then send the dataset's title and authors to Crossref. In this situation, the 'Scores' column will display Crossref's scoring of the closest match it found (in parenthesis) and the publication updater's internal score that is based on matching against the title and author list returned by Crossref</p>
 
+  <%= form_with url: stash_url_helpers.publication_updater_path, method: :get do |form| %>
+    <h2 class="o-heading__level2">Limit to</h2>
+
+    <div class="o-admin-form-pair">
+      <label for="list_search">Search:</label>
+      <%= text_field_tag 'list_search', params[:list_search], {size: 30, class: 'c-input__text'} %>
+    </div>
+
+    <%= form.submit "Submit", class: "o-button__submit" %>
+    <%= button_tag "Reset", type: :reset, id: 'reset_button', class: "o-button__remove" %>
+
+  <% end %>
+
   <div class="table-wrapper">
     <table class="c-lined-table">
       <thead>
@@ -58,10 +71,15 @@
   </div>
 
   <script type="text/javascript">
-
     $('.c-lined-table').on('click', 'button[name="accept_changes"], button[name="reject_changes"]', function(){
       $('#genericModalContent').html('<h1>Please wait . . .</h1>');
       $('#genericModalDialog')[0].showModal();
+    });
+
+    $("#reset_button").on("click", function(e) {
+      e.preventDefault();
+      $("#list_search").val("");
+      e.target.form.submit();
     });
   </script>
 </div>

--- a/db/migrate/20230710224653_add_subjects_to_proposed_changes.rb
+++ b/db/migrate/20230710224653_add_subjects_to_proposed_changes.rb
@@ -1,0 +1,5 @@
+class AddSubjectsToProposedChanges < ActiveRecord::Migration[6.1]
+  def change
+    add_column :stash_engine_proposed_changes, :subjects, :text, default: nil
+  end
+end

--- a/lib/stash/import/crossref.rb
+++ b/lib/stash/import/crossref.rb
@@ -1,4 +1,5 @@
 require 'amatch'
+require 'set'
 require 'byebug'
 
 require_relative '../../../app/models/stash_engine/proposed_change'
@@ -11,12 +12,12 @@ module Stash
       include Amatch
 
       CROSSREF_FIELD_LIST = %w[abstract author container-title DOI funder published-online
-                               published-print publisher score title type URL].freeze
+                               published-print publisher score title type URL subject].freeze
 
       def initialize(resource:, crossref_json:)
         @resource = resource
         crossref_json = JSON.parse(crossref_json) if crossref_json.is_a?(String)
-        @sm = crossref_json # which came form crossref (x-ref) ... see class methods below
+        @sm = crossref_json # which came from crossref (x-ref) ... see class methods below
       end
 
       class << self
@@ -51,16 +52,18 @@ module Stash
         end
 
         def from_proposed_change(proposed_change:)
-          return new(resource: nil, crossref_json: {}) unless proposed_change.is_a?(StashEngine::ProposedChange)
+          pro = proposed_change
+          return new(resource: nil, crossref_json: {}) unless pro.is_a?(StashEngine::ProposedChange)
 
           identifier = StashEngine::Identifier.find(proposed_change.identifier_id)
           message = {
-            'DOI' => proposed_change.publication_doi,
-            'publisher' => proposed_change.publication_name,
-            'title' => [proposed_change.title],
-            'URL' => proposed_change.url,
-            'score' => proposed_change.score,
-            'provenance_score' => proposed_change.provenance_score
+            'DOI' => pro.publication_doi,
+            'publisher' => pro.publication_name,
+            'title' => [pro.title],
+            'URL' => pro.url,
+            'score' => pro.score,
+            'provenance_score' => pro.provenance_score,
+            'subject' => (pro.subjects.present? ? JSON.parse(pro.subjects) : [])
           }
           new(resource: identifier.latest_resource, crossref_json: message)
         end
@@ -74,6 +77,18 @@ module Stash
         end
       end
 
+      # populate just a few fields for pub_updater
+      def populate_pub_update!
+        return nil unless @sm.present? && @resource.present?
+
+        populate_related_doi
+        populate_publication_issn
+        populate_publication_name
+        populate_subjects
+        @resource.reload
+      end
+
+      # populate the full resource from the crossref metadata
       def populate_resource!
         return unless @sm.present? && @resource.present?
 
@@ -84,6 +99,7 @@ module Stash
         populate_publication_issn
         populate_publication_name
         populate_title
+        populate_subjects
         @resource.save
         @resource.reload
       end
@@ -107,7 +123,8 @@ module Stash
           score: @sm['score'],
           provenance_score: @sm['provenance_score'],
           title: @sm['title']&.first&.to_s,
-          url: @sm['URL']
+          url: @sm['URL'],
+          subjects: @sm['subject'].to_json
         }
         pc = StashEngine::ProposedChange.new(params)
         resource_will_change?(proposed_change: pc) ? pc : nil
@@ -210,10 +227,20 @@ module Stash
           end
         end
 
+        if proposed_change.subjects.present?
+          subjects_changed = false
+          json = JSON.parse(proposed_change.subjects)
+          if json.is_a?(Array) && json.any?
+            proposed_subjs = json.map(&:downcase).to_set
+            existing_subjs = @resource.subjects.non_fos.map{|i| i.subject&.downcase }.to_set
+            subjects_changed = !proposed_subjs.subset?(existing_subjs)
+          end
+        end
+
         proposed_change.publication_date != @resource.publication_date ||
           internal_datum_will_change?(proposed_change: proposed_change) ||
           related_identifier_will_change?(proposed_change: proposed_change) ||
-          (proposed_change.authors.present? && (auths & @resource.authors).any?)
+          (proposed_change.authors.present? && (auths & @resource.authors).any?) || subjects_changed
       end
 
       def internal_datum_will_change?(proposed_change:)
@@ -282,6 +309,31 @@ module Stash
                                     hidden: false
                                   })
         related.save!
+      end
+
+      def populate_subjects
+        return unless @sm['subject'].present?
+
+        json = @sm['subject']
+        return unless json.is_a?(Array) && json.any?
+
+        # produces hash with downcase keys and original values
+        subj_hsh = json.to_h { |h| [h.downcase, h] }
+        proposed_subjs = subj_hsh.keys
+        existing_subjs = @resource.subjects.non_fos.map { |i| i.subject&.downcase }
+
+        to_add = proposed_subjs - existing_subjs
+
+        to_add.each do |subj|
+          # puts items with scheme first because of sql ordering
+          subs = StashDatacite::Subject.where(subject: subj).non_fos.order(subject_scheme: :desc)
+          sub = if subs.blank?
+                  StashDatacite::Subject.create(subject: subj_hsh[subj]) # create with original case
+                else
+                  subs.first
+                end
+          @resource.subjects << sub
+        end
       end
 
       def populate_funders

--- a/lib/stash/import/crossref.rb
+++ b/lib/stash/import/crossref.rb
@@ -231,8 +231,8 @@ module Stash
           subjects_changed = false
           json = JSON.parse(proposed_change.subjects)
           if json.is_a?(Array) && json.any?
-            proposed_subjs = json.map(&:downcase).to_set
-            existing_subjs = @resource.subjects.non_fos.map{|i| i.subject&.downcase }.to_set
+            proposed_subjs = json.to_set(&:downcase)
+            existing_subjs = @resource.subjects.non_fos.to_set { |i| i.subject&.downcase }
             subjects_changed = !proposed_subjs.subset?(existing_subjs)
           end
         end


### PR DESCRIPTION
closes https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2259 .

There is a lot in that ticket that was not unpacked fully or designed but I think this does the things asked for there.  We may want to modify the text at the top of the journal updater screen to explain what is happening better.

This also ends up modifying the import from CrossRef in the first step in the data entry since they use the same or entangled code.

## To test import of metadata from that page:

1. First find some good DOIs on CrossRef that you'd like to import like `https://api.crossref.org/works?query.bibliographic="pet snakes"&filter=type:journal-article&rows=100` (Change `query.bibliographic` value to whatever query you want to find some good articles to attempt importing metadata for).
2. Press CTRL/CMD-F to find `subject` in the json and find a record with a few subjects if you can.  Try to find the journal name and DOI in the record though it's sometimes hard to read. (JSON formatting plugins for your browser might help.)
3. Start a new dataset, choose `a published article` and put the journal name and doi in the form.
4. Click `Import article metadata` and you should see most of the metadata appear in the page.  You should see the subject items appear under the subject keywords section.  This is the new functionality and it didn't import keywords before.

## To test pub updater

1.  Do step 1 & 2 and find a good candidate article to pretend-enter a new dataset for.
2. Create a new dataset and enter the title and all the authors that the dataset has so it will be very similar. Use fake email addresses or whatever you need to do.
3. Continue filling stuff into the dataset and submit it.
4. After submission, go to the console and type `bundle exec rails publication_updater:crossref RAILS_ENV=development` (or replace environment to something else here).  It should run and try to find similar matches for datasets in Dryad on CrossRef and put the info into the database.
5. Go to the publication updater link in the admin area and you should be able to find a match between an article and the partial information you entered for the dataset.
6. If you click `accept` it should create a primary article link for that in the dataset, add publication name/issn in internal data (shown in first step of data entry) and populate new subjects that didn't exist. It also adds some stuff to the curation history.

## Testing other new functionality
- You can filter the list by search words.  This is an AND query (each word is required).
- You can click the export link and it exports what is essentially the same as what is shown on the screen (only all pages).

I find the DOI column a bit confusing here since in both cases (dataset and article) it's referring to the DOI recorded for the primary article.  You might think the DOI for the dataset row is the dataset DOI, but it's the DOI the dataset has recorded for the primary article.

I can look at instruction improvements and other stuff if you want.

The publication already sorts, I believe.  The way this is shown is wonky since there are compound rows to show changes and you can really only sort on one of them since the paired rows should be kept together.  In most cases they are the same or similar, though.

