### PR TITLE
API and functionality to do simple updates for related works

### DIFF
--- a/app/controllers/api_application_controller.rb
+++ b/app/controllers/api_application_controller.rb
@@ -110,6 +110,12 @@ class ApiApplicationController < StashEngine::ApplicationController
     render json: { error: 'unauthorized' }.to_json, status: 401
   end
 
+  def require_limited_curator
+    return if @user.limited_curator?
+
+    render json: { error: 'unauthorized' }.to_json, status: 401
+  end
+
   def require_curator
     return if @user.curator?
 

--- a/app/controllers/stash_api/frictionless_reports_controller.rb
+++ b/app/controllers/stash_api/frictionless_reports_controller.rb
@@ -1,5 +1,5 @@
 # This class is only for internal use and is not exposed to the public since it may include reports for
-# files that we don't own (at Zenodo) and would only be used by our Frictionless checker or perhas a view
+# files that we don't own (at Zenodo) and would only be used by our Frictionless checker or perhaps a view
 # and limited to roles that can access
 
 # expect URLs to look like /api/v2/files/<file-id>/frictionlessReport

--- a/app/controllers/stash_api/related_works_controller.rb
+++ b/app/controllers/stash_api/related_works_controller.rb
@@ -1,0 +1,63 @@
+module StashApi
+  class RelatedWorksController < ApiApplicationController
+
+    before_action :require_json_headers
+    before_action :force_json_content_type
+    before_action :doorkeeper_authorize!, only: %i[update]
+    before_action :require_api_user, only: %i[update]
+    before_action :require_limited_curator, only: %i[update]
+    before_action -> { require_stash_identifier(doi: params[:dataset_id]) }, only: %i[update]
+    before_action :require_good_doi, only: %i[update]
+    before_action :require_valid_work_type, only: %i[update]
+
+    # PUT
+    def update
+      # update dataset
+      @resource = @stash_identifier.latest_resource
+      related = StashDatacite::RelatedIdentifier.upsert_simple_relation(doi: @other_doi,
+                                                              resource_id: @resource.id,
+                                                              work_type: params[:work_type],
+                                                              added_by: 'api_simple',
+                                                              verified: true)
+
+      # Notify submitter and curators if not notified of an update to this dataset in the last 24 hours
+      send_email
+
+      # add curation activity for update
+      last_curation = @resource.curation_activities.last
+      StashEngine::CurationActivity.create(resource_id: @resource.id,
+                                           user_id: @user.id,
+                                           status: last_curation.status,
+                                           note: "Related #{params[:work_type]} added with #{@other_doi}} from the API",
+                                           created_at: Time.now)
+
+      render json: {
+        relationship: related.work_type,
+        identifierType: related.related_identifier_type_friendly,
+        identifier: related.related_identifier
+      }
+    end
+
+    private
+
+    def require_good_doi
+      @other_doi = StashDatacite::RelatedIdentifier.standardize_doi(params[:id])
+      good = StashDatacite::RelatedIdentifier.valid_doi_format?(@other_doi)
+      render json: { error: "bad request: related DOI isn't formatted correctly" }.to_json, status: 400 unless good
+    end
+
+    def require_valid_work_type
+      return if StashDatacite::RelatedIdentifier.work_types.keys.include?(params[:work_type])
+
+      render json: { error: "bad request: work_type is invalid, please choose from #{StashDatacite::RelatedIdentifier.work_types.keys.join(', ')}" }.to_json, status: 400
+    end
+
+    def send_email
+      last_cur = @resource.last_curation_activity
+      last_note = last_cur&.note || ''
+      return if last_note.match(/Related .+ added with http.+ from the API/) && last_cur.created_at > 1.day.ago
+
+      StashEngine::UserMailer.related_work_updated(@resource).deliver_now
+    end
+  end
+end

