### PR TITLE
Another query not to lose

### DIFF
--- a/documentation/sql_queries/uc_dois.md
+++ b/documentation/sql_queries/uc_dois.md
@@ -20,3 +20,24 @@ SELECT *
 	WHERE `identifier` NOT LIKE '10.5061%'
 	AND pub_state NOT IN ('published', 'embargoed', 'withdrawn');
 ```
+
+## Items not submitted to Merritt and over a year old
+
+This is helpful because we do not need to recreate these in DataCite, but there
+are only about 103 out of 750 unpublished right now.
+
+```mysql
+SELECT DISTINCT ids.* 
+	FROM `stash_engine_identifiers` ids
+		JOIN stash_engine_resources res
+			ON ids.id = res.identifier_id
+		JOIN (SELECT max(id) as res_id FROM stash_engine_resources GROUP BY identifier_id) last_res
+			ON res.id = last_res.res_id
+		JOIN stash_engine_versions ver
+			ON res.id = ver.resource_id
+		JOIN stash_engine_resource_states rs
+		   ON res.id = rs.resource_id
+   	WHERE ids.identifier NOT LIKE '10.5061%'
+		AND ids.pub_state NOT IN ('published', 'embargoed', 'withdrawn')
+		AND ver.version < 2 AND rs.resource_state <> 'submitted' AND ids.created_at < "2022-07-17";
+```


### PR DESCRIPTION
It tells us how many can be cleaned up because they seem abandoned (103) out of items that aren't published by UCs yet.  This is only a small number out of the 750 items minted but not used to set actual metadata on EZID yet.