### PR TITLE
Initialize Zenodo error classes

### DIFF
--- a/lib/stash/zenodo_replicate/retry_error.rb
+++ b/lib/stash/zenodo_replicate/retry_error.rb
@@ -1,0 +1,5 @@
+module Stash
+  module ZenodoReplicate
+    class RetryError < StandardError; end
+  end
+end

--- a/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -4,10 +4,6 @@ require 'stash/download'
 
 module Stash
   module ZenodoReplicate
-
-    class ZenodoError < StandardError; end
-    class RetryError < StandardError; end
-
     module ZenodoConnection
 
       SLEEP_TIME = 15

--- a/lib/stash/zenodo_replicate/zenodo_error.rb
+++ b/lib/stash/zenodo_replicate/zenodo_error.rb
@@ -1,0 +1,5 @@
+module Stash
+  module ZenodoReplicate
+    class ZenodoError < StandardError; end
+  end
+end


### PR DESCRIPTION
Fix issue with Zenodo uninitialized constants

(cherry picked from commit 1c5d9da6678079ce1194a46ef8e27ca225af1371)