### PR TITLE
2669 script to create lists of ezid registeredreserved items

### DIFF
--- a/lib/tasks/ezid_transition.rake
+++ b/lib/tasks/ezid_transition.rake
@@ -32,27 +32,24 @@ namespace :ezid_transition do
       csv << %w[identifier pub_state ezid_status]
       stash_ids = StashEngine::Identifier.where("identifier NOT LIKE '10.5061%' and identifier NOT LIKE '10.15146%'")
       stash_ids.each_with_index do |stash_id, idx|
-        begin
-          attempts ||= 1
-          resp = HTTP.accept('text/plain').timeout(15).get("https://ezid.cdlib.org/id/doi:#{stash_id.identifier}")
-          ezid_status = if resp.status == 200
-                          ezid_info = resp.body.to_s
-                          ezid_info.match(/^_status: (\S+)$/)[1]
-                        elsif resp.status == 400
-                          'not_found'
-                        end
 
-          puts "#{idx}/#{stash_ids.length} #{stash_id.identifier},#{stash_id.pub_state},#{ezid_status}"
-          csv << [stash_id.identifier, stash_id.pub_state, ezid_status]
-          sleep 0.5
-        rescue => e
-          if (attempts += 1) < 5
-            sleep 10
-            puts "  retrying #{stash_id.identifier} attempt #{attempts}"
-            retry # ⤴
-          end
-        ensure
-          attempts = 0
+        attempts ||= 1
+        resp = HTTP.accept('text/plain').timeout(15).get("https://ezid.cdlib.org/id/doi:#{stash_id.identifier}")
+        ezid_status = if resp.status == 200
+                        ezid_info = resp.body.to_s
+                        ezid_info.match(/^_status: (\S+)$/)[1]
+                      elsif resp.status == 400
+                        'not_found'
+                      end
+
+        puts "#{idx}/#{stash_ids.length} #{stash_id.identifier},#{stash_id.pub_state},#{ezid_status}"
+        csv << [stash_id.identifier, stash_id.pub_state, ezid_status]
+        sleep 0.5
+      rescue StandardError => e
+        if (attempts += 1) < 5
+          sleep 10
+          puts "  retrying #{stash_id.identifier} attempt #{attempts} with error #{e.message}"
+          retry # ⤴
         end
       end
     end

--- a/lib/tasks/ezid_transition.rake
+++ b/lib/tasks/ezid_transition.rake
@@ -1,11 +1,13 @@
+require 'csv'
 namespace :ezid_transition do
 
   # this will find ezid datasets over 1 year old that are not submitted and remove them, set RAILS_ENV=production
   # for real removals from production
+  desc 'Remove old unsubmitted datasets over a year old from EZID shoulders'
   task remove_old_unsubmitted: :environment do
 
     stash_ids = StashEngine::Identifier.where('created_at < ?', 1.year.ago)
-      .where("identifier NOT LIKE '10.5061%'")
+      .where("identifier NOT LIKE '10.5061%' and identifier NOT LIKE '10.15146%'")
 
     puts "Found #{stash_ids.count} identifiers over 1 year old from EZID shoulders"
 
@@ -20,5 +22,40 @@ namespace :ezid_transition do
     end
 
     puts "Removed #{count} identifiers over 1 year old from EZID shoulders"
+  end
+
+  # test id doi:10.6078/D1BB16
+  desc 'Makes csv of EZID status reserved/registered for all EZID identifiers'
+  task ezid_status: :environment do
+    filename = "ezid_dryad_identifiers_#{Time.now.iso8601}.csv"
+    CSV.open(filename, 'w') do |csv|
+      csv << %w[identifier pub_state ezid_status]
+      stash_ids = StashEngine::Identifier.where("identifier NOT LIKE '10.5061%' and identifier NOT LIKE '10.15146%'")
+      stash_ids.each_with_index do |stash_id, idx|
+        begin
+          attempts ||= 1
+          resp = HTTP.accept('text/plain').timeout(15).get("https://ezid.cdlib.org/id/doi:#{stash_id.identifier}")
+          ezid_status = if resp.status == 200
+                          ezid_info = resp.body.to_s
+                          ezid_info.match(/^_status: (\S+)$/)[1]
+                        elsif resp.status == 400
+                          'not_found'
+                        end
+
+          puts "#{idx}/#{stash_ids.length} #{stash_id.identifier},#{stash_id.pub_state},#{ezid_status}"
+          csv << [stash_id.identifier, stash_id.pub_state, ezid_status]
+          sleep 0.5
+        rescue => e
+          if (attempts += 1) < 5
+            sleep 10
+            puts "  retrying #{stash_id.identifier} attempt #{attempts}"
+            retry # ⤴
+          end
+        ensure
+          attempts = 0
+        end
+      end
+    end
+    puts "file written to #{filename}"
   end
 end


### PR DESCRIPTION
This rake task script creates a csv file of all the non-dryad DOIs with status and EZID status (reserved/public) for further work.

It sounds like Maria maybe would like us to register all the reserved ones with minimal placeholder metadata for ease of transferring later (meeting next week).