### PR TITLE
Dryad owned bucket for dev deposited to by Merritt

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -14,7 +14,7 @@ defaults: &DEFAULTS
   # sandbox orcid credentials
   repository:
     domain: https://merritt-stage.cdlib.org
-    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev"
+    endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryaddev_3043"
     username: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_username] %>
     password: <%= Rails.application.credentials[Rails.env.to_sym][:merritt_dryaddev_password] %>
   orcid:


### PR DESCRIPTION
Updating to use the cross-account bucket and merritt collection so we can really test the direct S3 functionality in our development environment since we'll need this.