### PR TITLE
Give update choices for pub updater (preprint, primary article, related article)

### DIFF
--- a/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/app/controllers/stash_engine/publication_updater_controller.rb
@@ -63,11 +63,12 @@ module StashEngine
     # rubocop:enable Metrics/AbcSize
 
     def update
+      byebug
       respond_to do |format|
         @proposed_change = authorize StashEngine::ProposedChange.find(params[:id])
         @resource = @proposed_change.identifier&.latest_resource if @proposed_change.present?
-        @proposed_change.approve!(current_user: current_user)
-        @proposed_change.reload
+        # @proposed_change.approve!(current_user: current_user)
+        # @proposed_change.reload
         format.js
       end
     end

--- a/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/app/controllers/stash_engine/publication_updater_controller.rb
@@ -63,12 +63,11 @@ module StashEngine
     # rubocop:enable Metrics/AbcSize
 
     def update
-      byebug
       respond_to do |format|
         @proposed_change = authorize StashEngine::ProposedChange.find(params[:id])
         @resource = @proposed_change.identifier&.latest_resource if @proposed_change.present?
-        # @proposed_change.approve!(current_user: current_user)
-        # @proposed_change.reload
+        @proposed_change.approve!(current_user: current_user, approve_type: params['stash_engine_proposed_change']['related_type'])
+        @proposed_change.reload
         format.js
       end
     end

--- a/app/models/stash_engine/proposed_change.rb
+++ b/app/models/stash_engine/proposed_change.rb
@@ -18,11 +18,20 @@ module StashEngine
         other.publication_name == publication_name && other.title == title
     end
 
-    def approve!(current_user:)
+    def approve!(current_user:, approve_type: )
+      # values are primary, primary_no_metadata, preprint, preprint_no_metadata, related, related_no_metadata
+      dropdown_to_type = {primary: 'primary_article', related: 'article', preprint: 'preprint'}.with_indifferent_access
+
+      bare_approve_type = approve_type.to_s.gsub('_no_metadata', '')
+      return false if dropdown_to_type[bare_approve_type].blank?
+
+      article_type = dropdown_to_type[bare_approve_type]
+      update_type = ( approve_type.to_s.end_with?('_no_metadata') ? 'relationship' : 'metadata' )
+
       return false if current_user.blank? || !current_user.is_a?(StashEngine::User)
 
       cr = Stash::Import::Crossref.from_proposed_change(proposed_change: self)
-      resource = cr.populate_pub_update!
+      resource = cr.populate_pub_update!(article_type: article_type, update_type: update_type)
 
       add_metadata_updated_curation_note(cr.class.name.downcase.split('::').last, resource)
       update(approved: true, user_id: current_user.id)

--- a/app/models/stash_engine/proposed_change.rb
+++ b/app/models/stash_engine/proposed_change.rb
@@ -18,15 +18,15 @@ module StashEngine
         other.publication_name == publication_name && other.title == title
     end
 
-    def approve!(current_user:, approve_type: )
+    def approve!(current_user:, approve_type:)
       # values are primary, primary_no_metadata, preprint, preprint_no_metadata, related, related_no_metadata
-      dropdown_to_type = {primary: 'primary_article', related: 'article', preprint: 'preprint'}.with_indifferent_access
+      dropdown_to_type = { primary: 'primary_article', related: 'article', preprint: 'preprint' }.with_indifferent_access
 
       bare_approve_type = approve_type.to_s.gsub('_no_metadata', '')
       return false if dropdown_to_type[bare_approve_type].blank?
 
       article_type = dropdown_to_type[bare_approve_type]
-      update_type = ( approve_type.to_s.end_with?('_no_metadata') ? 'relationship' : 'metadata' )
+      update_type = (approve_type.to_s.end_with?('_no_metadata') ? 'relationship' : 'metadata')
 
       return false if current_user.blank? || !current_user.is_a?(StashEngine::User)
 

