### PR TITLE
Adds config for mrt bucket and refactors S3 wrapper library

### DIFF
--- a/app/controllers/stash_api/files_controller.rb
+++ b/app/controllers/stash_api/files_controller.rb
@@ -39,7 +39,7 @@ module StashApi
     def update
       # lots of checks and setup before creating the file (also see the before_actions above)
       pre_upload_checks { return }
-      Stash::Aws::S3.put_stream(s3_key: @file_path, stream: request.body)
+      Stash::Aws::S3.new.put_stream(s3_key: @file_path, stream: request.body)
       after_upload_processing { return }
       file = StashApi::File.new(file_id: @file.id)
       render json: file.metadata, status: 201
@@ -110,7 +110,7 @@ module StashApi
     end
 
     def check_file_size
-      return if Stash::Aws::S3.size(s3_key: @file_path) <= APP_CONFIG.maximums.merritt_size
+      return if Stash::Aws::S3.new.size(s3_key: @file_path) <= APP_CONFIG.maximums.merritt_size
 
       (render json: { error:
           "Your file size is larger than the maximum submission size of #{view_context.filesize(APP_CONFIG.maximums.merritt_size)}" }.to_json,
@@ -122,7 +122,7 @@ module StashApi
       file = StashEngine::DataFile.create(
         upload_file_name: @sanitized_name,
         upload_content_type: file_content_type,
-        upload_file_size: Stash::Aws::S3.size(s3_key: @file_path),
+        upload_file_size: Stash::Aws::S3.new.size(s3_key: @file_path),
         resource_id: @resource.id,
         upload_updated_at: Time.new.utc,
         file_state: 'created',

--- a/app/models/stash_datacite/resource/dataset_validations.rb
+++ b/app/models/stash_datacite/resource/dataset_validations.rb
@@ -203,7 +203,7 @@ module StashDatacite
         files = @resource.generic_files.newly_created.file_submission
         errored_uploads = []
         files.each do |f|
-          errored_uploads.push(f.upload_file_name) unless Stash::Aws::S3.exists?(s3_key: f.calc_s3_path)
+          errored_uploads.push(f.upload_file_name) unless Stash::Aws::S3.new.exists?(s3_key: f.calc_s3_path)
         end
 
         return [] if errored_uploads.empty?

--- a/app/models/stash_engine/data_file.rb
+++ b/app/models/stash_engine/data_file.rb
@@ -58,7 +58,7 @@ module StashEngine
     # the presigned URL for a file that was "directly" uploaded to Dryad,
     # rather than a file that was indicated by a URL reference
     def direct_s3_presigned_url
-      Stash::Aws::S3.presigned_download_url(s3_key: "#{resource.s3_dir_name(type: 'data')}/#{upload_file_name}")
+      Stash::Aws::S3.new.presigned_download_url(s3_key: "#{resource.s3_dir_name(type: 'data')}/#{upload_file_name}")
     end
 
     # the URL we use for replication to zenodo, for software it's always the merritt url, but for software we have the same

--- a/app/models/stash_engine/generic_file.rb
+++ b/app/models/stash_engine/generic_file.rb
@@ -103,7 +103,7 @@ module StashEngine
     def smart_destroy!
       # see if it's on the file system and destroy it if it's there
       s3_key = calc_s3_path
-      Stash::Aws::S3.delete_file(s3_key: s3_key) if !s3_key.blank? && Stash::Aws::S3.exists?(s3_key: s3_key)
+      Stash::Aws::S3.new.delete_file(s3_key: s3_key) if !s3_key.blank? && Stash::Aws::S3.new.exists?(s3_key: s3_key)
 
       # convert to hash so we still have after destroying them
       prev_files = case_insensitive_previous_files.map do |pf|

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -125,7 +125,7 @@ module StashEngine
     end
 
     def remove_s3_temp_files
-      Stash::Aws::S3.delete_dir(s3_key: s3_dir_name(type: 'base'))
+      Stash::Aws::S3.new.delete_dir(s3_key: s3_dir_name(type: 'base'))
     end
 
     after_create :init_state_and_version
@@ -356,7 +356,7 @@ module StashEngine
       end
 
       # add file
-      Stash::Aws::S3.put_stream(
+      Stash::Aws::S3.new.put_stream(
         s3_key: "#{s3_dir_name(type: 'data')}/README.md",
         stream: StringIO.new(technical_info)
       )

--- a/app/models/stash_engine/software_file.rb
+++ b/app/models/stash_engine/software_file.rb
@@ -25,7 +25,7 @@ module StashEngine
     # the presigned URL for a file that was "directly" uploaded to Dryad,
     # rather than a file that was indicated by a URL reference
     def direct_s3_presigned_url
-      Stash::Aws::S3.presigned_download_url(s3_key: "#{resource.s3_dir_name(type: 'software')}/#{upload_file_name}")
+      Stash::Aws::S3.new.presigned_download_url(s3_key: "#{resource.s3_dir_name(type: 'software')}/#{upload_file_name}")
     end
 
     # the URL we use for replication from other source (Presigned or URL) up to Zenodo

--- a/app/models/stash_engine/supp_file.rb
+++ b/app/models/stash_engine/supp_file.rb
@@ -25,7 +25,7 @@ module StashEngine
     # the presigned URL for a file that was "directly" uploaded to Dryad,
     # rather than a file that was indicated by a URL reference
     def direct_s3_presigned_url
-      Stash::Aws::S3.presigned_download_url(s3_key: "#{resource.s3_dir_name(type: 'supplemental')}/#{upload_file_name}")
+      Stash::Aws::S3.new.presigned_download_url(s3_key: "#{resource.s3_dir_name(type: 'supplemental')}/#{upload_file_name}")
     end
 
     # the URL we use for replication from other source (Presigned or URL) up to Zenodo

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -165,6 +165,7 @@ defaults: &DEFAULTS
   s3:
     region: us-west-2
     bucket: dryad-s3-dev
+    merritt_bucket: dryad-assetstore-merritt-stage
     key: AKIA2KERHV5E3OITXZXC
     secret: <%= Rails.application.credentials[Rails.env.to_sym][:s3_secret] %>
   google_analytics_id: null
@@ -284,6 +285,7 @@ stage:
   s3:
     region: us-west-2
     bucket: dryad-s3-stg
+    merritt_bucket: dryad-assetstore-merritt-stage
     key: AKIA2KERHV5E3OITXZXC
     secret: <%= Rails.application.credentials[Rails.env.to_sym][:s3_secret] %>
   cedar:
@@ -355,6 +357,7 @@ production:
   s3:
     region: us-west-2
     bucket: dryad-s3-prd
+    merritt_bucket: dryad-assetstore-merritt-west
     key: AKIA2KERHV5E3OITXZXC
     secret: <%= Rails.application.credentials[Rails.env.to_sym][:s3_secret] %>
   google_analytics_id: G-6CWE0T05CC

--- a/dryad-config-example/app_config.yml
+++ b/dryad-config-example/app_config.yml
@@ -149,6 +149,7 @@ defaults: &DEFAULTS
   s3:
     region: us-west-2
     bucket: a-test-bucket
+    merritt_bucket: a-merritt-test-bucket
     key: abcdefg
     secret: HIJKLMNOP
   maximums:

--- a/lib/stash/aws/s3.rb
+++ b/lib/stash/aws/s3.rb
@@ -3,9 +3,9 @@ require 'aws-sdk-s3'
 # use example
 # require 'stash/aws/s3'
 #
-# Stash::Aws::S3.put(s3_key: 'test01/color.txt', contents: 'Dryad Green is #40841c')
-# Stash::Aws::S3.exists?(s3_key: 'test01/color.txt')
-# Stash::Aws::S3.delete_file(s3_key: 'test01/color.txt')
+# Stash::Aws::S3.new.put(s3_key: 'test01/color.txt', contents: 'Dryad Green is #40841c')
+# Stash::Aws::S3.new.exists?(s3_key: 'test01/color.txt')
+# Stash::Aws::S3.new.delete_file(s3_key: 'test01/color.txt')
 
 module Stash
   module Aws

--- a/lib/stash/aws/s3.rb
+++ b/lib/stash/aws/s3.rb
@@ -11,14 +11,20 @@ module Stash
   module Aws
     class S3
 
-      def self.put(s3_key:, contents:)
+      attr_reader :s3_bucket
+
+      def initialize(s3_bucket_name: APP_CONFIG[:s3][:bucket])
+        @s3_bucket = s3_resource.bucket(s3_bucket_name)
+      end
+
+      def put(s3_key:, contents:)
         return unless s3_key && contents
 
         object = s3_bucket.object(s3_key)
         object.put(body: contents)
       end
 
-      def self.put_stream(s3_key:, stream:)
+      def put_stream(s3_key:, stream:)
         return unless s3_key && stream
 
         object = s3_bucket.object(s3_key)
@@ -27,70 +33,64 @@ module Stash
         end
       end
 
-      def self.put_file(s3_key:, filename:)
+      def put_file(s3_key:, filename:)
         return unless s3_key && filename
 
         object = s3_bucket.object(s3_key)
         object.upload_file(filename)
       end
 
-      def self.exists?(s3_key:)
+      def exists?(s3_key:)
         obj = s3_bucket.object(s3_key)
         obj.exists?
       end
 
-      def self.size(s3_key:)
+      def size(s3_key:)
         obj = s3_bucket.object(s3_key)
         obj.size
       end
 
-      def self.presigned_download_url(s3_key:)
+      def presigned_download_url(s3_key:)
         return unless s3_key
 
         object = s3_bucket.object(s3_key)
         object.presigned_url(:get, expires_in: 1.day.to_i)
       end
 
-      def self.delete_file(s3_key:)
+      def delete_file(s3_key:)
         return unless s3_key
 
         object = s3_bucket.object(s3_key)
         object.delete
       end
 
-      def self.delete_dir(s3_key:)
+      def delete_dir(s3_key:)
         return unless s3_key
 
         s3_key = s3_key.chop if s3_key.ends_with?('/')
         s3_bucket.objects(prefix: "#{s3_key}/").batch_delete!
       end
 
-      def self.objects(starts_with:)
+      def objects(starts_with:)
         return unless starts_with
 
         s3_bucket.objects(prefix: starts_with)
       end
 
-      class << self
-        private
+      private
 
-        def s3_credentials
-          @s3_credentials ||= ::Aws::Credentials.new(APP_CONFIG[:s3][:key], APP_CONFIG[:s3][:secret])
-        end
-
-        def s3_client
-          @s3_client ||= ::Aws::S3::Client.new(region: APP_CONFIG[:s3][:region], credentials: s3_credentials)
-        end
-
-        def s3_resource
-          @s3_resource ||= ::Aws::S3::Resource.new(client: s3_client)
-        end
-
-        def s3_bucket
-          @s3_bucket ||= s3_resource.bucket(APP_CONFIG[:s3][:bucket])
-        end
-
+      def s3_credentials
+        @s3_credentials ||= ::Aws::Credentials.new(APP_CONFIG[:s3][:key], APP_CONFIG[:s3][:secret])
       end
+
+      def s3_client
+        @s3_client ||= ::Aws::S3::Client.new(region: APP_CONFIG[:s3][:region], credentials: s3_credentials)
+      end
+
+      def s3_resource
+        @s3_resource ||= ::Aws::S3::Resource.new(client: s3_client)
+      end
+
     end
   end
 end

--- a/lib/stash/repo/file_builder.rb
+++ b/lib/stash/repo/file_builder.rb
@@ -67,7 +67,7 @@ module Stash
         return unless file_contents.present?
 
         file_path = "#{target_dir}/#{file_name}"
-        Stash::Aws::S3.put(s3_key: file_path, contents: file_contents)
+        Stash::Aws::S3.new.put(s3_key: file_path, contents: file_contents)
         file_path
       end
     end

--- a/lib/stash/repo/repository.rb
+++ b/lib/stash/repo/repository.rb
@@ -174,8 +174,8 @@ module Stash
       end
 
       def remove_s3_data_files(resource)
-        Stash::Aws::S3.delete_dir(s3_key: resource.s3_dir_name(type: 'manifest').to_s)
-        Stash::Aws::S3.delete_dir(s3_key: resource.s3_dir_name(type: 'data').to_s)
+        Stash::Aws::S3.new.delete_dir(s3_key: resource.s3_dir_name(type: 'manifest').to_s)
+        Stash::Aws::S3.new.delete_dir(s3_key: resource.s3_dir_name(type: 'data').to_s)
       end
 
       def update_submission_log(result)

--- a/lib/stash/zenodo_software/copier.rb
+++ b/lib/stash/zenodo_software/copier.rb
@@ -138,7 +138,7 @@ module Stash
           @resource_method, deposition_id: @resp[:id], zc_id: @copy.id)
 
         # clean up the S3 storage of zenodo files that have been successfully replicated
-        Stash::Aws::S3.delete_dir(s3_key: @resource.s3_dir_name(type: @s3_method))
+        Stash::Aws::S3.new.delete_dir(s3_key: @resource.s3_dir_name(type: @s3_method))
 
         @copy.reload
         @copy.update(state: 'finished', error_info: nil)

--- a/lib/tasks/local_to_s3.rake
+++ b/lib/tasks/local_to_s3.rake
@@ -46,13 +46,13 @@ namespace :local_to_s3 do
         if File.directory?(file_path)
           puts "    -- #{file_name} --> skipping temp directory"
           next
-        elsif Stash::Aws::S3.exists?(s3_key: s3_file) && (Stash::Aws::S3.size(s3_key: s3_file) == File.size(file_path))
+        elsif Stash::Aws::S3.new.exists?(s3_key: s3_file) && (Stash::Aws::S3.new.size(s3_key: s3_file) == File.size(file_path))
           puts "    -- #{file_name} --> already in S3"
           next
         end
         # otherwise, send it to s3
         puts "    -- #{file_name} --> #{s3_file}"
-        Stash::Aws::S3.put_file(s3_key: s3_file, filename: file_path)
+        Stash::Aws::S3.new.put_file(s3_key: s3_file, filename: file_path)
       end
     end
   end

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -150,7 +150,7 @@ namespace :identifiers do
       s3_dir = res.s3_dir_name(type: 'base')
       puts "ident #{ident.id} Res #{res.id} -- updated_at #{res.updated_at}"
       puts "   DESTROY s3 #{s3_dir}"
-      Stash::Aws::S3.delete_dir(s3_key: s3_dir) unless dry_run
+      Stash::Aws::S3.new.delete_dir(s3_key: s3_dir) unless dry_run
       puts "   DESTROY resource #{res.id}"
       res.destroy unless dry_run
     end
@@ -162,7 +162,7 @@ namespace :identifiers do
                 else
                   ''
                 end
-    Stash::Aws::S3.objects(starts_with: s3_prefix).each do |s3o|
+    Stash::Aws::S3.new.objects(starts_with: s3_prefix).each do |s3o|
       id_prefix = s3o.key.split('/').first
       res_id = if id_prefix.include?('-')
                  id_prefix.split('-').last
@@ -177,12 +177,12 @@ namespace :identifiers do
            (r.zenodo_copies.where("copy_type LIKE 'software%' OR copy_type like 'supp%'").where.not(state: 'finished').count == 0)
           # if the resource is state == submitted and all zenodo transfers have completed, delete the data
           puts "   resource is submitted -- DELETE s3 dir #{id_prefix}"
-          Stash::Aws::S3.delete_dir(s3_key: id_prefix) unless dry_run
+          Stash::Aws::S3.new.delete_dir(s3_key: id_prefix) unless dry_run
         end
       else
         # there is no reasource, delete the files
         puts "   resource is deleted -- DELETE s3 dir #{id_prefix}"
-        Stash::Aws::S3.delete_dir(s3_key: id_prefix) unless dry_run
+        Stash::Aws::S3.new.delete_dir(s3_key: id_prefix) unless dry_run
       end
     end
   end

--- a/spec/features/stash_engine/upload_files_spec.rb
+++ b/spec/features/stash_engine/upload_files_spec.rb
@@ -396,7 +396,7 @@ RSpec.feature 'UploadFiles', type: :feature, js: true do
       # TODO: S3.exists? mock returns true now.
       #  See if it's possible to return something from the Evaporate using S3 mocks
       # TODO: remove raw url for s3 dir name
-      result = Stash::Aws::S3.exists?(s3_key: '37fb70ac-1/data/file_10.ods')
+      result = Stash::Aws::S3.new.exists?(s3_key: '37fb70ac-1/data/file_10.ods')
       expect(result).to be true
     end
 

--- a/spec/lib/stash/aws/s3_spec.rb
+++ b/spec/lib/stash/aws/s3_spec.rb
@@ -12,7 +12,7 @@ module Stash
       describe '#delete_file' do
         it 'calls s3 to delete a file' do
           stub_request(:delete, 'https://a-test-bucket.s3.us-west-2.amazonaws.com/mugawump')
-          Stash::Aws::S3.delete_file(s3_key: 'mugawump')
+          Stash::Aws::S3.new.delete_file(s3_key: 'mugawump')
           expect(a_request(:delete, 'https://a-test-bucket.s3.us-west-2.amazonaws.com/mugawump')).to have_been_made.once
         end
       end
@@ -20,7 +20,7 @@ module Stash
       describe '#exists?' do
         it 'calls s3 to see if a key exists' do
           stub_request(:head, 'https://a-test-bucket.s3.us-west-2.amazonaws.com/mugawump')
-          Stash::Aws::S3.exists?(s3_key: 'mugawump')
+          Stash::Aws::S3.new.exists?(s3_key: 'mugawump')
           expect(a_request(:head, 'https://a-test-bucket.s3.us-west-2.amazonaws.com/mugawump')).to have_been_made.once
         end
       end
@@ -28,8 +28,9 @@ module Stash
       describe '#objects' do
         it 'calls s3 to get list of objects' do
           # Basic test that the bucket receives an objects message. "send" bypasses it being a private method, so can test
-          expect(Stash::Aws::S3.send(:s3_bucket)).to receive(:objects).with(prefix: '12xu')
-          Stash::Aws::S3.objects(starts_with: '12xu')
+          s3 = Stash::Aws::S3.new
+          expect(s3.send(:s3_bucket)).to receive(:objects).with(prefix: '12xu')
+          s3.objects(starts_with: '12xu')
         end
       end
 

--- a/spec/lib/stash/zenodo_software/copier_spec.rb
+++ b/spec/lib/stash/zenodo_software/copier_spec.rb
@@ -240,7 +240,7 @@ module Stash
             @zsc.instance_variable_set(:@resp, { state: 'open' }) # so as not to try re-opening it for modification
             deposit = @zsc.instance_variable_get(:@deposit)
             allow(deposit).to receive(:update_metadata)
-            allow(Stash::Aws::S3).to receive(:delete_dir)
+            allow_any_instance_of(Stash::Aws::S3).to receive(:delete_dir)
             expect(deposit).not_to receive(:publish)
             @zsc.publish_dataset
             expect(@zc.reload.state).to eq('finished')
@@ -297,7 +297,7 @@ module Stash
             file_coll = @zsc.instance_eval('@file_collection', __FILE__, __LINE__)
             expect(file_coll).to receive(:synchronize_to_zenodo).with(bucket_url: bucket_link).and_return(nil)
             expect(Stash::ZenodoSoftware::FileCollection).to receive(:check_uploaded_list).and_return(nil) # don't check against zenodo
-            expect(Stash::Aws::S3).to receive(:delete_dir).and_return(nil) # because it will try to delete the dir when done
+            expect_any_instance_of(Stash::Aws::S3).to receive(:delete_dir).and_return(nil) # because it will try to delete the dir when done
 
             @zsc.add_to_zenodo
             @zc.reload
@@ -332,7 +332,7 @@ module Stash
               file_coll = @zsc2.instance_eval('@file_collection', __FILE__, __LINE__)
               expect(file_coll).to receive(:synchronize_to_zenodo).with(bucket_url: bucket_link)
               expect(Stash::ZenodoSoftware::FileCollection).to receive(:check_uploaded_list).and_return(nil)
-              expect(Stash::Aws::S3).to receive(:delete_dir).and_return(nil) # because it will try to delete the dir when done
+              expect_any_instance_of(Stash::Aws::S3).to receive(:delete_dir).and_return(nil) # because it will try to delete the dir when done
 
               @zsc2.add_to_zenodo
               @zc2.reload
@@ -352,7 +352,7 @@ module Stash
               file_coll = @zsc2.instance_eval('@file_collection', __FILE__, __LINE__)
               expect(file_coll).to receive(:synchronize_to_zenodo)
               expect(Stash::ZenodoSoftware::FileCollection).to receive(:check_uploaded_list).and_return(nil)
-              expect(Stash::Aws::S3).to receive(:delete_dir).and_return(nil) # because it will try to delete the dir when done
+              expect_any_instance_of(Stash::Aws::S3).to receive(:delete_dir).and_return(nil) # because it will try to delete the dir when done
 
               @zsc2.add_to_zenodo
               @zc2.reload

--- a/spec/models/stash-merritt/object_manifest_package_spec.rb
+++ b/spec/models/stash-merritt/object_manifest_package_spec.rb
@@ -75,9 +75,9 @@ module Stash
 
       describe :manifest do
         let(:instance) { instance_double(Stash::Aws::S3) }
-        let(:double_class) {
+        let(:double_class) do
           class_double(Stash::Aws::S3).as_stubbed_const
-        }
+        end
 
         before(:each) do
           # make Stash::Aws::S3 an rspec "spy", so we can test how it was called
@@ -91,16 +91,16 @@ module Stash
         it 'builds a manifest' do
           # expect(instance).to have_received(:put)
           expect(instance).to have_received(:put).with(s3_key: /manifest\.checkm/,
-                                                             contents: /%checkm_/).at_least(:once)
+                                                       contents: /%checkm_/).at_least(:once)
           expect(instance).to have_received(:put).with(s3_key: /manifest\.checkm/,
-                                                             contents: %r{stash-wrapper\.xml \| text/xml}).at_least(:once)
+                                                       contents: %r{stash-wrapper\.xml \| text/xml}).at_least(:once)
         end
 
         describe 'public/system' do
           it 'writes mrt-dataone-manifest.txt' do
             # This file should look like spec/data/stash-merritt/mrt-dataone-manifest.txt
             package = ObjectManifestPackage.new(resource: @resource)
