### PR TITLE
Fix error with rendering resources in the API

### DIFF
--- a/app/models/stash_datacite/resource/dataset_validations.rb
+++ b/app/models/stash_datacite/resource/dataset_validations.rb
@@ -224,7 +224,7 @@ module StashDatacite
         files = @resource.generic_files.newly_created.file_submission
         errored_uploads = []
         files.each do |f|
-          errored_uploads.push(f.upload_file_name) unless Stash::Aws::S3.new.exists?(s3_key: f.calc_s3_path)
+          errored_uploads.push(f.upload_file_name) unless Stash::Aws::S3.new.exists?(s3_key: f.s3_staged_path)
         end
 
         return [] if errored_uploads.empty?

--- a/app/models/stash_engine/data_file.rb
+++ b/app/models/stash_engine/data_file.rb
@@ -18,14 +18,14 @@ module StashEngine
 
       # submitted resources after the current one
       resources = resource.identifier.resources.joins(:current_resource_state)
-                          .where(current_resource_state: { resource_state: 'submitted' } )
-                          .where('stash_engine_resources.id > ?', resource.id)
+        .where(current_resource_state: { resource_state: 'submitted' })
+        .where('stash_engine_resources.id > ?', resource.id)
 
       terminal_file = self
 
       # from relevant resources, same filename
       matching_files = DataFile.where(resource_id: resources.pluck(:id), upload_file_name: upload_file_name)
-                                            .order(id: :asc)
+        .order(id: :asc)
 
       # find the last one that is not deleted or changed
       matching_files.each do |f|
@@ -49,7 +49,7 @@ module StashEngine
     # the permanent storage URL, not the staged storage URL
     def s3_permanent_presigned_url
       Stash::Aws::S3.new(s3_bucket_name: APP_CONFIG[:s3][:merritt_bucket])
-                    .presigned_download_url(s3_key: s3_permanent_path)
+        .presigned_download_url(s3_key: s3_permanent_path)
     end
 
     # http://<merritt-url>/d/<ark>/<version>/<encoded-fn> is an example of the URLs Merritt takes

--- a/app/models/stash_engine/data_file.rb
+++ b/app/models/stash_engine/data_file.rb
@@ -84,7 +84,7 @@ module StashEngine
     #
     # If you use this method, you need to rescue the HTTP::Error and Stash::Download::Merritt errors if you don't want them raised
     def merritt_s3_presigned_url
-      raise Stash::Download::MerrittError, "Tenant not defined for resource_id: #{resource&.id}" if resource&.tenant.blank?
+      raise Stash::Download::S3CustomError, "Tenant not defined for resource_id: #{resource&.id}" if resource&.tenant.blank?
 
       http = HTTP.use(normalize_uri: { normalizer: Stash::Download::NORMALIZER })
         .timeout(connect: 10, read: 10).timeout(10).follow(max_hops: 2)
@@ -94,7 +94,7 @@ module StashEngine
 
       return r.parse.with_indifferent_access[:url] if r.status.success?
 
-      raise Stash::Download::MerrittError,
+      raise Stash::Download::S3CustomError,
             "Merritt couldn't create presigned URL for #{merritt_presign_info_url}\nHttp status code: #{r.status.code}"
     end
 
@@ -117,7 +117,7 @@ module StashEngine
       s3_url = nil
       begin
         s3_url = s3_permanent_presigned_url
-      rescue HTTP::Error, Stash::Download::MerrittError => e
+      rescue HTTP::Error, Stash::Download::S3CustomError => e
         logger.info("Couldn't get presigned for #{inspect}\nwith error #{e}")
       end
 
@@ -141,12 +141,12 @@ module StashEngine
       s3_url = nil
       begin
         s3_url = (file_state == 'copied' && last_version_file && last_version_file&.s3_permanent_presigned_url) || nil
-      rescue HTTP::Error, Stash::Download::MerrittError => e
+      rescue HTTP::Error, Stash::Download::S3CustomError => e
         logger.info("Couldn't get presigned for #{inspect}\nwith error #{e}")
       end
       begin
         s3_url = s3_permanent_presigned_url if s3_url.nil?
-      rescue HTTP::Error, Stash::Download::MerrittError => e
+      rescue HTTP::Error, Stash::Download::S3CustomError => e
         logger.info("Couldn't get presigned for #{inspect}\nwith error #{e}")
       end
       s3_url = s3_staged_presigned_url if s3_url.nil?

--- a/app/models/stash_engine/data_file.rb
+++ b/app/models/stash_engine/data_file.rb
@@ -3,7 +3,7 @@ module StashEngine
   class DataFile < GenericFile
     has_many :container_files, class_name: 'StashEngine::ContainerFile', dependent: :delete_all
 
-    def calc_s3_path
+    def s3_staged_path
       return nil if file_state == 'copied' || file_state == 'deleted' # no current file to have a path for
 
       "#{resource.s3_dir_name(type: 'data')}/#{upload_file_name}"
@@ -57,7 +57,7 @@ module StashEngine
 
     # the presigned URL for a file that was "directly" uploaded to Dryad,
     # rather than a file that was indicated by a URL reference
-    def direct_s3_presigned_url
+    def s3_staged_presigned_url
       Stash::Aws::S3.new.presigned_download_url(s3_key: "#{resource.s3_dir_name(type: 'data')}/#{upload_file_name}")
     end
 
@@ -106,7 +106,7 @@ module StashEngine
       rescue HTTP::Error, Stash::Download::MerrittError => e
         logger.info("Couldn't get presigned for #{inspect}\nwith error #{e}")
       end
-      s3_url = direct_s3_presigned_url if s3_url.nil?
+      s3_url = s3_staged_presigned_url if s3_url.nil?
 
       return nil if s3_url.nil?
 

--- a/app/models/stash_engine/data_file.rb
+++ b/app/models/stash_engine/data_file.rb
@@ -9,6 +9,12 @@ module StashEngine
       "#{resource.s3_dir_name(type: 'data')}/#{upload_file_name}"
     end
 
+    def s3_permanent_path
+      return nil if file_state == 'deleted' # no current file to have a path for
+
+
+    endb
+
     # http://<merritt-url>/d/<ark>/<version>/<encoded-fn> is an example of the URLs Merritt takes
     def merritt_url
       domain, ark = resource.merritt_protodomain_and_local_id

--- a/app/models/stash_engine/data_file.rb
+++ b/app/models/stash_engine/data_file.rb
@@ -20,8 +20,7 @@ module StashEngine
 
       # this gets the last time this file was in a previous version in the "created" state ie. the last creation
       DataFile.where(resource_id: resources.pluck(:id), upload_file_name: upload_file_name,
-                                      file_state: 'created').order(id: :desc).first
-
+                     file_state: 'created').order(id: :desc).first
     end
 
     # permanent storage rather than staging path

