### PR TITLE
2668 cleanup non submitted uc ezid datasets over a year old

### DIFF
--- a/lib/tasks/ezid_transition.rake
+++ b/lib/tasks/ezid_transition.rake
@@ -1,0 +1,25 @@
+
+namespace :ezid_transition do
+
+  # this will find ezid datasets over 1 year old that are not submitted and remove them, set RAILS_ENV=production
+  # for real removals from production
+  task remove_old_unsubmitted: :environment do
+
+    stash_ids = StashEngine::Identifier.where('created_at < ?', 1.year.ago).
+      where("identifier NOT LIKE '10.5061%'")
+
+    puts "Found #{stash_ids.count} identifiers over 1 year old from EZID shoulders"
+
+    count = 0
+    stash_ids.each do |stash_id|
+      next if stash_id.resources.count > 1 || stash_id.resources.first&.current_state == 'submitted'
+
+      count += 1
+      # verified that there is a model callback to remove S3 uploaded staging files before destroying
+      puts "Destroying identifier: #{stash_id.identifier}"
+      stash_id.destroy!
+    end
+
+    puts "Removed #{count} identifiers over 1 year old from EZID shoulders"
+  end
+end

--- a/lib/tasks/ezid_transition.rake
+++ b/lib/tasks/ezid_transition.rake
@@ -1,12 +1,11 @@
-
 namespace :ezid_transition do
 
   # this will find ezid datasets over 1 year old that are not submitted and remove them, set RAILS_ENV=production
   # for real removals from production
   task remove_old_unsubmitted: :environment do
 
-    stash_ids = StashEngine::Identifier.where('created_at < ?', 1.year.ago).
-      where("identifier NOT LIKE '10.5061%'")
+    stash_ids = StashEngine::Identifier.where('created_at < ?', 1.year.ago)
+      .where("identifier NOT LIKE '10.5061%'")
 
     puts "Found #{stash_ids.count} identifiers over 1 year old from EZID shoulders"
 


### PR DESCRIPTION
Can someone have a look at this task to be sure it seems reasonable?  It removes unsubmitted datasets over a year old.

I just want to double-check it before running I really run it.