### PR TITLE
Addresses publication updater issues curators raised

### DIFF
--- a/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/app/controllers/stash_engine/publication_updater_controller.rb
@@ -27,7 +27,9 @@ module StashEngine
     # the admin datasets main page showing users and stats, but slightly different in scope for curators vs tenant admins
     def index
       proposed_changes = authorize StashEngine::ProposedChange # .includes(identifier: :latest_resource)
-        .joins(identifier: :latest_resource).where(approved: false, rejected: false).select('stash_engine_proposed_changes.*')
+        .joins(identifier: :latest_resource).where(approved: false, rejected: false)
+        .where('stash_engine_identifiers.pub_state != ?', 'withdrawn')
+        .select('stash_engine_proposed_changes.*')
 
       if params[:list_search].present?
         proposed_changes = proposed_changes.joins(CONCAT_FOR_SEARCH)

--- a/app/views/stash_engine/publication_updater/_proposed_change_line.html.erb
+++ b/app/views/stash_engine/publication_updater/_proposed_change_line.html.erb
@@ -3,6 +3,12 @@
   existing_pubissn = fetch_identifier_metadata(resource: resource, data_type: 'publicationISSN')
   existing_pubdoi = fetch_related_primary_article(resource: resource)
 %>
+
+<% return if existing_pubname == proposed_change.publication_name &&
+            (existing_pubissn == proposed_change.publication_issn || proposed_change.publication_issn.blank?) &&
+            existing_pubdoi == proposed_change.publication_doi
+%>
+
 <tr class="c-lined-table__row" id="current_<%= proposed_change.id %>">
   <%= render partial: 'current_metadata', locals: { resource: resource, existing_pubdoi: existing_pubdoi, existing_pubissn: existing_pubissn, existing_pubname: existing_pubname } %>
 

--- a/app/views/stash_engine/publication_updater/_proposed_change_line.html.erb
+++ b/app/views/stash_engine/publication_updater/_proposed_change_line.html.erb
@@ -4,15 +4,15 @@
   existing_pubdoi = fetch_related_primary_article(resource: resource)
 %>
 
-<% return if existing_pubname == proposed_change.publication_name &&
+<% unless existing_pubname == proposed_change.publication_name &&
             (existing_pubissn == proposed_change.publication_issn || proposed_change.publication_issn.blank?) &&
             existing_pubdoi == proposed_change.publication_doi
 %>
 
-<tr class="c-lined-table__row" id="current_<%= proposed_change.id %>">
-  <%= render partial: 'current_metadata', locals: { resource: resource, existing_pubdoi: existing_pubdoi, existing_pubissn: existing_pubissn, existing_pubname: existing_pubname } %>
-
-</tr>
-<tr class="c-lined-table__row" id="proposed_<%= proposed_change.id %>">
-  <%= render partial: 'proposed_metadata', locals: { proposed_change: proposed_change, existing_pubdoi: existing_pubdoi, existing_pubissn: existing_pubissn, existing_pubname: existing_pubname, resource: resource } %>
-</tr>
+  <tr class="c-lined-table__row" id="current_<%= proposed_change.id %>">
+    <%= render partial: 'current_metadata', locals: { resource: resource, existing_pubdoi: existing_pubdoi, existing_pubissn: existing_pubissn, existing_pubname: existing_pubname } %>
+  </tr>
+  <tr class="c-lined-table__row" id="proposed_<%= proposed_change.id %>">
+    <%= render partial: 'proposed_metadata', locals: { proposed_change: proposed_change, existing_pubdoi: existing_pubdoi, existing_pubissn: existing_pubissn, existing_pubname: existing_pubname, resource: resource } %>
+  </tr>
+<% end %>

--- a/app/views/stash_engine/publication_updater/index.html.erb
+++ b/app/views/stash_engine/publication_updater/index.html.erb
@@ -13,7 +13,7 @@
 
   <p>If you select to update with metadata then the items that update are: the issn, publication name, subjects and related identifier</p>
 
-  <p>Selecting to update without (w/o) metadata means only the related identifier is updated and the other items are left as is in the dataset.</p>
+  <p>Selecting to update without (w/o) metadata means only the related identifier is updated and the other items are left &quot;as is&quot; in the dataset.</p>
 
   <%= form_with url: stash_url_helpers.publication_updater_path, method: :get do |form| %>
     <h2 class="o-heading__level2">Limit to</h2>

--- a/lib/tasks/publication_updater.rake
+++ b/lib/tasks/publication_updater.rake
@@ -67,7 +67,7 @@ namespace :publication_updater do
   # ON pc.identifier_id = i.id
   # WHERE i.id IS NULL;
 