-            the_path = package.create_manifest
+            package.create_manifest
             @resource.new_data_files.find_each do |upload|
               target_string = "#{upload.upload_file_name} | #{upload.upload_content_type}"
               expect(instance).to have_received(:put)
@@ -182,7 +182,7 @@ module Stash
             package.create_manifest
 
             expect(instance).to have_received(:put).with(s3_key: /manifest\.checkm/,
-                                                                               contents: /mrt-delete\.txt/).at_least(:once)
+                                                         contents: /mrt-delete\.txt/).at_least(:once)
             deleted.each do |filename|
               expect(instance).to have_received(:put)
                 .with(s3_key: /mrt-delete\.txt/,

--- a/spec/models/stash/repo/file_builder_spec.rb
+++ b/spec/models/stash/repo/file_builder_spec.rb
@@ -59,9 +59,9 @@ module Stash
           builder = FileBuilder.new(file_name: file_name)
           builder.define_singleton_method(:contents) { contents }
           expect_any_instance_of(Stash::Aws::S3).to receive(:put)
-                                                    .with(s3_key: "#{target_dir}/#{file_name}",
-                                                          contents: contents)
-                                                    .at_least(:once)
+            .with(s3_key: "#{target_dir}/#{file_name}",
+                  contents: contents)
+            .at_least(:once)
           builder.write_s3_file(target_dir)
         end
 

--- a/spec/models/stash/repo/file_builder_spec.rb
+++ b/spec/models/stash/repo/file_builder_spec.rb
@@ -53,27 +53,25 @@ module Stash
 
       describe :write_file do
         it 'writes the file' do
-          allow(Stash::Aws::S3).to receive(:put)
           contents = "<contents/>\n"
           file_name = 'contents.xml'
           target_dir = 'some/bogus/target_dir'
           builder = FileBuilder.new(file_name: file_name)
           builder.define_singleton_method(:contents) { contents }
+          expect_any_instance_of(Stash::Aws::S3).to receive(:put)
+                                                    .with(s3_key: "#{target_dir}/#{file_name}",
+                                                          contents: contents)
+                                                    .at_least(:once)
           builder.write_s3_file(target_dir)
-          expect(Stash::Aws::S3).to have_received(:put)
-            .with(s3_key: "#{target_dir}/#{file_name}",
-                  contents: contents)
-            .at_least(:once)
         end
 
         it 'writes nothing if #contents returns nil' do
-          allow(Stash::Aws::S3).to receive(:put)
           file_name = 'contents.xml'
           target_dir = 'some/bogus/target_dir'
           builder = FileBuilder.new(file_name: file_name)
+          expect_any_instance_of(Stash::Aws::S3).not_to receive(:put)
           builder.define_singleton_method(:contents) { nil }
           builder.write_s3_file(target_dir)
-          expect(Stash::Aws::S3).not_to have_received(:put)
         end
       end
     end

--- a/spec/models/stash_datacite/dataset_validations_spec.rb
+++ b/spec/models/stash_datacite/dataset_validations_spec.rb
@@ -179,7 +179,7 @@ module StashDatacite
         it 'returns missing files when files uploaded to s3 are not present' do
           files = @resource.generic_files
           files.map(&:calc_s3_path).each do |s3_path|
-            allow(Stash::Aws::S3).to receive('exists?').with(s3_key: s3_path).and_return(false)
+            allow_any_instance_of(Stash::Aws::S3).to receive('exists?').with(s3_key: s3_path).and_return(false)
           end
 
           validations = DatasetValidations.new(resource: @resource)
@@ -193,7 +193,7 @@ module StashDatacite
 
         it 'does not check missing files once Merritt processing is complete' do
           @resource.generic_files.map(&:calc_s3_path).each do |s3_path|
-            allow(Stash::Aws::S3).to receive('exists?').with(s3_key: s3_path).and_return(false)
+            allow_any_instance_of(Stash::Aws::S3).to receive('exists?').with(s3_key: s3_path).and_return(false)
           end
           allow(@resource).to receive('submitted?').and_return(true)
 
@@ -208,7 +208,7 @@ module StashDatacite
           @resource.generic_files.third.update(url: 'http://example.com')
           @resource.generic_files.fourth.update(file_state: 'copied')
           @resource.generic_files.map(&:calc_s3_path).each do |s3_path|
-            allow(Stash::Aws::S3).to receive('exists?').with(s3_key: s3_path).and_return(false)
+            allow_any_instance_of(Stash::Aws::S3).to receive('exists?').with(s3_key: s3_path).and_return(false)
           end
 
           validations = DatasetValidations.new(resource: @resource)

--- a/spec/models/stash_engine/data_file_spec.rb
+++ b/spec/models/stash_engine/data_file_spec.rb
@@ -52,16 +52,16 @@ module StashEngine
       end
 
       it 'deletes a file that was just created, from the database and s3' do
-        expect(Stash::Aws::S3).to receive(:exists?).and_return(true)
-        expect(Stash::Aws::S3).to receive(:delete_file)
+        expect_any_instance_of(Stash::Aws::S3).to receive(:exists?).and_return(true)
+        expect_any_instance_of(Stash::Aws::S3).to receive(:delete_file)
         @files2[1].smart_destroy!
         @resource2.reload
         expect(@resource2.data_files.map(&:upload_file_name).include?('noggin2.jpg')).to eq(false)
       end
 
       it "deletes from database even if the s3 file doesn't exist" do
-        expect(Stash::Aws::S3).to receive(:exists?).and_return(false)
-        expect(Stash::Aws::S3).not_to receive(:delete_file)
+        expect_any_instance_of(Stash::Aws::S3).to receive(:exists?).and_return(false)
+        expect_any_instance_of(Stash::Aws::S3).not_to receive(:delete_file)
         @files2[1].smart_destroy!
         @resource2.reload
         expect(@resource2.data_files.map(&:upload_file_name).include?('noggin2.jpg')).to eq(false)

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -138,10 +138,9 @@ module StashEngine
       end
 
       it 'removes the S3 temporary files when the resource is destroyed' do
-        allow(Stash::Aws::S3).to receive(:delete_dir)
+        expect_any_instance_of(Stash::Aws::S3).to receive(:delete_dir)
         s3_dir = @resource.s3_dir_name(type: 'base')
         @resource.destroy
-        expect(Stash::Aws::S3).to have_received(:delete_dir).with(s3_key: s3_dir)
       end
     end
 

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -139,7 +139,7 @@ module StashEngine
 
       it 'removes the S3 temporary files when the resource is destroyed' do
         expect_any_instance_of(Stash::Aws::S3).to receive(:delete_dir)
-        s3_dir = @resource.s3_dir_name(type: 'base')
+        @resource.s3_dir_name(type: 'base')
         @resource.destroy
       end
     end

--- a/stash/stash-merritt/lib/stash/merritt/object_manifest_package.rb
+++ b/stash/stash-merritt/lib/stash/merritt/object_manifest_package.rb
@@ -29,8 +29,8 @@ module Stash
 
         # Save a copy of the manifest in S3 for debugging if needed, but the actual
         # merritt submission will use the local file
-        Stash::Aws::S3.put(s3_key: "#{resource.s3_dir_name(type: 'manifest')}/manifest.checkm",
-                           contents: manifest.write_to_string)
+        Stash::Aws::S3.new.put(s3_key: "#{resource.s3_dir_name(type: 'manifest')}/manifest.checkm",
+                               contents: manifest.write_to_string)
         manifest_path = workdir_path.join("#{resource_id}-manifest.checkm").to_s
         File.open(manifest_path, 'w') { |f| manifest.write_to(f) }
         manifest_path
@@ -70,7 +70,7 @@ module Stash
 
         file_name = builder.file_name
         OpenStruct.new(
-          file_url: Stash::Aws::S3.presigned_download_url(s3_key: path),
+          file_url: Stash::Aws::S3.new.presigned_download_url(s3_key: path),
           file_name: file_name,
           mime_type: builder.mime_type
         )


### PR DESCRIPTION
Adds an additional bucket config to the yml files.

Refactors all the calls to the S3 wrapper library we use to be an instance rather than a static object. Default of `new` is to create based on the temp storage bucket.  Otherwise pass a parameter for the bucket and it will use a different one.

A bunch of tests broke and had to add different ways to update the mocks.

I believe I got all the places where this library is called and it's a lot more places than I thought.