### PR TITLE
Remove webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,8 +132,6 @@ group :test do
   gem 'capybara'
   # Automatically create snapshots when Cucumber steps fail with Capybara and Rails (http://github.com/mattheworiordan/capybara-screenshot)
   gem 'capybara-screenshot'
-  # chromedriver-helper is now deprecated, use webdrivers instead
-  gem 'webdrivers', '~> 5.0', require: false
   # required for weird-ass rspec_custom_matchers that isn't in any actual gem/engine, but gets loaded in some weird circumstances
   gem 'diffy'
   # required for weird-ass rspec_custom_matchers that isn't in any actual gem/engine, but gets loaded in some weird circumstances
@@ -159,7 +157,7 @@ group :test do
   gem 'rspec-html'
 
   # The next generation developer focused tool for automated testing of webapps (https://github.com/SeleniumHQ/selenium)
-  gem 'selenium-webdriver'
+  gem 'selenium-webdriver', '~> 4.6'
   # Making tests easy on the fingers and eyes (https://github.com/thoughtbot/shoulda)
   gem 'shoulda'
   # Simple one-liner tests for common Rails functionality (https://github.com/thoughtbot/shoulda-matchers)

--- a/Gemfile
+++ b/Gemfile
@@ -157,7 +157,7 @@ group :test do
   gem 'rspec-html'
 
   # The next generation developer focused tool for automated testing of webapps (https://github.com/SeleniumHQ/selenium)
-  gem 'selenium-webdriver', '~> 4.6'
+  gem 'selenium-webdriver', '~> 4'
   # Making tests easy on the fingers and eyes (https://github.com/thoughtbot/shoulda)
   gem 'shoulda'
   # Simple one-liner tests for common Rails functionality (https://github.com/thoughtbot/shoulda-matchers)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -878,7 +878,7 @@ DEPENDENCIES
   rubocop (~> 1.38)
   rubyzip (~> 2.3, >= 2.3.2)
   sassc-rails (~> 2.1.2)
-  selenium-webdriver (~> 4.6)
+  selenium-webdriver (~> 4)
   serrano (~> 1.0)
   shoulda
   shoulda-matchers (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -757,10 +757,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -882,7 +878,7 @@ DEPENDENCIES
   rubocop (~> 1.38)
   rubyzip (~> 2.3, >= 2.3.2)
   sassc-rails (~> 2.1.2)
-  selenium-webdriver
+  selenium-webdriver (~> 4.6)
   serrano (~> 1.0)
   shoulda
   shoulda-matchers (~> 5.0)
@@ -903,7 +899,6 @@ DEPENDENCIES
   uc3-ssm!
   uglifier (~> 4.2.0)
   web-console
-  webdrivers (~> 5.0)
   webmock
   webpacker (~> 5.4.3)
   wicked_pdf (~> 2.1.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
-require 'webdrivers'
+require 'selenium-webdriver'
 
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,9 +7,7 @@ require_relative 'helpers/tinymce_helper'
 require_relative 'helpers/routes_helper'
 require_relative 'helpers/session_helper'
 require_relative 'helpers/webmock_helper'
-require 'webdrivers'
-
-Webdrivers::Chromedriver.update
+require 'selenium-webdriver'
 
 # make CAPY_SHOW environment variable set to see the browser doing its thing
 if ENV['CAPY_SHOW']
@@ -54,7 +52,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
     opts.args << '--disable-extensions'
     opts.args << '--disable-popup-blocking'
   end
-  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: browser_options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
For rspec running error:

```
An error occurred while loading rails_helper.
Failure/Error: Webdrivers::Chromedriver.update

Webdrivers::VersionError:
  Unable to find latest point release version for 115.0.5790. You appear to be using a non-production version of Chrome. Please set `Webdrivers::Chromedriver.required_version = <desired driver version>` to a known chromedriver version: https://chromedriver.storage.googleapis.com/index.html
```

See https://github.com/titusfortner/webdrivers/issues/247