### PR TITLE
Activity notes from PubUpdater are credited to the system, not the author

### DIFF
--- a/app/models/stash_engine/proposed_change.rb
+++ b/app/models/stash_engine/proposed_change.rb
@@ -40,7 +40,7 @@ module StashEngine
 
     def add_metadata_updated_curation_note(provenance, resource)
       resource.curation_activities << StashEngine::CurationActivity.new(
-        user_id: resource.last_curation_activity.user_id,
+        user_id: 0, # system user
         status: resource.current_curation_status,
         note: "#{provenance.capitalize} #{CROSSREF_UPDATE_MESSAGE}"
       )


### PR DESCRIPTION
When PubUpdater makes a change, the log entry should indicate the System user.