--- a/app/controllers/stash_api/related_works_controller.rb
+++ b/app/controllers/stash_api/related_works_controller.rb
@@ -15,10 +15,10 @@ module StashApi
       # update dataset
       @resource = @stash_identifier.latest_resource
       related = StashDatacite::RelatedIdentifier.upsert_simple_relation(doi: @other_doi,
-                                                              resource_id: @resource.id,
-                                                              work_type: params[:work_type],
-                                                              added_by: 'api_simple',
-                                                              verified: true)
+                                                                        resource_id: @resource.id,
+                                                                        work_type: params[:work_type],
+                                                                        added_by: 'api_simple',
+                                                                        verified: true)
 
       # Notify submitter and curators if not notified of an update to this dataset in the last 24 hours
       send_email
@@ -49,7 +49,8 @@ module StashApi
     def require_valid_work_type
       return if StashDatacite::RelatedIdentifier.work_types.keys.include?(params[:work_type])
 
-      render json: { error: "bad request: work_type is invalid, please choose from #{StashDatacite::RelatedIdentifier.work_types.keys.join(', ')}" }.to_json, status: 400
+      render json: { error: 'bad request: work_type is invalid, please choose from ' \
+                            "#{StashDatacite::RelatedIdentifier.work_types.keys.join(', ')}" }.to_json, status: 400
     end
 
     def send_email

--- a/app/mailers/stash_engine/user_mailer.rb
+++ b/app/mailers/stash_engine/user_mailer.rb
@@ -141,6 +141,17 @@ module StashEngine
            subject: "#{rails_env}Voided invoices need to be updated")
     end
 
+    def related_work_updated(resource)
+      return unless resource.present?
+
+      assign_variables(resource)
+      return unless @user.present? && user_email(@user).present?
+
+      bc_email = Rails.env.production? ? @helpdesk_email : nil
+      mail(to: user_email(@user), bcc: bc_email,
+           subject: "#{rails_env}Related work updated for \"#{resource.title}\"")
+    end
+
     private
 
     # rubocop:disable Style/NestedTernaryOperator

--- a/app/models/stash_datacite/related_identifier.rb
+++ b/app/models/stash_datacite/related_identifier.rb
@@ -193,7 +193,8 @@ module StashDatacite
     end
 
     # inserts or updates as is appropriate.  Usually inserts, but may update if the doi for resource is already in the database or
-    # for special circumstances like "there can be only one" primary articles.  Also assumes always a doi for simplicty of use.
+    # for special circumstances like "there can be only one" primary articles.  Also assumes always a doi for simplicity of use.
+    # DOI is the one of the external item, adds to the resource given, work types re list in the enum.
     def self.upsert_simple_relation(doi:, resource_id:, work_type:, added_by: 'simple_relation', verified: true)
       work_type = work_type.to_s # just in case it's a symbol instead of a string
 

--- a/app/models/stash_datacite/related_identifier.rb
+++ b/app/models/stash_datacite/related_identifier.rb
@@ -2,6 +2,7 @@
 
 require 'http'
 
+# rubocop:disable Metrics/ClassLength
 module StashDatacite
 
   class ExternalServerError < RuntimeError; end
@@ -200,7 +201,7 @@ module StashDatacite
 
       raise ArgumentError, 'work type is invalid' unless work_types.keys.include?(work_type)
 
-      fixed_doi = self.standardize_doi(doi)
+      fixed_doi = standardize_doi(doi)
       existing_item = where(resource_id: resource_id).where(related_identifier: fixed_doi).first
       existing_primary = where(resource_id: resource_id).where(work_type: :primary_article).first
 
@@ -212,11 +213,11 @@ module StashDatacite
 
       if existing_item.present?
         existing_item.update(related_identifier: fixed_doi,
-                              related_identifier_type: 'doi',
-                              work_type: work_type,
-                              added_by: added_by,
-                              verified: verified,
-                              relation_type: WORK_TYPES_TO_RELATION_TYPE[work_type])
+                             related_identifier_type: 'doi',
+                             work_type: work_type,
+                             added_by: added_by,
+                             verified: verified,
+                             relation_type: WORK_TYPES_TO_RELATION_TYPE[work_type])
         existing_item
       else
         create(related_identifier: fixed_doi,
@@ -228,7 +229,6 @@ module StashDatacite
                resource_id: resource_id)
       end
     end