--- a/app/views/stash_engine/publication_updater/_proposed_metadata.html.erb
+++ b/app/views/stash_engine/publication_updater/_proposed_metadata.html.erb
@@ -6,8 +6,19 @@
   <strong>Changes</strong>
   <% url = "#{stash_url_helpers.publication_updater_path}/#{proposed_change.id}" %>
   <%= form_with model: StashEngine::ProposedChange.new, url: url, method: :PUT, local: false do |f| %>
-    <button name="accept_changes" type="submit">Accept</button>
+    <button name="accept_changes" type="submit">Accept as</button>
+    <%= f.select :related_type, options_for_select(
+        [
+            ['Primary w/ metadata', 'primary'],
+            ['Primary w/o metadata', 'primary_no_metadata'],
+            ['Preprint w/ metadata', 'preprint'],
+            ['Preprint w/o metadata', 'preprint_no_metadata'],
+            ['Related w/ metadata', 'related'],
+            ['Related w/o metadata', 'related_no_metadata']
+        ]
+    ) %>
   <% end %>
+  <hr/>
   <%= form_with model: StashEngine::ProposedChange.new, url: url, method: :DELETE, local: false do |f| %>
      <button name="reject_changes" type="submit">Reject</button>
     <% end %>

--- a/app/views/stash_engine/publication_updater/_proposed_metadata.html.erb
+++ b/app/views/stash_engine/publication_updater/_proposed_metadata.html.erb
@@ -1,6 +1,7 @@
 <td>
   <strong>Publication:</strong>
-  <%= link_to proposed_change.title, proposed_change.url, target: '_blank' %>
+  <%= link_to proposed_change.title, proposed_change.url, target: '_blank' %><br/>
+  type: <%= proposed_change.xref_type %><br/>
 </td>
 <td class="c-proposed-change-table__column-centered">
   <strong>Changes</strong>

--- a/app/views/stash_engine/publication_updater/index.html.erb
+++ b/app/views/stash_engine/publication_updater/index.html.erb
@@ -9,6 +9,12 @@
   <p>The first row in a group represents the existing information we have for the dataset. The second row of tthe group represents the proposed changes (highlighted in blue). Clicking the <em>'Accept'</em> button will transfer the proposed changes in 'blue' to the dataset. Clicking <em>'Reject'</em> will cancel the proposed changes</p>
   <p>The publication updater will try to match a dataset's publication DOI (if available). If Crossref finds a match for the DOI then the 'Scores' column will display `1 (DOI match)`. In the event that no publication DOI was available, the publication updater will then send the dataset's title and authors to Crossref. In this situation, the 'Scores' column will display Crossref's scoring of the closest match it found (in parenthesis) and the publication updater's internal score that is based on matching against the title and author list returned by Crossref</p>
 
+  <p>Three related work types are now available to select for the update: primary (article), related (article), preprint (article).</p>
+
+  <p>If you select to update with metadata then the items that update are: the issn, publication name, subjects and related identifier</p>
+
+  <p>Selecting to update without (w/o) metadata means only the related identifier is updated and the other items are left as is in the dataset.</p>
+
   <%= form_with url: stash_url_helpers.publication_updater_path, method: :get do |form| %>
     <h2 class="o-heading__level2">Limit to</h2>
 

--- a/db/migrate/20230818233307_add_type_to_stash_engine_proposed_changes.rb
+++ b/db/migrate/20230818233307_add_type_to_stash_engine_proposed_changes.rb
@@ -1,0 +1,5 @@
+class AddTypeToStashEngineProposedChanges < ActiveRecord::Migration[6.1]
+  def change
+    add_column :stash_engine_proposed_changes, :xref_type, :string
+  end
+end

--- a/lib/stash/import/crossref.rb
+++ b/lib/stash/import/crossref.rb
@@ -297,7 +297,7 @@ module Stash
         end
       end
 
-      # rubocop:disable Naminng/AccessorMethodName
+      # rubocop:disable Naming/AccessorMethodName
       def get_or_new_related_doi
         my_related = @sm['URL'] || @sm['DOI']
         return nil if my_related.blank?