--- a/app/models/stash_engine/data_file.rb
+++ b/app/models/stash_engine/data_file.rb
@@ -107,7 +107,7 @@ module StashEngine
     # the URL we use for replication to zenodo, for software it's always the merritt url, but for software we have the same
     # method but switches between S3 and external URL depending on source
     def zenodo_replication_url
-      merritt_s3_presigned_url
+      s3_permanent_presigned_url
     end
 
     # gets the S3 presigned and loads in only the first few kilobytes of the file rather than all of it and returns
@@ -116,7 +116,7 @@ module StashEngine
       # get the presigned URL
       s3_url = nil
       begin
-        s3_url = merritt_s3_presigned_url
+        s3_url = s3_permanent_presigned_url
       rescue HTTP::Error, Stash::Download::MerrittError => e
         logger.info("Couldn't get presigned for #{inspect}\nwith error #{e}")
       end
@@ -140,12 +140,12 @@ module StashEngine
       # get the presigned URL
       s3_url = nil
       begin
-        s3_url = (file_state == 'copied' && last_version_file && last_version_file&.merritt_s3_presigned_url) || nil
+        s3_url = (file_state == 'copied' && last_version_file && last_version_file&.s3_permanent_presigned_url) || nil
       rescue HTTP::Error, Stash::Download::MerrittError => e
         logger.info("Couldn't get presigned for #{inspect}\nwith error #{e}")
       end
       begin
-        s3_url = merritt_s3_presigned_url if s3_url.nil?
+        s3_url = s3_permanent_presigned_url if s3_url.nil?
       rescue HTTP::Error, Stash::Download::MerrittError => e
         logger.info("Couldn't get presigned for #{inspect}\nwith error #{e}")
       end

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -3,6 +3,7 @@ require 'stash/aws/s3'
 require 'stash/indexer/solr_indexer'
 # the following is required to make our wonky tests work and may break if we move stuff around
 require_relative '../../../lib/stash/indexer/indexing_resource'
+require 'cgi'
 
 module StashEngine
   class Resource < ApplicationRecord # rubocop:disable Metrics/ClassLength
