### PR TITLE
Upgrade to self-managing selenium-webdriver gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,8 +95,10 @@ gem 'omniauth-orcid', '~> 2.1', '>= 2.1.1'
 gem 'omniauth-rails_csrf_protection', '~> 1.0.1'
 gem 'omniauth-shibboleth', '~> 1.3.0'
 gem 'posix-spawn', '~> 0.3.15'
+gem 'pundit', '~> 2.3'
 gem 'rack-attack'
 gem 'rb-readline', require: false
+gem 'recaptcha', '~> 5.14'
 gem 'redcarpet', '~> 3.5.1'  # I'm not sure we're still using markdown for others to create documents
 gem 'responders', '~> 3.0.1' # do we use this?
 gem 'rest-client', '~> 2.1.0' # yet another http gem, not sure it's used
@@ -159,7 +161,7 @@ group :test do
   gem 'rspec-html'
 
   # The next generation developer focused tool for automated testing of webapps (https://github.com/SeleniumHQ/selenium)
-  gem 'selenium-webdriver', '~> 4'
+  gem 'selenium-webdriver', '~> 4.11'
   # Making tests easy on the fingers and eyes (https://github.com/thoughtbot/shoulda)
   gem 'shoulda'
   # Simple one-liner tests for common Rails functionality (https://github.com/thoughtbot/shoulda-matchers)
@@ -184,7 +186,3 @@ group :development, :test, :local_dev do
   # rspec command for spring (https://github.com/jonleighton/spring-commands-rspec)
   gem 'spring-commands-rspec'
 end
-
-gem 'pundit', '~> 2.3'
-
-gem 'recaptcha', '~> 5.14'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -668,7 +668,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -880,7 +880,7 @@ DEPENDENCIES
   rubocop (~> 1.38)
   rubyzip (~> 2.3, >= 2.3.2)
   sassc-rails (~> 2.1.2)
-  selenium-webdriver (~> 4)
+  selenium-webdriver (~> 4.11)
   serrano (~> 1.0)
   shoulda
   shoulda-matchers (~> 5.0)


### PR DESCRIPTION
Needed so tests will run; otherwise there are Chrome driver errors

```
Selenium::WebDriver::Error::SessionNotCreatedError:
              session not created: This version of ChromeDriver only supports Chrome version 114
              Current browser version is 116.0.5845.96 with binary path /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
```

Looked at managing driver versions with webdrivers gem again and got this message:

```
Post-install message from webdrivers:
Webdrivers gem update options

Selenium itself now manages drivers by default: https://www.selenium.dev/documentation/selenium_manager
* If you are using Ruby 3+ — please update to Selenium 4.11+ and stop requiring this gem
```

selenium-webdriver 4.11+ seems to do the trick (see https://www.selenium.dev/documentation/selenium_manager)