### PR TITLE
Correct curation stats counting

### DIFF
--- a/app/models/stash_engine/curation_stats.rb
+++ b/app/models/stash_engine/curation_stats.rb
@@ -91,11 +91,14 @@ module StashEngine
       # for each dataset that received the target status on the given day
       cas = CurationActivity.where(created_at: date..(date + 1.day), status: %w[submitted])
       cas.each do |ca|
-        # include this dataset unless it has a previous resource that had been submitted
         this_resource = ca.resource
         found_dataset = this_resource&.identifier
         next unless found_dataset
 
+        # skip if the dataset was not first submitted on this date
+        next unless found_dataset.first_submitted_resource.submitted_date.to_date == date
+
+        # include this dataset unless it has a previous resource that had been submitted
         prev_resources = this_resource.identifier.resources.where(id: 0..this_resource.id - 1)
         prev_resources.each do |pr|
           found_dataset = nil if pr.submitted_date

--- a/app/models/stash_engine/curation_stats.rb
+++ b/app/models/stash_engine/curation_stats.rb
@@ -96,7 +96,7 @@ module StashEngine
         next unless found_dataset
 
         # skip if the dataset was not first submitted on this date
-        next unless found_dataset.first_submitted_resource.submitted_date.to_date == date
+        next unless found_dataset.first_submitted_resource&.submitted_date&.to_date == date
 
         # include this dataset unless it has a previous resource that had been submitted
         prev_resources = this_resource.identifier.resources.where(id: 0..this_resource.id - 1)

--- a/app/models/stash_engine/curation_stats.rb
+++ b/app/models/stash_engine/curation_stats.rb
@@ -116,7 +116,7 @@ module StashEngine
       cas = CurationActivity.where(created_at: date..(date + 1.day), status: %w[peer_review])
       cas.each do |ca|
         this_resource = ca.resource
-        found_dataset = this_resource.identifier
+        found_dataset = this_resource&.identifier
         next unless found_dataset
 
         # skip if the dataset was not first submitted on this date

--- a/app/models/stash_engine/curation_stats.rb
+++ b/app/models/stash_engine/curation_stats.rb
@@ -115,15 +115,14 @@ module StashEngine
       # for each dataset that received the target status on the given day
       cas = CurationActivity.where(created_at: date..(date + 1.day), status: %w[peer_review])
       cas.each do |ca|
-        prev_ca = CurationActivity.where(resource_id: ca.resource_id, id: 0..ca.id - 1).last
-        # don't count reminder statuses or other minor updates
-        next if prev_ca&.peer_review? || ca.note&.include?('peer_review_reminder') || ca.note&.include?('notification sent to author')
+        this_resource = ca.resource
+        found_dataset = this_resource.identifier
+        next unless found_dataset
+
+        # skip if the dataset was not first submitted on this date
+        next unless found_dataset.first_submitted_resource&.submitted_date&.to_date == date
 
         # include this dataset unless it has a previous resource that had been submitted
-        this_resource = ca.resource
-        next unless this_resource
-
-        found_dataset = this_resource.identifier
         prev_resources = this_resource.identifier.resources.where(id: 0..this_resource.id - 1)
         prev_resources.each do |pr|
           found_dataset = nil if pr.submitted_date
@@ -232,6 +231,9 @@ module StashEngine
       # for each dataset that received the target status on the given day
       cas = CurationActivity.where(created_at: date..(date + 1.day), status: 'submitted')
       cas.each do |ca|
+        # check if this was the actual date of submission for this resource
+        next unless ca.resource.curation_activities.where(status: 'submitted')&.first&.created_at&.between?(date, date + 1.day)
+
         # if this dataset has been published or embargoed, count it
         ident = ca.resource&.identifier
         next unless ident

--- a/app/models/stash_engine/curation_stats.rb
+++ b/app/models/stash_engine/curation_stats.rb
@@ -232,7 +232,7 @@ module StashEngine
       cas = CurationActivity.where(created_at: date..(date + 1.day), status: 'submitted')
       cas.each do |ca|
         # check if this was the actual date of submission for this resource
-        next unless ca.resource.curation_activities.where(status: 'submitted')&.first&.created_at&.between?(date, date + 1.day)
+        next unless ca.resource.curation_activities.where(status: 'submitted')&.first&.created_at&.to_date&.between?(date, date + 1.day)
 
         # if this dataset has been published or embargoed, count it
         ident = ca.resource&.identifier

--- a/spec/models/stash_engine/curation_stats_spec.rb
+++ b/spec/models/stash_engine/curation_stats_spec.rb
@@ -222,11 +222,13 @@ module StashEngine
         expect(stats.new_datasets_to_peer_review).to eq(0)
 
         # YES -- move into peer_review