@@ -414,6 +415,12 @@ module StashEngine
 
       matches = download_uri.match(%r{^(https*://[^/]+)/d/(\S+)$})
       [matches[1], matches[2]]
+    end
+
+    def merritt_ark
+      item = merritt_protodomain_and_local_id
+
+      CGI.unescape(item[1])
     end
 
     # ------------------------------------------------------------

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -886,10 +886,10 @@ module StashEngine
       edits = []
       edits << { deleted: other_authors.length - authors.length } if other_authors.length > authors.length
       this_authors = authors.map do |a|
-        { author_full_name: a.author_full_name, affiliation: "#{a.affiliation.long_name}#{a.affiliation.ror_id}", email: a.author_email }
+        { author_full_name: a.author_full_name, affiliation: "#{a.affiliation&.long_name}#{a.affiliation&.ror_id}", email: a.author_email }
       end
       that_authors = other_authors.map do |a|
-        { author_full_name: a.author_full_name, affiliation: "#{a.affiliation.long_name}#{a.affiliation.ror_id}", email: a.author_email }
+        { author_full_name: a.author_full_name, affiliation: "#{a.affiliation&.long_name}#{a.affiliation&.ror_id}", email: a.author_email }
       end
       this_authors.each_with_index do |a, i|
         diff = a.diff(that_authors[i] || {})

--- a/app/models/stash_engine/software_file.rb
+++ b/app/models/stash_engine/software_file.rb
@@ -1,7 +1,7 @@
 module StashEngine
   class SoftwareFile < GenericFile
 
-    def calc_s3_path
+    def s3_staged_path
       return nil if file_state == 'copied' || file_state == 'deleted' # no current file to have a path for
 
       "#{resource.s3_dir_name(type: 'software')}/#{upload_file_name}"
@@ -24,14 +24,14 @@ module StashEngine
 
     # the presigned URL for a file that was "directly" uploaded to Dryad,
     # rather than a file that was indicated by a URL reference
-    def direct_s3_presigned_url
+    def s3_staged_presigned_url
       Stash::Aws::S3.new.presigned_download_url(s3_key: "#{resource.s3_dir_name(type: 'software')}/#{upload_file_name}")
     end
 
     # the URL we use for replication from other source (Presigned or URL) up to Zenodo
     def zenodo_replication_url
       if url.blank?
-        direct_s3_presigned_url
+        s3_staged_presigned_url
       else
         url
       end

--- a/app/models/stash_engine/supp_file.rb
+++ b/app/models/stash_engine/supp_file.rb
@@ -1,7 +1,7 @@
 module StashEngine
   class SuppFile < GenericFile
 
-    def calc_s3_path
+    def s3_staged_path
       return nil if file_state == 'copied' || file_state == 'deleted' # no current file to have a path for
 
       "#{resource.s3_dir_name(type: 'supplemental')}/#{upload_file_name}"
@@ -24,14 +24,14 @@ module StashEngine
 
     # the presigned URL for a file that was "directly" uploaded to Dryad,
     # rather than a file that was indicated by a URL reference
-    def direct_s3_presigned_url
+    def s3_staged_presigned_url
       Stash::Aws::S3.new.presigned_download_url(s3_key: "#{resource.s3_dir_name(type: 'supplemental')}/#{upload_file_name}")
     end
 
     # the URL we use for replication from other source (Presigned or URL) up to Zenodo
     def zenodo_replication_url
       if url.blank?
-        direct_s3_presigned_url
+        s3_staged_presigned_url
       else
         url
       end

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -165,7 +165,7 @@ defaults: &DEFAULTS
   s3:
     region: us-west-2
     bucket: dryad-s3-dev
-    merritt_bucket: dryad-assetstore-merritt-stage
+    merritt_bucket: dryad-assetstore-merritt-stage2
     key: AKIA2KERHV5E3OITXZXC
     secret: <%= Rails.application.credentials[Rails.env.to_sym][:s3_secret] %>
   google_analytics_id: null

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -165,7 +165,7 @@ defaults: &DEFAULTS
   s3:
     region: us-west-2
     bucket: dryad-s3-dev
-    merritt_bucket: dryad-assetstore-merritt-stage2
+    merritt_bucket: dryad-assetstore-merritt-dev
     key: AKIA2KERHV5E3OITXZXC
     secret: <%= Rails.application.credentials[Rails.env.to_sym][:s3_secret] %>
   google_analytics_id: null

--- a/lib/stash/compressed/tar_gz.rb
+++ b/lib/stash/compressed/tar_gz.rb
@@ -4,7 +4,7 @@ require 'open3'
 
 # test with files 14139 and 14140
 # df = StashEngine::DataFile.find(14139)
-# tgz = Stash::Compressed::TarGz.new(presigned_url: df.merritt_s3_presigned_url)
+# tgz = Stash::Compressed::TarGz.new(presigned_url: df.s3_permanent_presigned_url)
 # tgz.file_entries
 
 module Stash

--- a/lib/stash/download/file_presigned.rb
+++ b/lib/stash/download/file_presigned.rb
@@ -6,7 +6,7 @@ require 'http'
 module Stash
   module Download
 
-    class MerrittError < StandardError; end
+    class S3CustomError < StandardError; end
 
     class FilePresigned
       attr_reader :cc
@@ -29,7 +29,7 @@ module Stash
 
         cc.redirect_to url
       rescue HTTP::Error => e
-        raise MerrittError, "HTTP Error while creating presigned URL from S3\n" \
+        raise S3CustomError, "HTTP Error while creating presigned URL from S3\n" \
                             "#{file.merritt_presign_info_url}\n" \
                             "Original HTTP library error: #{e}\n" \
                             "#{e.full_message}"

--- a/lib/stash/download/file_presigned.rb
+++ b/lib/stash/download/file_presigned.rb
@@ -25,11 +25,11 @@ module Stash
           return
         end
 
-        url = file.merritt_s3_presigned_url
+        url = file.s3_permanent_presigned_url
 
         cc.redirect_to url
       rescue HTTP::Error => e
-        raise MerrittError, "HTTP Error while creating presigned URL with Merritt\n" \
+        raise MerrittError, "HTTP Error while creating presigned URL from S3\n" \
                             "#{file.merritt_presign_info_url}\n" \
                             "Original HTTP library error: #{e}\n" \
                             "#{e.full_message}"

--- a/lib/stash/download/file_presigned.rb
+++ b/lib/stash/download/file_presigned.rb
@@ -30,9 +30,9 @@ module Stash
         cc.redirect_to url
       rescue HTTP::Error => e
         raise S3CustomError, "HTTP Error while creating presigned URL from S3\n" \
-                            "#{file.merritt_presign_info_url}\n" \
-                            "Original HTTP library error: #{e}\n" \
-                            "#{e.full_message}"
+                             "#{file.merritt_presign_info_url}\n" \
+                             "Original HTTP library error: #{e}\n" \
+                             "#{e.full_message}"
       end
     end
   end

--- a/lib/stash/merritt_download.rb
+++ b/lib/stash/merritt_download.rb
@@ -1,5 +1,0 @@
-module Stash
-  module MerrittDownload
-    Dir.glob(::File.expand_path('merritt_download/*.rb', __dir__)).each(&method(:require))
-  end
-end

--- a/lib/stash/merritt_download/file.rb
+++ b/lib/stash/merritt_download/file.rb
@@ -22,7 +22,7 @@ module Stash
 
       # download file a and return a hash, we should be tracking success routinely since downloads are error-prone
       def download_file(db_file:)
-        s3_resp = get_url(url: db_file.merritt_s3_presigned_url)
+        s3_resp = get_url(url: db_file.s3_permanent_presigned_url)
 
         unless s3_resp.status.success?
           return { success: false,

--- a/lib/stash/s3_download.rb
+++ b/lib/stash/s3_download.rb
@@ -1,0 +1,5 @@
+module Stash
+  module S3Download
+    Dir.glob(::File.expand_path('s3_download/*.rb', __dir__)).each(&method(:require))
+  end
+end

--- a/lib/stash/s3_download/file.rb
+++ b/lib/stash/s3_download/file.rb
@@ -64,7 +64,7 @@ module Stash
 
         if (db_file.digest_type == 'md5' && db_file.digest != md5_hex) ||
             (db_file.digest_type == 'sha-256' && db_file.digest != sha_256_hex)
-          raise Stash::MerrittDownload::DownloadError, "Digest for downloaded file doesn't match database value. File.id: #{db_file.id}"
+          raise Stash::S3Download::DownloadError, "Digest for downloaded file doesn't match database value. File.id: #{db_file.id}"
         end
 
         { md5_hex: md5_hex, sha256_hex: sha256_hex }

--- a/lib/stash/s3_download/file.rb
+++ b/lib/stash/s3_download/file.rb
@@ -7,7 +7,7 @@ require 'fileutils'
 require 'stash/download'
 
 module Stash
-  module S3Download
+  module S3Download # was MerrittDownload
 
     # calling this class File means we need to namespace the built-in Ruby file class when calling it in here
     class File

--- a/lib/stash/s3_download/file.rb
+++ b/lib/stash/s3_download/file.rb
@@ -7,7 +7,7 @@ require 'fileutils'
 require 'stash/download'
 
 module Stash
-  module MerrittDownload
+  module S3Download
 
     # calling this class File means we need to namespace the built-in Ruby file class when calling it in here
     class File

--- a/lib/stash/s3_download/file.rb
+++ b/lib/stash/s3_download/file.rb
@@ -45,8 +45,8 @@ module Stash
         get_digests(md5_obj: md5, sha256_obj: sha256, db_file: db_file).merge(success: true)
       rescue HTTP::Error => e
         { success: false, error: "Error downloading file for resource #{@resource.id}\nHTTP::Error #{e}" }
-      rescue Stash::Download::MerrittError => e
-        { success: false, error: "Error downloading file for resource #{@resource.id}\nMerrittError: #{e}" }
+      rescue Stash::Download::S3CustomError => e
+        { success: false, error: "Error downloading file for resource #{@resource.id}\nS3CustomError: #{e}" }
       end
 
       # gets the file url and returns an HTTP.get(url) response object

--- a/lib/stash/s3_download/file_collection.rb
+++ b/lib/stash/s3_download/file_collection.rb
@@ -19,7 +19,7 @@ module Stash
         FileUtils.mkdir_p(@path) # makes entire path to this file if is needed
 
         # sets up file download stuff for a resource, but different method for each file download
-        @smdf = Stash::MerrittDownload::File.new(resource: @resource, path: @path)
+        @smdf = Stash::S3Download::File.new(resource: @resource, path: @path)
 
         # Set info hash as files are downloaded.  key=filename, value = { success: <t/f>, sha256_digest:, md5_digest: }.
         # Unsuccessful files raise DownloadError.
@@ -32,7 +32,7 @@ module Stash
 
         copy_files.each do |f|
           status = @smdf.download_file(db_file: f)
-          raise Stash::MerrittDownload::DownloadError, "Download: #{status[:error]}\nfile.id #{f.id}" unless status[:success]
+          raise Stash::S3Download::DownloadError, "Download: #{status[:error]}\nfile.id #{f.id}" unless status[:success]
 
           @info_hash[f.upload_file_name] = status
         end

--- a/lib/stash/s3_download/file_collection.rb
+++ b/lib/stash/s3_download/file_collection.rb
@@ -1,7 +1,7 @@
 require 'fileutils'
 
 module Stash
-  module MerrittDownload
+  module S3Download
 
     class DownloadError < StandardError; end
 

--- a/lib/stash/zenodo_replicate/copier.rb
+++ b/lib/stash/zenodo_replicate/copier.rb
@@ -76,7 +76,7 @@ module Stash
         @deposit.publish
         @copy.reload
         @copy.update(state: 'finished', error_info: nil)
-      rescue Stash::MerrittDownload::DownloadError, Stash::ZenodoReplicate::ZenodoError, HTTP::Error => e
+      rescue Stash::S3Download::DownloadError, Stash::ZenodoReplicate::ZenodoError, HTTP::Error => e
         # log this in the database so we can track it
         @copy.reload
         error_info = "#{Time.new} #{e.class}\n#{e}\n---\n#{@copy.error_info}" # append current error info first

--- a/lib/stash/zenodo_replicate/copier.rb
+++ b/lib/stash/zenodo_replicate/copier.rb
@@ -1,4 +1,4 @@
-require 'stash/merritt_download'
+require 'stash/s3_download'
 require 'http'
 require 'stash/zenodo_replicate'
 require 'stash/zenodo_replicate/copier_mixin'

--- a/lib/stash/zenodo_software/streamer.rb
+++ b/lib/stash/zenodo_software/streamer.rb
@@ -79,7 +79,7 @@ module Stash
         end
 
         { response: put_response, digests: digests_obj.hex_digests }
-      rescue Stash::Download::MerrittError => e
+      rescue Stash::Download::S3CustomError => e
         raise Stash::ZenodoReplicate::ZenodoError, "Couldn't create presigned URL for id: #{@file_model.id}, fn: #{@file_model.upload_file_name}\n" \
                                                    "Original error: #{e}\n#{e.full_message}"
       rescue HTTP::Error => e

--- a/lib/tasks/compressed/info.rb
+++ b/lib/tasks/compressed/info.rb
@@ -8,10 +8,10 @@ module Tasks
       def self.files(db_file:)
         entries =
           if db_file.upload_file_name.downcase.end_with?('.zip')
-            zip_info = Stash::Compressed::ZipInfo.new(presigned_url: db_file.merritt_s3_presigned_url)
+            zip_info = Stash::Compressed::ZipInfo.new(presigned_url: db_file.s3_permanent_presigned_url)
             zip_info.entries_with_fallback
           elsif db_file.upload_file_name.downcase.end_with?('.tar.gz', '.tgz')
-            tar_gz_info = Stash::Compressed::TarGz.new(presigned_url: db_file.merritt_s3_presigned_url)
+            tar_gz_info = Stash::Compressed::TarGz.new(presigned_url: db_file.s3_permanent_presigned_url)
             tar_gz_info.entries_with_fallback
           else
             raise Stash::Compressed::Error, "Unknown file type for #{db_file.upload_file_name}"

--- a/lib/tasks/dev_ops/download_s3.rb
+++ b/lib/tasks/dev_ops/download_s3.rb
@@ -10,7 +10,7 @@ module Tasks
       end
 
       def download(file_obj:)
-        dl_url = file_obj.direct_s3_presigned_url
+        dl_url = file_obj.s3_staged_presigned_url
         resp = @http.get(dl_url)
 
         File.binwrite(File.join(@path, file_obj.upload_file_name), resp.body)

--- a/lib/tasks/download_check/merritt.rb
+++ b/lib/tasks/download_check/merritt.rb
@@ -24,7 +24,7 @@ module Tasks
               { doi: identifier.identifier, resource: res.id, file: file.upload_file_name,
                 dl_uri: res.download_uri, error: false }
             )
-          rescue Stash::Download::MerrittError, HTTP::Error => e
+          rescue Stash::Download::S3CustomError, HTTP::Error => e
             @accumulator.push(
               { doi: identifier.identifier, resource: res.id, file: file.upload_file_name,
                 dl_uri: res.download_uri, error: e.to_s }
@@ -68,7 +68,7 @@ module Tasks
               if file.upload_file_size != size
                 save_error(resource: res, file: file, error: "bad content length: db: #{file.upload_file_size} vs s3: #{size}")
               end
-            rescue Stash::Download::MerrittError, HTTP::Error => e
+            rescue Stash::Download::S3CustomError, HTTP::Error => e
               save_error(resource: res, file: file, error: e)
             end
           end

--- a/lib/tasks/download_check/merritt.rb
+++ b/lib/tasks/download_check/merritt.rb
@@ -19,7 +19,7 @@ module Tasks
           next if file.nil?
 
           begin
-            file.merritt_s3_presigned_url
+            file.s3_permanent_presigned_url
             @accumulator.push(
               { doi: identifier.identifier, resource: res.id, file: file.upload_file_name,
                 dl_uri: res.download_uri, error: false }
@@ -55,7 +55,7 @@ module Tasks
               sleep 0.01 while Time.new - last_query_time < 0.05
               last_query_time = Time.new
 
-              url = file.merritt_s3_presigned_url
+              url = file.s3_permanent_presigned_url
 
               resp = @http.get(url)
               size = resp.headers['Content-Length']&.to_i || 0

--- a/spec/lib/stash/download/file_presigned_spec.rb
+++ b/spec/lib/stash/download/file_presigned_spec.rb
@@ -43,22 +43,6 @@ module Stash
           expect(@controller_context).to receive(:render)
           @fp.download(file: nil)
         end
-
-        it 'raises an error for bad status response from Merritt' do
-          remove_request_stub(@stubby)
-
-          stub_request(:get, @data_file.merritt_presign_info_url)
-            .with(
-              headers: {
-                'Authorization' => 'Basic aG9yc2VjYXQ6TXlIb3JzZUNhdFBhc3N3b3Jk',
-                'Host' => 'merritt-fake.cdlib.org'
-              }
-            )
-            .to_return(status: 500, body: '{"url":"https://my.testing.url.example.com"}',
-                       headers: { 'Content-Type' => 'application/json' })
-
-          expect { @fp.download(file: @data_file) }.to raise_error(Stash::Download::MerrittError)
-        end
       end
     end
   end

--- a/spec/lib/stash/s3_download/file_collection_spec.rb
+++ b/spec/lib/stash/s3_download/file_collection_spec.rb
@@ -39,32 +39,17 @@ module Stash
         end
 
         it 'raises an exception for S3 download errors' do
-          stub_request(:get, %r{http://merritt-fake\.cdlib\.org/api/presign-file/.+})
+          stub_request(:get, %r{https://a-merritt-test-bucket.s3.us-west-2.amazonaws.com/ark+.})
             .to_return(status: 404, body: '', headers: {})
-          expect { @fc.download_files }.to raise_error(Stash::S3Download::DownloadError)
-        end
-
-        it 'raises an exception for S3 download errors' do
-          # first return from Merritt
-          stub_request(:get, @data_file.merritt_presign_info_url).to_return(status: 200,
-                                                                            body: '{"url": "http://presigned.example.com/is/great/39768945"}',
-                                                                            headers: { 'Content-Type': 'application/json' })
-
-          stub_request(:get, 'http://presigned.example.com/is/great/39768945')
-            .to_return(status: 404, body: '', headers: {})
-
           expect { @fc.download_files }.to raise_error(Stash::S3Download::DownloadError)
         end
 
         it 'sets up info_hash on success' do
-          # first return from Merritt
-          stub_request(:get, @data_file.merritt_presign_info_url).to_return(status: 200,
-                                                                            body: '{"url": "http://presigned.example.com/is/great/39768945"}',
-                                                                            headers: { 'Content-Type': 'application/json' })
-
-          stub_request(:get, 'http://presigned.example.com/is/great/39768945')
+          stub_request(:get, %r{https://a-merritt-test-bucket.s3.us-west-2.amazonaws.com/ark+.})
             .to_return(status: 200, body: '', headers: {})
+
           @fc.download_files
+
           expect(@fc.info_hash.keys).to include(@data_file.upload_file_name)
         end
       end

--- a/spec/lib/stash/s3_download/file_collection_spec.rb
+++ b/spec/lib/stash/s3_download/file_collection_spec.rb
@@ -1,6 +1,6 @@
 # testing in here since testing is much better with real loading of the engines and application without wonky problems
 # from the manual setup that doesn't really load rails right in the engines
-require 'stash/merritt_download'
+require 'stash/s3_download'
 require 'byebug'
 require 'http'
 require 'fileutils'

--- a/spec/lib/stash/s3_download/file_collection_spec.rb
+++ b/spec/lib/stash/s3_download/file_collection_spec.rb
@@ -8,7 +8,7 @@ require 'fileutils'
 RSpec.configure(&:infer_spec_type_from_file_location!)
 
 module Stash
-  module MerrittDownload
+  module S3Download
     RSpec.describe FileCollection do
 
       include Mocks::Tenant
@@ -38,10 +38,10 @@ module Stash
           @data_file = create(:data_file, resource_id: @resource.id)
         end
 
-        it 'raises an exception for Merritt download errors' do
+        it 'raises an exception for S3 download errors' do
           stub_request(:get, %r{http://merritt-fake\.cdlib\.org/api/presign-file/.+})
             .to_return(status: 404, body: '', headers: {})
-          expect { @fc.download_files }.to raise_error(Stash::MerrittDownload::DownloadError)
+          expect { @fc.download_files }.to raise_error(Stash::S3Download::DownloadError)
         end
 
         it 'raises an exception for S3 download errors' do
@@ -53,7 +53,7 @@ module Stash
           stub_request(:get, 'http://presigned.example.com/is/great/39768945')
             .to_return(status: 404, body: '', headers: {})
 
-          expect { @fc.download_files }.to raise_error(Stash::MerrittDownload::DownloadError)
+          expect { @fc.download_files }.to raise_error(Stash::S3Download::DownloadError)
         end
 
         it 'sets up info_hash on success' do

--- a/spec/lib/stash/s3_download/file_spec.rb
+++ b/spec/lib/stash/s3_download/file_spec.rb
@@ -10,7 +10,7 @@ require 'rails_helper'
 RSpec.configure(&:infer_spec_type_from_file_location!)
 
 module Stash
-  module MerrittDownload
+  module S3Download
     RSpec.describe File do
       include Mocks::Tenant
 
@@ -18,7 +18,7 @@ module Stash
         mock_tenant!
         @resource = create(:resource)
         @data_file = create(:data_file, resource_id: @resource.id)
-        @file_dl_obj = Stash::MerrittDownload::File.new(resource: @resource, path: Rails.root.join('upload', 'zenodo_replication'))
+        @file_dl_obj = Stash::S3Download::File.new(resource: @resource, path: Rails.root.join('upload', 'zenodo_replication'))
       end
 
       after(:each) do
@@ -142,7 +142,7 @@ module Stash
                                                                                          body: 'The cat meows in my face.',
                                                                                          headers: {})
 
-          expect { @file_dl_obj.download_file(db_file: @data_file) }.to raise_error(Stash::MerrittDownload::DownloadError)
+          expect { @file_dl_obj.download_file(db_file: @data_file) }.to raise_error(Stash::S3Download::DownloadError)
         end
       end
 

--- a/spec/lib/stash/s3_download/file_spec.rb
+++ b/spec/lib/stash/s3_download/file_spec.rb
@@ -1,6 +1,6 @@
 # testing in here since testing is much better with real loading of the engines and application without wonky problems
 # from the manual setup that doesn't really load rails right in the engines
-require 'stash/merritt_download'
+require 'stash/s3_download'
 require 'byebug'
 require 'http'
 require 'fileutils'

--- a/spec/lib/stash/zenodo_software/streamer_spec.rb
+++ b/spec/lib/stash/zenodo_software/streamer_spec.rb
@@ -95,7 +95,13 @@ module Stash
         end
 
         it 'raises Stash::ZenodoReplicate::ZenodoError for handling with S3CustomErrors' do
-          stub_request(:get, /merritt-fake/).to_return(status: 404, body: '', headers: {})
+          stub_request(:get, %r{https://a-merritt-test-bucket.s3.us-west-2.amazonaws.com/ark+.})
+            .to_return(status: 200, body: '', headers: {})
+
+          stub_request(:put, %r{https://example.org/my/great/test/bucket/.+})
+            .to_return(status: 404, body: "", headers: {})
+
+          # stub_request(:get, /merritt-fake/).to_return(status: 404, body: '', headers: {})
           @resource.data_files << create(:data_file)
           data_file = @resource.data_files.first
 

--- a/spec/lib/stash/zenodo_software/streamer_spec.rb
+++ b/spec/lib/stash/zenodo_software/streamer_spec.rb
@@ -94,12 +94,12 @@ module Stash
           end.to raise_exception(Stash::ZenodoReplicate::ZenodoError)
         end
 
-        it 'raises Stash::ZenodoReplicate::ZenodoError for handling with MerrittErrors' do
+        it 'raises Stash::ZenodoReplicate::ZenodoError for handling with S3CustomErrors' do
           stub_request(:get, /merritt-fake/).to_return(status: 404, body: '', headers: {})
           @resource.data_files << create(:data_file)
           data_file = @resource.data_files.first
 
-          # allow(data_file).to receive(:zenodo_replication_url).and_raise(Stash::Download::MerrittError, "can't create presigned url")
+          # allow(data_file).to receive(:zenodo_replication_url).and_raise(Stash::Download::S3CustomError, "can't create presigned url")
           @streamer = Streamer.new(file_model: data_file, zenodo_bucket_url: @bucket_url, zc_id: @zenodo_copy.id)
 
           expect do

--- a/spec/lib/stash/zenodo_software/streamer_spec.rb
+++ b/spec/lib/stash/zenodo_software/streamer_spec.rb
@@ -99,7 +99,7 @@ module Stash
             .to_return(status: 200, body: '', headers: {})
 
           stub_request(:put, %r{https://example.org/my/great/test/bucket/.+})
-            .to_return(status: 404, body: "", headers: {})
+            .to_return(status: 404, body: '', headers: {})
 
           # stub_request(:get, /merritt-fake/).to_return(status: 404, body: '', headers: {})
           @resource.data_files << create(:data_file)

--- a/spec/models/stash_datacite/dataset_validations_spec.rb
+++ b/spec/models/stash_datacite/dataset_validations_spec.rb
@@ -185,7 +185,7 @@ module StashDatacite
       describe :s3_error_uploads do
         it 'returns missing files when files uploaded to s3 are not present' do
           files = @resource.generic_files
-          files.map(&:calc_s3_path).each do |s3_path|
+          files.map(&:s3_staged_path).each do |s3_path|
             allow_any_instance_of(Stash::Aws::S3).to receive('exists?').with(s3_key: s3_path).and_return(false)
           end
 
@@ -199,7 +199,7 @@ module StashDatacite
         end
 
         it 'does not check missing files once Merritt processing is complete' do
-          @resource.generic_files.map(&:calc_s3_path).each do |s3_path|
+          @resource.generic_files.map(&:s3_staged_path).each do |s3_path|
             allow_any_instance_of(Stash::Aws::S3).to receive('exists?').with(s3_key: s3_path).and_return(false)
           end
           allow(@resource).to receive('submitted?').and_return(true)
@@ -214,7 +214,7 @@ module StashDatacite
           @resource.generic_files.second.update(file_state: 'copied')
           @resource.generic_files.third.update(url: 'http://example.com')
           @resource.generic_files.fourth.update(file_state: 'copied')
-          @resource.generic_files.map(&:calc_s3_path).each do |s3_path|
+          @resource.generic_files.map(&:s3_staged_path).each do |s3_path|
             allow_any_instance_of(Stash::Aws::S3).to receive('exists?').with(s3_key: s3_path).and_return(false)
           end
 

--- a/spec/models/stash_engine/data_file_spec.rb
+++ b/spec/models/stash_engine/data_file_spec.rb
@@ -148,13 +148,13 @@ module StashEngine
         allow(Tenant).to receive(:find).with('ucop').and_return(tenant)
       end
 
-      it 'raises Stash::Download::MerrittError for missing resource.tenant' do
+      it 'raises Stash::Download::S3CustomError for missing resource.tenant' do
         @upload.resource.update(tenant_id: nil)
         @upload.resource.reload
-        expect { @upload.merritt_s3_presigned_url }.to raise_error(Stash::Download::MerrittError)
+        expect { @upload.merritt_s3_presigned_url }.to raise_error(Stash::Download::S3CustomError)
       end
 
-      it 'raises Stash::Download::MerrittError for unsuccessful response from Merritt' do
+      it 'raises Stash::Download::S3CustomError for unsuccessful response' do
         stub_request(:get, 'https://merritt.example.com/api/presign-file/ark:%2F12345%2F38568/1/producer%2Ffoo.bar?no_redirect=true')
           .with(
             headers: {
@@ -163,7 +163,7 @@ module StashEngine
             }
           )
           .to_return(status: 404, body: '[]', headers: { 'Content-Type': 'application/json' })
-        expect { @upload.merritt_s3_presigned_url }.to raise_error(Stash::Download::MerrittError)
+        expect { @upload.merritt_s3_presigned_url }.to raise_error(Stash::Download::S3CustomError)
       end
 
       it 'returns a URL based on json response and url in the data' do

--- a/spec/models/stash_engine/data_file_spec.rb
+++ b/spec/models/stash_engine/data_file_spec.rb
@@ -97,9 +97,9 @@ module StashEngine
       end
     end
 
-    describe :calc_s3_path do
+    describe :s3_staged_path do
       it 'returns path in uploads containing resource_id and filename' do
-        cs3p = @upload.calc_s3_path
+        cs3p = @upload.s3_staged_path
         expect(cs3p).to end_with('/data/foo.bar')
         expect(cs3p).to include(@resource.id.to_s)
       end
@@ -107,13 +107,13 @@ module StashEngine
       it 'returns nil if it is copied' do
         @upload.update(file_state: 'copied')
         @upload.reload
-        expect(@upload.calc_s3_path).to eq(nil)
+        expect(@upload.s3_staged_path).to eq(nil)
       end
 
       it 'returns nil if it is deleted' do
         @upload.update(file_state: 'deleted')
         @upload.reload
-        expect(@upload.calc_s3_path).to eq(nil)
+        expect(@upload.s3_staged_path).to eq(nil)
       end
     end
 

--- a/spec/models/stash_engine/data_file_spec.rb
+++ b/spec/models/stash_engine/data_file_spec.rb
@@ -350,49 +350,60 @@ module StashEngine
     end
 
     # finds the last instance of the file from possibly multiple versions for forward delta deduplication
-    describe :last_unchanged_permanent_file do
-      it 'returns the last permanent file that was not changed for one version' do
+    describe :original_deposit_file do
+      it 'returns the current file if only one version' do
         @resource.current_resource_state.update(resource_state: 'submitted')
-        expect(@upload.last_unchanged_permanent_file).to eq(@upload)
+        expect(@upload.original_deposit_file).to eq(@upload)
       end
 
-      it 'returns the last file from a series of versions that were not changed' do
+      it 'returns the first file from a series of versions that were not changed' do
         @resource.current_resource_state.update(resource_state: 'submitted')
+
         @resource2 = create(:resource, user: @user, tenant_id: 'ucop', identifier: @identifier)
         @resource2.current_resource_state.update(resource_state: 'submitted')
         @file2 = create(:data_file, resource: @resource2, file_state: 'copied', upload_file_name: 'foo.bar')
+
         @resource3 = create(:resource, user: @user, tenant_id: 'ucop', identifier: @identifier)
         @resource3.current_resource_state.update(resource_state: 'submitted')
         @file3 = create(:data_file, resource: @resource3, file_state: 'copied', upload_file_name: 'foo.bar')
 
-        expect(@upload.last_unchanged_permanent_file).to eq(@file3)
+        expect(@file3.original_deposit_file).to eq(@upload)
       end
 
-      it 'returns the next to last file from a series of versions when last was deleted' do
+      it 'returns last uploaded submission, not the original submission' do
         @resource.current_resource_state.update(resource_state: 'submitted')
+
         @resource2 = create(:resource, user: @user, tenant_id: 'ucop', identifier: @identifier)
         @resource2.current_resource_state.update(resource_state: 'submitted')
-        @file2 = create(:data_file, resource: @resource2, file_state: 'copied', upload_file_name: 'foo.bar')
+        @file2 = create(:data_file, resource: @resource2, file_state: 'deleted', upload_file_name: 'foo.bar')
+
         @resource3 = create(:resource, user: @user, tenant_id: 'ucop', identifier: @identifier)
         @resource3.current_resource_state.update(resource_state: 'submitted')
-        @file3 = create(:data_file, resource: @resource3, file_state: 'deleted', upload_file_name: 'foo.bar')
+        @file3 = create(:data_file, resource: @resource3, file_state: 'created', upload_file_name: 'foo.bar')
 
-        expect(@upload.last_unchanged_permanent_file).to eq(@file2)
-      end
-
-      it 'returns version 2 from a series of versions when it was deleted in v3 and added in v4' do
-        @resource.current_resource_state.update(resource_state: 'submitted')
-        @resource2 = create(:resource, user: @user, tenant_id: 'ucop', identifier: @identifier)
-        @resource2.current_resource_state.update(resource_state: 'submitted')
-        @file2 = create(:data_file, resource: @resource2, file_state: 'copied', upload_file_name: 'foo.bar')
-        @resource3 = create(:resource, user: @user, tenant_id: 'ucop', identifier: @identifier)
-        @resource3.current_resource_state.update(resource_state: 'submitted')
-        @file3 = create(:data_file, resource: @resource3, file_state: 'deleted', upload_file_name: 'foo.bar')
         @resource4 = create(:resource, user: @user, tenant_id: 'ucop', identifier: @identifier)
         @resource4.current_resource_state.update(resource_state: 'submitted')
-        @file4 = create(:data_file, resource: @resource3, file_state: 'created', upload_file_name: 'foo.bar')
+        @file4 = create(:data_file, resource: @resource4, file_state: 'copied', upload_file_name: 'foo.bar')
 
-        expect(@upload.last_unchanged_permanent_file).to eq(@file2)
+        expect(@file4.original_deposit_file).to eq(@file3)
+      end
+
+      it 'returns last submission if submitted last even if other stuff before' do
+        @resource.current_resource_state.update(resource_state: 'submitted')
+
+        @resource2 = create(:resource, user: @user, tenant_id: 'ucop', identifier: @identifier)
+        @resource2.current_resource_state.update(resource_state: 'submitted')
+        @file2 = create(:data_file, resource: @resource2, file_state: 'copied', upload_file_name: 'foo.bar')
+
+        @resource3 = create(:resource, user: @user, tenant_id: 'ucop', identifier: @identifier)
+        @resource3.current_resource_state.update(resource_state: 'submitted')
+        @file3 = create(:data_file, resource: @resource3, file_state: 'copied', upload_file_name: 'foo.bar')
+
+        @resource4 = create(:resource, user: @user, tenant_id: 'ucop', identifier: @identifier)
+        @resource4.current_resource_state.update(resource_state: 'submitted')
+        @file4 = create(:data_file, resource: @resource4, file_state: 'created', upload_file_name: 'foo.bar')
+
+        expect(@file4.original_deposit_file).to eq(@file4)
       end
     end
 

--- a/spec/models/stash_engine/data_file_spec.rb
+++ b/spec/models/stash_engine/data_file_spec.rb
@@ -235,7 +235,7 @@ module StashEngine
     describe '#zenodo_replication_url' do
       it 'always replicates urls from merritt for Zenodo data copies' do
         fu = @resource.data_files.first
-        expect(fu).to receive(:merritt_s3_presigned_url).and_return(nil)
+        expect(fu).to receive(:s3_permanent_presigned_url).and_return(nil)
         fu.zenodo_replication_url
       end
     end
@@ -247,39 +247,16 @@ module StashEngine
                           file_state: 'created',
                           upload_file_name: 'mytest.csv')
       end
-      it 'returns nil without being able to get presigned url' do
-        stub_request(:get, %r{merritt-fake.cdlib.org/api/presign-file/})
-          .with(headers: { 'Host' => 'merritt-fake.cdlib.org' })
-          .to_return(status: 404, body: '', headers: {})
-
-        expect(@upload2.preview_file).to be_nil
-      end
 
       it 'returns nil if unable to retrieve range of S3 file' do
-        # stubbing a request to merritt for presigned URL
-        stub_request(:get, %r{merritt-fake.cdlib.org/api/presign-file/})
-          .with(headers: { 'Host' => 'merritt-fake.cdlib.org' })
-          .to_return(status: 200, body: File.read('spec/fixtures/http_responses/mrt_presign.json'),
-                     headers: { 'Content-Type' => 'application/json' })
-
-        # stubbing the S3 request as a 404
-        stub_request(:get, %r{uc3-s3mrt5001-stg.s3.us-west-2.amazonaws.com/ark})
-          .with(headers: { 'Host' => 'uc3-s3mrt5001-stg.s3.us-west-2.amazonaws.com' })
+        stub_request(:get, %r{https://a-merritt-test-bucket.s3.us-west-2.amazonaws.com/ark+.})
           .to_return(status: 404, body: '', headers: {})
 
         expect(@upload2.preview_file).to be_nil
       end
 
       it 'returns content if successful request for http URL' do
-        # stubbing a request to merritt for presigned URL
-        stub_request(:get, %r{merritt-fake.cdlib.org/api/presign-file/})
-          .with(headers: { 'Host' => 'merritt-fake.cdlib.org' })
-          .to_return(status: 200, body: File.read('spec/fixtures/http_responses/mrt_presign.json'),
-                     headers: { 'Content-Type' => 'application/json' })
-
-        # stubbing the S3 request
-        stub_request(:get, %r{uc3-s3mrt5001-stg.s3.us-west-2.amazonaws.com/ark})
-          .with(headers: { 'Host' => 'uc3-s3mrt5001-stg.s3.us-west-2.amazonaws.com' })
+        stub_request(:get, %r{https://a-merritt-test-bucket.s3.us-west-2.amazonaws.com/ark+.})
           .to_return(status: 200, body: "This,is,my,great,csv\n0,1,2,3,4", headers: {})
 
         expect(@upload2.preview_file).to eql("This,is,my,great,csv\n0,1,2,3,4")
@@ -294,30 +271,14 @@ module StashEngine
                           upload_file_name: 'README.md')
       end
       it 'returns nil if unable to retrieve range of S3 file' do
-        # stubbing a request to merritt for presigned URL
-        stub_request(:get, %r{merritt-fake.cdlib.org/api/presign-file/})
-          .with(headers: { 'Host' => 'merritt-fake.cdlib.org' })
-          .to_return(status: 200, body: File.read('spec/fixtures/http_responses/mrt_presign.json'),
-                     headers: { 'Content-Type' => 'application/json' })
-
-        # stubbing the S3 request as a 404
-        stub_request(:get, %r{uc3-s3mrt5001-stg.s3.us-west-2.amazonaws.com/ark})
-          .with(headers: { 'Host' => 'uc3-s3mrt5001-stg.s3.us-west-2.amazonaws.com' })
+        stub_request(:get, %r{https://a-merritt-test-bucket.s3.us-west-2.amazonaws.com/ark+.})
           .to_return(status: 404, body: '', headers: {})
 
         expect(@upload2.file_content).to be_nil
       end
 
       it 'returns content if successful request for http URL' do
-        # stubbing a request to merritt for presigned URL
-        stub_request(:get, %r{merritt-fake.cdlib.org/api/presign-file/})
-          .with(headers: { 'Host' => 'merritt-fake.cdlib.org' })
-          .to_return(status: 200, body: File.read('spec/fixtures/http_responses/mrt_presign.json'),
-                     headers: { 'Content-Type' => 'application/json' })
-
-        # stubbing the S3 request
-        stub_request(:get, %r{uc3-s3mrt5001-stg.s3.us-west-2.amazonaws.com/ark})
-          .with(headers: { 'Host' => 'uc3-s3mrt5001-stg.s3.us-west-2.amazonaws.com' })
+        stub_request(:get, %r{https://a-merritt-test-bucket.s3.us-west-2.amazonaws.com/ark+.})
           .to_return(status: 200, body: '### This is a test README title!', headers: {})
 
         expect(@upload2.file_content).to eql('### This is a test README title!')

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -249,7 +249,6 @@ module StashEngine
         end
       end
 
-      # TODO: this shouldn't be in StashEngine
       describe :merritt_protodomain_and_local_id do
         it 'returns the merritt protocol and domain and local ID' do
           download_uri = 'https://merritt.example.edu/d/ark%3A%2Fb5072%2Ffk2736st5z'
@@ -259,6 +258,15 @@ module StashEngine
           merritt_protodomain, local_id = resource.merritt_protodomain_and_local_id
           expect(merritt_protodomain).to eq('https://merritt.example.edu')
           expect(local_id).to eq('ark%3A%2Fb5072%2Ffk2736st5z')
+        end
+      end
+
+      describe :merritt_ark do
+        it 'extracts the Merritt ark from the download URI' do
+          download_uri = 'https://merritt.example.edu/d/ark%3A%2Fb5072%2Ffk2736st5z'
+          resource = Resource.create(user_id: user.id)
+          resource.download_uri = download_uri
+          expect(resource.merritt_ark).to eq('ark:/b5072/fk2736st5z')
         end
       end
     end

--- a/spec/models/stash_engine/software_file_spec.rb
+++ b/spec/models/stash_engine/software_file_spec.rb
@@ -28,9 +28,9 @@ module StashEngine
                                     state: 'finished', copy_type: 'software_publish')
     end
 
-    describe '#calc_s3_path' do
+    describe '#s3_staged_path' do
       it 'returns a path for zenodo files' do
-        expect(@upload.calc_s3_path).to \
+        expect(@upload.s3_staged_path).to \
           end_with("#{@resource.id}/sfw/#{@upload.upload_file_name}")
       end
     end
@@ -55,7 +55,7 @@ module StashEngine
     describe '#zenodo_replication_url' do
       it 'replicates from s3 if direct upload' do
         fu = @resource.software_files.first
-        expect(fu).to receive(:direct_s3_presigned_url).and_return(nil)
+        expect(fu).to receive(:s3_staged_presigned_url).and_return(nil)
         fu.zenodo_replication_url
       end
 

--- a/spec/models/stash_engine/supp_file_spec.rb
+++ b/spec/models/stash_engine/supp_file_spec.rb
@@ -29,9 +29,9 @@ module StashEngine
                                     state: 'finished', copy_type: 'supp_publish')
     end
 
-    describe '#calc_s3_path' do
+    describe '#s3_staged_path' do
       it 'returns a path for zenodo files' do
-        expect(@upload.calc_s3_path).to \
+        expect(@upload.s3_staged_path).to \
           end_with("#{@resource.id}/supp/#{@upload.upload_file_name}")
       end
     end
@@ -56,7 +56,7 @@ module StashEngine
     describe '#zenodo_replication_url' do
       it 'replicates from s3 if direct upload' do
         fu = @resource.supp_files.first
-        expect(fu).to receive(:direct_s3_presigned_url).and_return(nil)
+        expect(fu).to receive(:s3_staged_presigned_url).and_return(nil)
         fu.zenodo_replication_url
       end
 

--- a/stash/stash-merritt/lib/stash/merritt/object_manifest_package.rb
+++ b/stash/stash-merritt/lib/stash/merritt/object_manifest_package.rb
@@ -52,7 +52,7 @@ module Stash
 
       def data_file_entry(upload)
         upload_file_name = upload.upload_file_name
-        upload_url = upload.url || upload.direct_s3_presigned_url
+        upload_url = upload.url || upload.s3_staged_presigned_url
         throw ArgumentError, "No upload URL for upload #{upload.id} ('#{upload_file_name}')" unless upload_url
 
         upload_file_size = upload.upload_file_size


### PR DESCRIPTION
We were getting a lot of emails about this as bots hit API pages. The rendering would fail for authors who did not have an affilation.