### PR TITLE
Expand journals on the journal page

### DIFF
--- a/app/controllers/stash_engine/journals_controller.rb
+++ b/app/controllers/stash_engine/journals_controller.rb
@@ -16,7 +16,7 @@ module StashEngine
       display_journals = metadata_journals | sponsoring_journals
 
       ord = helpers.sortable_table_order(whitelist: %w[title issn allow_blackout payment_plan_type name])
-      @journals = Journal.joins(:sponsor).where(id: display_journals).order(ord, title: :asc)
+      @journals = Journal.left_outer_joins(:sponsor).where(id: display_journals).order(ord, title: :asc)
 
       respond_to do |format|
         format.html


### PR DESCRIPTION
Curators were having difficulty reconciling journal information for journals that send metadata (integrated), but do not have an active sponsor. 

This allows journals to show on the `/journals` page even if there is no sponsor present.