### PR TITLE
Correct dashboard ordering by last update

### DIFF
--- a/app/policies/stash_engine/identifier_policy.rb
+++ b/app/policies/stash_engine/identifier_policy.rb
@@ -46,7 +46,7 @@ module StashEngine
               ELSE 3
             END as sort_order")
           .order('sort_order ASC')
-          .order('updated_at DESC')
+          .merge(CurationActivity.order(updated_at: :desc))
       end
 
       private


### PR DESCRIPTION
Order of items on user dashboard was by identifier updated_at. What is displayed on the dashboard is resource/last curation activity update. Corrected the ordering to match.