@@ -307,9 +307,8 @@ module Stash
           .where(related_identifier: StashDatacite::RelatedIdentifier.standardize_doi(my_related),
                  related_identifier_type: 'doi').first || @resource.related_identifiers.new
       end
-      # rubocop:enable Naminng/AccessorMethodName
+      # rubocop:enable Naming/AccessorMethodName
 
-      # article type should be
       def populate_article_type(article_type:)
         return unless article_type.present? && %w[primary_article article preprint].include?(article_type)
 

--- a/lib/stash/import/crossref.rb
+++ b/lib/stash/import/crossref.rb
@@ -297,15 +297,17 @@ module Stash
         end
       end
 
+      # rubocop:disable Naminng/AccessorMethodName
       def get_or_new_related_doi
         my_related = @sm['URL'] || @sm['DOI']
         return nil if my_related.blank?
 
         # Use the URL if available otherwise just use the DOI
-        related = @resource.related_identifiers
-                           .where(related_identifier: StashDatacite::RelatedIdentifier.standardize_doi(my_related),
-                                  related_identifier_type: 'doi').first || @resource.related_identifiers.new
+        @resource.related_identifiers
+          .where(related_identifier: StashDatacite::RelatedIdentifier.standardize_doi(my_related),
+                 related_identifier_type: 'doi').first || @resource.related_identifiers.new
       end
+      # rubocop:enable Naminng/AccessorMethodName
 
       # article type should be
       def populate_article_type(article_type:)
@@ -314,8 +316,6 @@ module Stash
         related = get_or_new_related_doi
         my_related = @sm['URL'] || @sm['DOI']
         return if related.nil? || my_related.nil?
