### PR TITLE
Fix issue with base rate calculation for tiered payments

### DIFF
--- a/documentation/reports.md
+++ b/documentation/reports.md
@@ -76,9 +76,10 @@ RAILS_ENV=production bundle exec rails identifiers:deferred_journal_reports SC_R
 For journals that have a tiered payment plan, a secondary task generates PDF
 reports that can be be sent to the journal sponsors. The secondary task takes as
 input a shopping_cart_report, as generated above, but it also needs a cumulative
-shopping_cart_report for prior quarters to calculate the "base rate". Both files
-should be quarterly reports to follow the current billing model. For the first
-quarter, the base report can be an empty file.
+shopping_cart_report for prior quarters, including the current quarter, to
+calculate the "base rate". Both files should be quarterly reports to follow the
+current billing model. For the first quarter, the base report can be an empty
+file.
 
 Run the tiered journal payment reports with a command like:
 ```

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -709,21 +709,21 @@ namespace :identifiers do
     base_values
   end
 
-  def tiered_price(current_count, base_count)
-    return nil unless current_count.is_a?(Integer) && base_count.is_a?(Integer)
+  # the tiered_price is based on the total number of datasets, including the current quarter
+  # current_count should be the number of datasets in the current quarter
+  # cumulative_count should be the total cumulative datasets, *including* the current quarter
+  def tiered_price(current_count, cumulative_count)
+    return nil unless current_count.is_a?(Integer) && cumulative_count.is_a?(Integer)
 
     free_datasets = 10
 
-    # the base_price is based on the total number of datasets, including the current quarter
-    total_datasets = current_count + base_count
-
-    base_price = if total_datasets <= free_datasets
+    base_price = if cumulative_count <= free_datasets
                    0
-                 elsif total_datasets <= 100
+                 elsif cumulative_count <= 100
                    135
-                 elsif total_datasets <= 250
+                 elsif cumulative_count <= 250
                    100
-                 elsif total_datasets <= 500
+                 elsif cumulative_count <= 500
                    85
                  else
                    55


### PR DESCRIPTION
The tiered payment plans have a "base rate" which should be set using the total cumulative submissions *including* the current quarter. This updates the documentation around the calculation and updates the `tiered_price` method, which had previously assumed that the current quarter was not included.