+        @res[1].resource_states.first.update(resource_state: 'submitted')
         @res[1].curation_activities << CurationActivity.create(status: 'peer_review', user: @user, created_at: @day)
         stats.recalculate
         expect(stats.new_datasets_to_peer_review).to eq(1)
 
         # YES -- move into published
+        @res[2].resource_states.first.update(resource_state: 'submitted')
         @res[2].curation_activities << CurationActivity.create(status: 'peer_review', user: @user, created_at: @day)
         @res[2].curation_activities << CurationActivity.create(status: 'curation', user: @curator, created_at: @day)
         @res[2].curation_activities << CurationActivity.create(status: 'published', user: @curator, created_at: @day)
@@ -234,6 +236,7 @@ module StashEngine
         expect(stats.new_datasets_to_peer_review).to eq(2)
 
         # NO -- was submitted previously
+        @res[3].resource_states.first.update(resource_state: 'submitted')
         @res[3].curation_activities << CurationActivity.create(status: 'peer_review', user: @user, created_at: @day - 2.days)
         stats.recalculate
         expect(stats.new_datasets_to_peer_review).to eq(2)
@@ -241,8 +244,10 @@ module StashEngine
         # YES -- but this dataset has two resources, and only one should count
         id_new = create(:identifier, identifier_type: 'DOI', identifier: '10.123/two_resource_ident_prev_submission')
         res_new = create(:resource, identifier_id: id_new.id, user: @user, tenant_id: 'dryad')
+        res_new.resource_states.first.update(resource_state: 'submitted')
         res_new.curation_activities << CurationActivity.create(status: 'peer_review', user: @user, created_at: @day)
         res_new2 = create(:resource, identifier_id: id_new.id, user: @user, tenant_id: 'dryad')
+        res_new2.resource_states.first.update(resource_state: 'submitted')
         res_new2.curation_activities << CurationActivity.create(status: 'peer_review', user: @user, created_at: @day)
         stats.recalculate
         expect(stats.new_datasets_to_peer_review).to eq(3)
@@ -250,13 +255,16 @@ module StashEngine
         # NO -- this dataset has two resources, and the first was submitted before the target day
         id_new2 = create(:identifier, identifier_type: 'DOI', identifier: '10.123/two_resource_ident_prev_submission')
         res_new3 = create(:resource, identifier_id: id_new2.id, user: @user, tenant_id: 'dryad')
+        res_new3.resource_states.first.update(resource_state: 'submitted')
         res_new3.curation_activities << CurationActivity.create(status: 'peer_review', user: @user, created_at: @day - 2.days)
         res_new4 = create(:resource, identifier_id: id_new2.id, user: @user, tenant_id: 'dryad')
+        res_new4.resource_states.first.update(resource_state: 'submitted')
         res_new4.curation_activities << CurationActivity.create(status: 'peer_review', user: @user, created_at: @day)
         stats.recalculate
         expect(stats.new_datasets_to_peer_review).to eq(3)
 
         # YES -- goes through 'submitted' before 'peer_review
+        @res[4].resource_states.first.update(resource_state: 'submitted')
         @res[4].curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: @day)
         @res[4].curation_activities << CurationActivity.create(status: 'peer_review', user: @user, created_at: @day)
         stats.recalculate

--- a/spec/models/stash_engine/curation_stats_spec.rb
+++ b/spec/models/stash_engine/curation_stats_spec.rb
@@ -37,8 +37,8 @@ module StashEngine
       end
 
       @day = Date.today
-      @day1 = @day + 1.day + 1.second
-      @day2 = @day + 2.days + 1.second
+      @day1 = @day + 1.day
+      @day2 = @day + 2.days
     end
 
     describe :status_on_date do
@@ -60,8 +60,8 @@ module StashEngine
       end
 
       it 'finds an intermediate status' do
-        @res.first.curation_activities << CurationActivity.create(status: 'curation', user: @curator, created_at: @day1)
-        @res.first.curation_activities << CurationActivity.create(status: 'published', user: @curator, created_at: @day2)
+        @res.first.curation_activities << CurationActivity.create(status: 'curation', user: @curator, created_at: @day1 + 1.second)
+        @res.first.curation_activities << CurationActivity.create(status: 'published', user: @curator, created_at: @day2 + 1.second)
         stats = CurationStats.create(date: @day + 1.day)
         expect(stats.status_on_date(@idents.first)).to eq('curation')
       end
@@ -73,8 +73,8 @@ module StashEngine
         # NO -- move into curation, but not out
         @res[1].curation_activities << CurationActivity.create(status: 'curation', user: @curator, created_at: @day)
         # NO -- move into published, but on day1
