### PR TITLE
Fixes render/redirect error and machine gun clicking on submit

### DIFF
--- a/app/controllers/stash_datacite/resources_controller.rb
+++ b/app/controllers/stash_datacite/resources_controller.rb
@@ -135,11 +135,9 @@ module StashDatacite
 
     def processing?(resource)
       if (resource && resource.identifier && resource.identifier.processing?) || resource&.current_resource_state&.resource_state != 'in_progress'
-        redirect_back(fallback_location: stash_url_helpers.dashboard_path,
-                      notice: 'You may not submit this version of the dataset because a previous version has not finished ' \
-                              'processing or you are trying to re-submit an old version')
         return true
       end
+
       resource.current_resource_state.update(resource_state: 'processing') # should lock them out of multiple rapid submissions of same resource
       false
     end

--- a/app/views/stash_datacite/resources/_review.html.erb
+++ b/app/views/stash_datacite/resources/_review.html.erb
@@ -144,7 +144,7 @@
       <% end %>
     <% end %>
   <% elsif @error_items.blank? # valid data %>
-    <%= form_with(url: resources_submission_path) do -%>
+    <%= form_with(url: resources_submission_path, id: 'submit_dataset_form') do -%>
       <%= hidden_field_tag :resource_id, @resource.id %>
       <%= hidden_field_tag :software_license, @resource&.identifier&.software_license&.identifier || 'MIT' %>
       <%= check_box_tag 'all_filled',  1, true, :style => "display: none;", class: 'all_filled js-agrees' %>
@@ -176,6 +176,11 @@
       updateSubmitCommentDisabled();
     });
   }
+
+  $("#submit_dataset_form").submit(function () {
+    $("#submit_dataset").attr("disabled", true);
+    return true;
+  });
 
   function updateSubmitCommentDisabled(){
     let hasErrors = ($('div.c-error-box').length > 0) && ($('div.c-error-box')[0].innerHTML.length > 0);


### PR DESCRIPTION
Fixes the problem where it gives a double-render error on submitting a dataset that's already being submitted.

Also adds protection to the submit so that once submit is clicked once it's disabled to prevent machine gunning.

To test that the double-render fix.

- Add or edit dataset and go to the review page that is ready to submit.
- Look at the URL bar and filter the `stash_engine_resource_states` by the resource_id in your db browser. 
- change the `resource_state` from `in_progress` to `processing`.
- Clicking submit now should return you to the landing page with a message showing the item is already submitting.
- set the `resource_state` back to `in_progress` for future fun with the dataset.