### PR TITLE
remove automated DataCite counter runs until verification complete

### DIFF
--- a/cron/weekly.sh
+++ b/cron/weekly.sh
@@ -24,5 +24,7 @@ if [ "$RAILS_ENV" == "production" ] || [ "$RAILS_ENV" == "stage" ]
 then
     source ~/.profile.d/pyenv
     cd /apps/dryad/apps/ui/current/cron
-    ./counter.sh >> /apps/dryad/apps/ui/shared/cron/logs/counter.log 2>&1
+    # I am commenting out the counter runs for the next few weeks since we want a stable
+    # set of data (July 1-15) to upload to "the hub" for testing with Kristian at DataCite
+    # ./counter.sh >> /apps/dryad/apps/ui/shared/cron/logs/counter.log 2>&1
 fi


### PR DESCRIPTION
I would like to disable this on Sunday.  I hope before I leave on the 31st that I can un-disable this for the next release.  I'll start the counter stats generation for July 1-15th today.