-
 
     # look for doi in string and make standardized format
     def self.standardize_doi(doi)
@@ -310,3 +310,4 @@ module StashDatacite
   end
 
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -601,7 +601,7 @@ module StashEngine
     def permission_to_edit?(user:)
       return false unless user
 
-      # cuartor, dataset owner or admin for the same tenant
+      # curator, dataset owner or admin for the same tenant
       admin_for_this_item?(user: user)
     end
 

--- a/app/views/stash_engine/user_mailer/related_work_updated.html.erb
+++ b/app/views/stash_engine/user_mailer/related_work_updated.html.erb
@@ -1,0 +1,15 @@
+<p>Dear <%= @user_name %>,</p>
+
+<p>We have received an update to a related work for your dataset.</p>
+
+<p>The updated dataset is shown below:</p>
+
+<p>
+  Title: <%= @resource.title %><br/>
+  DOI: <%= @resource.identifier_str %>
+</p>
+
+<p>Please contact the Dryad Helpdesk at <a href="mailto:<%= @helpdesk_email %>"><%= @helpdesk_email %></a> if you have any questions.</p>
+
+<p>Kind regards,<br/>
+  The Dryad Team</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,7 @@ Rails.application.routes.draw do
         post 'set_internal_datum'
         post 'add_internal_datum'
       end
+      resources :related_works, shallow: false, only: 'update'
       resources :internal_data, shallow: true, path: '/internal_data'
       resources :curation_activity, shallow: false, path: '/curation_activity'
 

--- a/lib/tasks/related_identifiers.rake
+++ b/lib/tasks/related_identifiers.rake
@@ -33,8 +33,8 @@ namespace :related_identifiers do
       stash_id = StashEngine::Identifier.where(identifier: row[0]).first
       res = stash_id.latest_resource
 
-      result1 = StashDatacite::RelatedIdentifier.upsert_simple_relation(doi: row[1], resource_id: res.id, work_type: 'preprint')
-      result2 = StashDatacite::RelatedIdentifier.upsert_simple_relation(doi: row[2], resource_id: res.id, work_type: 'primary_article')
+      StashDatacite::RelatedIdentifier.upsert_simple_relation(doi: row[1], resource_id: res.id, work_type: 'preprint')
+      StashDatacite::RelatedIdentifier.upsert_simple_relation(doi: row[2], resource_id: res.id, work_type: 'primary_article')
     end
     puts 'done'
   end

--- a/lib/tasks/related_identifiers.rake
+++ b/lib/tasks/related_identifiers.rake
@@ -1,4 +1,5 @@
 require_relative 'related_identifiers/replacements'
+require 'csv'
 
 namespace :related_identifiers do
 
@@ -12,5 +13,29 @@ namespace :related_identifiers do
     Tasks::RelatedIdentifiers::Replacements.update_protocol_free
     Tasks::RelatedIdentifiers::Replacements.update_non_ascii
     Tasks::RelatedIdentifiers::Replacements.remaining_strings_containing_dois
+  end
+
+  # not sure we'll ever see this format again, a one-off spreadsheet from Ted
+  desc 'An ephemeral csv from Ted with our doi, preprint doi and primary article doi'
+  task ted_preprint_csv: :environment do
+    unless ENV['RAILS_ENV']
+      puts 'RAILS_ENV must be explicitly set before running this script'
+      next
+    end
+
+    unless ARGV.length == 2
+      puts 'Please put the path to the file to process'
+      next
+    end
+    rows = CSV.read(ARGV[1])
+
+    rows.each do |row|
+      stash_id = StashEngine::Identifier.where(identifier: row[0]).first
+      res = stash_id.latest_resource
+
+      result1 = StashDatacite::RelatedIdentifier.upsert_simple_relation(doi: row[1], resource_id: res.id, work_type: 'preprint')
+      result2 = StashDatacite::RelatedIdentifier.upsert_simple_relation(doi: row[2], resource_id: res.id, work_type: 'primary_article')
+    end
+    puts 'done'
   end
 end

--- a/public/openapi.yml
+++ b/public/openapi.yml
@@ -481,6 +481,31 @@ paths:
               schema:
                 $ref: '#/components/schemas/processor_result'
 
