### PR TITLE
Get counter stats weekly from DataCite hub rather than our own stat files

### DIFF
--- a/app/models/stash_engine/counter_stat.rb
+++ b/app/models/stash_engine/counter_stat.rb
@@ -68,7 +68,7 @@ module StashEngine
     end
 
     # This will return the calendar year and week of that year for checking if something has been updated in the last calendar week.
-    # If it is nil or not a time then return week 30 days ago.
+    # If it is nil or not a time then return week 30 days ago (which will be out of caching period)
     def calendar_week(time)
       # %W calculates weeks based on starting Monday and not Sunday, %U is Sunday and %V is ???.
       # This produces year-week string.

--- a/cron/counter.sh
+++ b/cron/counter.sh
@@ -73,7 +73,8 @@ cd /apps/dryad/apps/ui/current
 # repopulate all stats back into our tables
 # -----------------------------------------
 echo "Repopulating stats into database cache"
-JSON_DIRECTORY="$COUNTER_JSON_STORAGE" bundle exec rails counter:cop_manual
+# JSON_DIRECTORY="$COUNTER_JSON_STORAGE" bundle exec rails counter:cop_manual # this populates from our local reports
+bundle exec rails counter:cop_populate # this does it from the hub instead of our local files
 
 # -----------------------------------------------
 # remove old logs that are past our deletion time


### PR DESCRIPTION
This turned out to be an easier change than I thought since all the code for retrieving from the DataCite hub is existing. I had to re-test to be sure since we haven't used it for a while.

In the past it would automatically retrieve from the DataCite hub on the fly when a cached stat was more than a week out of date.  The auto-caching was removed when we populated from our own files, but it turned out to be a fairly simple task to automate updating the stats from the DataCite hub by just using the `update_if_necessary` method (updates if the last update was older than this week).

Added a rake task to go through all public datasets (published and embargoed) to update these stats weekly.

To verify that it still works is rather difficult on development servers, but doing something like this is a good test of it working on production where datasets have stats in DataCite.

```
RAILS_ENV=production bundle exec rails c

# you should now be in the rails console
identifier = StashEngine::Identifier.find_by_identifier('10.5061/dryad.bvq83bk8p') # identifier with stats

# destroy the cached stats and reload so they update
identifier.counter_stat.destroy!
identifier.reload

identifier.counter_stat # verify it is zero now.  by default stats are created on access if needed

identifier.counter_stat.update_if_necessary

identifier.reload
identifier.counter_stat # verify that the counter stat has updated from the "hub"
```

The rake task just iterates and updates all as part of a cron once a week