-  # note:  This will fill in the subjects and also get a type from crossref
+  # NOTE: This will fill in the subjects and also get a type from crossref
   desc 'Rescan non-processed proposed changes for metadata updates at crossref'
   task rescan: :environment do
     StashEngine::ProposedChange.where(approved: false, rejected: false).each do |existing_pc|
@@ -83,7 +83,10 @@ namespace :publication_updater do
 
       begin
         # Hit Crossref for info
-        cr = Stash::Import::Crossref.query_by_doi(resource: resource, doi: primary_article.related_identifier) if primary_article&.related_identifier.present?
+        if primary_article&.related_identifier.present?
+          cr = Stash::Import::Crossref.query_by_doi(resource: resource,
+                                                    doi: primary_article.related_identifier)
+        end
         cr = Stash::Import::Crossref.query_by_author_title(resource: resource) unless cr.present?
       rescue URI::InvalidURIError => e
         # If the URI is invalid, just skip to the next record

--- a/lib/tasks/publication_updater.rake
+++ b/lib/tasks/publication_updater.rake
@@ -32,6 +32,7 @@ namespace :publication_updater do
 
       begin
         resource = StashEngine::Resource.find(result.resource_id)
+        next if resource.nil? || resource.identifier.blank? || resource.identifier.pub_state == 'withdrawn'
 
         # Hit Crossref for info
         cr = Stash::Import::Crossref.query_by_doi(resource: resource, doi: result.doi) if result.doi.present?
@@ -56,6 +57,51 @@ namespace :publication_updater do
     end
 
     p 'Finished scanning Crossref API'
+  end
+
+  # THERE was a lot of junk data on our dev machine and orphaned proposed changes for identifiers that didn't exist.
+  # cleanup the table like this:
+
+  # DELETE pc FROM `stash_engine_proposed_changes` pc
+  # LEFT JOIN stash_engine_identifiers i
+  # ON pc.identifier_id = i.id
+  # WHERE i.id IS NULL;
+
+  # note:  This will fill in the subjects and also get a type from crossref
+  desc 'Rescan non-processed proposed changes for metadata updates at crossref'
+  task rescan: :environment do
+    StashEngine::ProposedChange.where(approved: false, rejected: false).each do |existing_pc|
+      identifier = existing_pc.identifier
+      resource = identifier&.latest_resource
+      primary_article = resource&.related_identifiers&.primary_article&.first
+      # remove this from the changes table and try re-adding it
+      next if resource.nil? || existing_pc.identifier.pub_state == 'withdrawn'
+
+      puts "rescanning existing proposed change id: #{existing_pc.id}, #{existing_pc.title}"
+
+      existing_pc.destroy # and re-import below
+
+      begin
+        # Hit Crossref for info
+        cr = Stash::Import::Crossref.query_by_doi(resource: resource, doi: primary_article.related_identifier) if primary_article&.related_identifier.present?
+        cr = Stash::Import::Crossref.query_by_author_title(resource: resource) unless cr.present?
+      rescue URI::InvalidURIError => e
+        # If the URI is invalid, just skip to the next record
+        p "ERROR querying Crossref for publication DOI: '#{result.doi}' for identifier: '#{resource&.identifier}' : #{e.message}"
+        next
+      end
+
+      pc = cr.to_proposed_change if cr.present?
+
+      # Tweakable threshold for scoring (score is ours ... 1 == DOI match, < 1 is title+authors matching)
+      #                                 (provenance_score is Crossref's score)
+      next unless pc.present? && pc.score >= 0.6
+
+      p "  found changes for: #{resource.id} (#{resource.title}" if pc.present?
+      pc.save if pc.present?
+    end
+
+    puts 'Finished rescanning Crossref API to update existing entries'
   end
 
 end


### PR DESCRIPTION
See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2720 .

Addresses the items raised in this PR and the previous one.

- System matching to Withdrawn dataset
  - Excluded from the query
- System makes match with no apparent changes
  - Skips matches without apparent changes.  I believe these may have originally been different when the proposed change was imported and the dataset was updated sometime after the import from CrossRef.
- System wants to replace one ISSN with another (same journal)
  - This seems a curation call about which ISSN is appropriate.  It can be rejected or now there is the option to just update the related DOI if desired without updating the rest.
- System wants to remove ISSN
  - Items with blank ISSNs and no other differences are skipped.
- System wants to replace correctly primary article with unrelated article
  - From previous pull request, curators can now choose to update as either primary (article), related (article), preprint (article) if it is one of these instead or reject.
- Missing (newly added to pub updater) metadata
  - Added additional script to reprocess items that haven't been accepted or rejected yet and it will remove the existing item and re-check crossref to populate the keywords and the CrossRef `type` if they are available and put the record back in again with the newer items (If it's still available to lookup from CrossRef)