+  '/datasets/{doi}/related_works/{related_doi}':
+    put:
+      security:
+        - bearerAuth: [ ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/related_type'
+      summary: Update related works for a dryad doi
+      tags:
+        - internal
+      description: Adds or updates related works for a dryad doi
+      parameters:
+        - $ref: '#/components/parameters/doi'
+        - $ref: '#/components/parameters/doi'
+      responses:
+        '200':
+          description: A json representation of related work that was saved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/relatedWork'
+
   # --- reports ---
   /reports:
     get:
@@ -907,7 +932,8 @@ components:
     relatedWork:
       properties:
         relationship:
-          type: string
+          format: string
+          enum: [ 'article', 'dataset', 'preprint', 'software', 'supplemental_information', 'primary_article', 'data_management_plan' ]
         identifierType:
           type: string
         identifier:
@@ -966,6 +992,13 @@ components:
           format: string
         domainName:
           format: string
+    related_type:
+      type: object
+      properties:
+        work_type:
+          format: string
+          enum: [ 'article', 'dataset', 'preprint', 'software', 'supplemental_information', 'primary_article', 'data_management_plan' ]
+          example: article
 
     # --- specific link section for different resources ---
 

--- a/spec/requests/stash_api/related_works_controller_spec.rb
+++ b/spec/requests/stash_api/related_works_controller_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+require 'uri'
+require_relative 'helpers'
+require 'fixtures/stash_api/metadata'
+require 'fixtures/stash_api/curation_metadata'
+require 'cgi'
+# see https://relishapp.com/rspec/rspec-rails/v/3-8/docs/request-specs/request-spec
+module StashApi
+  RSpec.describe RelatedWorksController, type: :request do
+
+    include Mocks::CurationActivity
+    include Mocks::Salesforce
+    include Mocks::Tenant
+
+    # there is all kinds of confusion and badness creating urls with DOIs using route helpers since they have slashes
+    # in them and not as path separators in the URL. This makes them be properly escaped.
+    def related_url(dataset_doi:, related_doi:)
+      "/api/v2/datasets/#{CGI.escape(dataset_doi)}/related_works/#{CGI.escape(related_doi)}"
+    end
+
+    before(:each) do
+      @user = create(:user, role: 'superuser')
+      @doorkeeper_application = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
+                                       owner_id: @user.id, owner_type: 'StashEngine::User')
+      setup_access_token(doorkeeper_application: @doorkeeper_application)
+
+      neuter_curation_callbacks!
+      mock_tenant!
+
+      @tenant_ids = StashEngine::Tenant.all.map(&:tenant_id)
+
+      @user1 = create(:user, tenant_id: @tenant_ids.first, role: 'user')
+
+      @identifier = create(:identifier)
+      @resource = create(:resource, user_id: @user1.id, tenant_id: @user1.tenant_id, identifier_id: @identifier.id)
+    end
+
+    describe '#update' do
+
+      it 'gives error if dataset doi does not exist' do
+        @path = related_url(dataset_doi: 'bad_doi', related_doi: 'doi:10.1184/6478826')
+
+        response_code = put @path,
+                            params: { work_type: 'article' }.to_json, # same as report2 json
+                            headers: default_authenticated_headers
+
+        expect(response_code).to eq(404)
+        expect(response_body_hash['error']).to include('not-found')
+      end
+
+      it 'gives error if related doi is not formatted correctly' do
+        @path = related_url(dataset_doi: @identifier.to_s, related_doi: 'bad_doi')
+
+        response_code = put @path,
+                            params: { work_type: 'article' }.to_json, # same as report2 json
+                            headers: default_authenticated_headers
+
+        expect(response_code).to eq(400)
+        expect(response_body_hash['error']).to include("related DOI isn't formatted correctly")
+      end
+
+      it 'gives error if work type is incorrect' do
+        @path = related_url(dataset_doi: @identifier.to_s, related_doi: 'doi:10.1184/6478826')
+
+        response_code = put @path,
+                            params: { work_type: 'catfood' }.to_json, # same as report2 json
+                            headers: default_authenticated_headers
+
+        expect(response_code).to eq(400)
+        expect(response_body_hash['error']).to include('work_type is invalid')
+      end
+
+      it 'updates the related work for the dataset' do
+        @path = related_url(dataset_doi: @identifier.to_s, related_doi: 'doi:10.1184/6478826')
+
+        response_code = put @path,
+                            params: { work_type: 'article' }.to_json, # same as report2 json
+                            headers: default_authenticated_headers
+
+        expect(response_code).to eq(200)
+        expect(response_body_hash).to eq({"relationship"=>"article", "identifierType"=>"DOI", "identifier"=>"https://doi.org/10.1184/6478826"})
+      end
+
+      it 'updates the curation activity to indicate update' do
+        @path = related_url(dataset_doi: @identifier.to_s, related_doi: 'doi:10.1184/6478826')
+
+        response_code = put @path,
+                            params: { work_type: 'article' }.to_json, # same as report2 json
+                            headers: default_authenticated_headers
+
+        expect(response_code).to eq(200)
+        last_cur = @resource.reload.last_curation_activity
+        expect(last_cur.note).to start_with('Related article added')
+        expect(last_cur.status).to eq(@resource.curation_activities.first.status)
+      end
+
+      it 'sends an email for this update' do
+        ActionMailer::Base.delivery_method = :smtp
+        @path = related_url(dataset_doi: @identifier.to_s, related_doi: 'doi:10.1184/6478826')
+
+        expect {
+          put @path,
+            params: { work_type: 'article' }.to_json, # same as report2 json
+            headers: default_authenticated_headers
+        }.to raise_error(Errno::ECONNREFUSED)
+
+        ActionMailer::Base.delivery_method = :test
+      end
+    end
+  end
+end