-
-        byebug
 
         related.assign_attributes({
                                     related_identifier: StashDatacite::RelatedIdentifier.standardize_doi(my_related),

--- a/lib/stash/import/crossref.rb
+++ b/lib/stash/import/crossref.rb
@@ -110,6 +110,7 @@ module Stash
         # Skip if the identifier already has proposed changes
         return unless StashEngine::ProposedChange.where(identifier_id: @resource.identifier.id).empty?
 
+        # need to add a 'type' that maybe tells if it's a journal article or something else
         params = {
           identifier_id: @resource.identifier.id,
           approved: false,
@@ -124,7 +125,8 @@ module Stash
           provenance_score: @sm['provenance_score'],
           title: @sm['title']&.first&.to_s,
           url: @sm['URL'],
-          subjects: @sm['subject'].to_json
+          subjects: @sm['subject'].to_json,
+          xref_type: @sm['type']
         }
         pc = StashEngine::ProposedChange.new(params)
         resource_will_change?(proposed_change: pc) ? pc : nil

--- a/spec/lib/stash_datacite/crossref_spec.rb
+++ b/spec/lib/stash_datacite/crossref_spec.rb
@@ -273,7 +273,7 @@ module Stash
         end
 
         it 'takes the DOI URL for the article and turns it into cites for this dataset' do
-          @cr.send(:populate_article_type, { article_type: 'primary_article' })
+          @cr.send(:populate_article_type, article_type: 'primary_article')
           expect(@resource.related_identifiers.any?).to eql(true)
           expect(@resource.related_identifiers.first.related_identifier).to \
             eql(StashDatacite::RelatedIdentifier.standardize_doi(URL))
@@ -281,7 +281,7 @@ module Stash
 
         it 'ignores blank URLs' do
           @cr = Crossref.new(resource: @resource, crossref_json: { 'URL' => '' })
-          resp = @cr.send(:populate_article_type, { article_type: 'primary_article' })
+          resp = @cr.send(:populate_article_type, article_type: 'primary_article')
           expect(resp).to eql(nil)
           expect(@resource.related_identifiers.length).to eql(0)
         end

--- a/spec/lib/stash_datacite/crossref_spec.rb
+++ b/spec/lib/stash_datacite/crossref_spec.rb
@@ -267,13 +267,13 @@ module Stash
         end
       end
 
-      describe '#populate_related_doi' do
+      describe '#populate_article_type' do
         before(:each) do
           @cr = Crossref.new(resource: @resource, crossref_json: { 'URL' => URL })
         end
 
         it 'takes the DOI URL for the article and turns it into cites for this dataset' do
-          @cr.send(:populate_related_doi)
+          @cr.send(:populate_article_type, {article_type: 'primary_article'})
           expect(@resource.related_identifiers.any?).to eql(true)
           expect(@resource.related_identifiers.first.related_identifier).to \
             eql(StashDatacite::RelatedIdentifier.standardize_doi(URL))
@@ -281,7 +281,7 @@ module Stash
 
         it 'ignores blank URLs' do
           @cr = Crossref.new(resource: @resource, crossref_json: { 'URL' => '' })
-          resp = @cr.send(:populate_related_doi)
+          resp = @cr.send(:populate_article_type, {article_type: 'primary_article'})
           expect(resp).to eql(nil)
           expect(@resource.related_identifiers.length).to eql(0)
         end

--- a/spec/lib/stash_datacite/crossref_spec.rb
+++ b/spec/lib/stash_datacite/crossref_spec.rb
@@ -273,7 +273,7 @@ module Stash
         end
 
         it 'takes the DOI URL for the article and turns it into cites for this dataset' do
-          @cr.send(:populate_article_type, {article_type: 'primary_article'})
+          @cr.send(:populate_article_type, { article_type: 'primary_article' })
           expect(@resource.related_identifiers.any?).to eql(true)
           expect(@resource.related_identifiers.first.related_identifier).to \
             eql(StashDatacite::RelatedIdentifier.standardize_doi(URL))
@@ -281,7 +281,7 @@ module Stash
 
         it 'ignores blank URLs' do
           @cr = Crossref.new(resource: @resource, crossref_json: { 'URL' => '' })
-          resp = @cr.send(:populate_article_type, {article_type: 'primary_article'})
+          resp = @cr.send(:populate_article_type, { article_type: 'primary_article' })
           expect(resp).to eql(nil)
           expect(@resource.related_identifiers.length).to eql(0)
         end

--- a/spec/models/stash_engine/proposed_change_spec.rb
+++ b/spec/models/stash_engine/proposed_change_spec.rb
@@ -90,7 +90,7 @@ module StashEngine
     describe :approve! do
       it 'approves the changes' do
         old_title = @resource.title
-        @proposed_change.approve!(current_user: @user)
+        @proposed_change.approve!(current_user: @user, approve_type: 'primary')
         @resource.reload
 
         expect(@resource.title).to eql(old_title)
@@ -105,8 +105,8 @@ module StashEngine
       end
 
       it 'does not approve the changes if no user is specified' do
-        expect(@proposed_change.approve!(current_user: nil)).to eql(false)
-        expect(@proposed_change.approve!(current_user: 'John Doe')).to eql(false)
+        expect(@proposed_change.approve!(current_user: nil, approve_type: 'primary')).to eql(false)
+        expect(@proposed_change.approve!(current_user: 'John Doe', approve_type: 'primary')).to eql(false)
       end
     end
 


### PR DESCRIPTION
See comments on https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2667 .

This is easier to test against our development environment since there are already some crossref items populated into `stash_engine_proposed_changes`.  You can also reset items in that table by setting `approved` and `rejected` both to 0 and it will show up in the pub updater again.

- Add `xref_type` to the database and populates it from xref for newly processed items.
- This may be a hint at the type of work, for instance a preprint shows `posted-content` sometimes for a preprint (?)
- Now gives 3 options for acceptance type: primary (article), related (article) and preprint.  All three have the choice of updating with or without the metadata.
  - With the metadata it does as before (updates the issn, publication name, subjects and related identifier)
  - without metadata it only updates the related identifier relationship

I'll add another PR for the other related ticket about other, more minor things to change about the publication updater.


 