-        @res[2].curation_activities << CurationActivity.create(status: 'curation', user: @curator, created_at: @day1)
-        @res[2].curation_activities << CurationActivity.create(status: 'published', user: @curator, created_at: @day1)
+        @res[2].curation_activities << CurationActivity.create(status: 'curation', user: @curator, created_at: @day1 + 1.second)
+        @res[2].curation_activities << CurationActivity.create(status: 'published', user: @curator, created_at: @day1 + 2.seconds)
         stats = CurationStats.create(date: @day)
         expect(stats.datasets_curated).to eq(0)
       end
@@ -152,26 +152,29 @@ module StashEngine
       end
 
       it 'counts correctly when there are some' do
-        stats = CurationStats.create(date: @day)
+        stats = CurationStats.create(date: @day1)
 
         # NO -- move into curation, but not actually submitted
-        @res[0].curation_activities << CurationActivity.create(status: 'curation', user: @curator, created_at: @day)
+        @res[0].curation_activities << CurationActivity.create(status: 'curation', user: @curator, created_at: @day1)
         stats.recalculate
         expect(stats.new_datasets_to_submitted).to eq(0)
 
         # YES -- move into submitted
-        @res[1].curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: @day)
+        @res[1].resource_states.first.update(resource_state: 'submitted')
+        @res[1].curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: @day1)
         stats.recalculate
         expect(stats.new_datasets_to_submitted).to eq(1)
 
         # YES -- move into published
-        @res[2].curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: @day)
-        @res[2].curation_activities << CurationActivity.create(status: 'curation', user: @curator, created_at: @day)
-        @res[2].curation_activities << CurationActivity.create(status: 'published', user: @curator, created_at: @day)
+        @res[2].resource_states.first.update(resource_state: 'submitted')
+        @res[2].curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: @day1)
+        @res[2].curation_activities << CurationActivity.create(status: 'curation', user: @curator, created_at: @day1)
+        @res[2].curation_activities << CurationActivity.create(status: 'published', user: @curator, created_at: @day1)
         stats.recalculate
         expect(stats.new_datasets_to_submitted).to eq(2)
 
         # NO -- was submitted previously
+        @res[3].resource_states.first.update(resource_state: 'submitted')
         @res[3].curation_activities << CurationActivity.create(status: 'submitted', user: @user, created_at: @day - 2.days)
         stats.recalculate
         expect(stats.new_datasets_to_submitted).to eq(2)
@@ -179,21 +182,24 @@ module StashEngine
         # YES -- but there are two resources, and only one should count
         id_new = create(:identifier, identifier_type: 'DOI', identifier: '10.123/two_resource_ident')
         res_new = create(:resource, identifier_id: id_new.id, user: @user, tenant_id: 'dryad')
-        res_new.curation_activities << CurationActivity.create(status: 'submitted', user: @curator, created_at: @day)
+        res_new.resource_states.first.update(resource_state: 'submitted')
+        res_new.curation_activities << CurationActivity.create(status: 'submitted', user: @curator, created_at: @day1)
         res_new2 = create(:resource, identifier_id: id_new.id, user: @user, tenant_id: 'dryad')
-        res_new2.curation_activities << CurationActivity.create(status: 'submitted', user: @curator, created_at: @day)
+        res_new2.resource_states.first.update(resource_state: 'submitted')
+        res_new2.curation_activities << CurationActivity.create(status: 'submitted', user: @curator, created_at: @day1)
         stats.recalculate
         expect(stats.new_datasets_to_submitted).to eq(3)
 
         # NO -- there are two resources, and the first was submitted before the target day
         id_new2 = create(:identifier, identifier_type: 'DOI', identifier: '10.123/two_resource_ident_prev_submission')
         res_new3 = create(:resource, identifier_id: id_new2.id, user: @user, tenant_id: 'dryad')
-        res_new3.curation_activities << CurationActivity.create(status: 'submitted', user: @curator, created_at: @day - 2.days)
+        res_new3.resource_states.first.update(resource_state: 'submitted')
+        res_new3.curation_activities << CurationActivity.create(status: 'submitted', user: @curator, created_at: @day1 - 2.days)
         res_new4 = create(:resource, identifier_id: id_new2.id, user: @user, tenant_id: 'dryad')
-        res_new4.curation_activities << CurationActivity.create(status: 'submitted', user: @curator, created_at: @day)
+        res_new4.resource_states.first.update(resource_state: 'submitted')
+        res_new4.curation_activities << CurationActivity.create(status: 'submitted', user: @curator, created_at: @day1)
         stats.recalculate
         expect(stats.new_datasets_to_submitted).to eq(3)
-
       end
     end
 


### PR DESCRIPTION
Only count a dataset as submitted on a particular date if the submitted_date matches. This avoids erroneous counting for datasets like doi:10.5061/dryad.m63xsj47f, where the dataset was submitted on one date, but had some non-versioning activity that added new `submitted` statuses on another date.
