### PR TITLE
Fix error with rendering authors in the API

### DIFF
--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -879,10 +879,10 @@ module StashEngine
       edits = []
       edits << { deleted: other_authors.length - authors.length } if other_authors.length > authors.length
       this_authors = authors.map do |a|
-        { author_full_name: a.author_full_name, affiliation: "#{a.affiliation.long_name}#{a.affiliation.ror_id}", email: a.author_email }
+        { author_full_name: a.author_full_name, affiliation: "#{a.affiliation&.long_name}#{a.affiliation&.ror_id}", email: a.author_email }
       end
       that_authors = other_authors.map do |a|
-        { author_full_name: a.author_full_name, affiliation: "#{a.affiliation.long_name}#{a.affiliation.ror_id}", email: a.author_email }
+        { author_full_name: a.author_full_name, affiliation: "#{a.affiliation&.long_name}#{a.affiliation&.ror_id}", email: a.author_email }
       end
       this_authors.each_with_index do |a, i|
         diff = a.diff(that_authors[i] || {})


### PR DESCRIPTION
We were getting a lot of emails about this as bots hit API pages. The rendering would fail for authors who did not have an affiliation.

(Fix has been applied on production.)