--- a/spec/requests/stash_api/related_works_controller_spec.rb
+++ b/spec/requests/stash_api/related_works_controller_spec.rb
@@ -21,7 +21,7 @@ module StashApi
     before(:each) do
       @user = create(:user, role: 'superuser')
       @doorkeeper_application = create(:doorkeeper_application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-                                       owner_id: @user.id, owner_type: 'StashEngine::User')
+                                                                owner_id: @user.id, owner_type: 'StashEngine::User')
       setup_access_token(doorkeeper_application: @doorkeeper_application)
 
       neuter_curation_callbacks!
@@ -78,7 +78,8 @@ module StashApi
                             headers: default_authenticated_headers
 
         expect(response_code).to eq(200)
-        expect(response_body_hash).to eq({"relationship"=>"article", "identifierType"=>"DOI", "identifier"=>"https://doi.org/10.1184/6478826"})
+        expect(response_body_hash).to eq({ 'relationship' => 'article', 'identifierType' => 'DOI',
+                                           'identifier' => 'https://doi.org/10.1184/6478826' })
       end
 
       it 'updates the curation activity to indicate update' do
@@ -98,11 +99,11 @@ module StashApi
         ActionMailer::Base.delivery_method = :smtp
         @path = related_url(dataset_doi: @identifier.to_s, related_doi: 'doi:10.1184/6478826')
 
-        expect {
+        expect do
           put @path,
-            params: { work_type: 'article' }.to_json, # same as report2 json
-            headers: default_authenticated_headers
-        }.to raise_error(Errno::ECONNREFUSED)
+              params: { work_type: 'article' }.to_json, # same as report2 json
+              headers: default_authenticated_headers
+        end.to raise_error(Errno::ECONNREFUSED)
 
         ActionMailer::Base.delivery_method = :test
       end


### PR DESCRIPTION
I believe https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2387 documents this in general, especially see the comment from Ryan about all the functionality required.

The tests document the URLs and how this works pretty well.  See `https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2387`.  The URL to use on the API is `"/api/v2/datasets/#{CGI.escape(dataset_doi)}/related_works/#{CGI.escape(related_doi)}"`.

The updating method will create or update and I believe there are tests for that, also.

Updated the swagger documentation, also.  Chose PUT rather than another REST method since I believe that adds or updates the full model which is what this does.
