### PR TITLE
Give better response and email to "not found" file errors from initial deposit mismatches

### DIFF
--- a/app/mailers/stash_engine/user_mailer.rb
+++ b/app/mailers/stash_engine/user_mailer.rb
@@ -89,6 +89,7 @@ module StashEngine
       logger.warn("Unable to report update error #{error}; nil resource") unless resource.present?
       @zenodo_error_emails = APP_CONFIG['zenodo_error_email']
       return unless resource.present? && @zenodo_error_emails.present?
+
       @resource = resource
 
       @error_text = error_text

--- a/app/mailers/stash_engine/user_mailer.rb
+++ b/app/mailers/stash_engine/user_mailer.rb
@@ -85,6 +85,17 @@ module StashEngine
            subject: "#{rails_env}Submitting dataset \"#{@resource.title}\" (doi:#{@resource.identifier_value}) failed")
     end
 
+    def general_error(resource, error_text)
+      logger.warn("Unable to report update error #{error}; nil resource") unless resource.present?
+      @zenodo_error_emails = APP_CONFIG['zenodo_error_email']
+      return unless resource.present? && @zenodo_error_emails.present?
+      @resource = resource
+
+      @error_text = error_text
+      mail(to: @zenodo_error_emails,
+           subject: "#{rails_env}General error \"#{@resource.title}\" (doi:#{@resource.identifier_value})")
+    end
+
     def feedback_signup(message)
       @message = message
       @submission_error_emails = APP_CONFIG['submission_error_email'] || [@helpdesk_email]

--- a/app/views/stash_engine/user_mailer/general_error.html.erb
+++ b/app/views/stash_engine/user_mailer/general_error.html.erb
@@ -1,0 +1,13 @@
+<p>An error occurred</p>
+
+<pre>
+<%= @error_text %>
+</pre>
+
+<hr/>
+
+<pre>
+  resource_id: <%= @resource.id %>
+  identifier_id: <%= @resource&.identifier&.id %>
+  doi: <%= @resource&.identifier&.identifier %>
+</pre>

--- a/documentation/sql_queries/file_download.md
+++ b/documentation/sql_queries/file_download.md
@@ -1,0 +1,43 @@
+# Troubleshooting individual file download issues
+
+The file model is deep in the heirarchy, so in order to get useful information
+you need to join many tables and select the most relevant information.
+
+Some useful example queries, below.  Replace the items in the WHERE clause with your values.
+
+```sql
+/* get information about the file and up to the identifier */
+SELECT gf.id file_id, gf.upload_file_name, res.id resource_id, res.identifier_id,
+       ids.identifier, res.download_uri, vers.version, vers.merritt_version
+FROM stash_engine_resources res
+    JOIN stash_engine_generic_files gf
+        ON res.id = gf.resource_id
+    JOIN stash_engine_identifiers ids
+        ON res.identifier_id = ids.id
+    JOIN stash_engine_versions vers
+        ON res.id = vers.resource_id
+WHERE gf.id = 102442;
+```
+
+```sql
+/* get information about this file over time through different version */
+SELECT ids.identifier, gf.id as file_id, res.identifier_id, res.id as resource_id,
+       gf.upload_file_name, gf.upload_file_size, gf.file_state, vers.version, vers.merritt_version
+FROM stash_engine_resources res
+    JOIN stash_engine_generic_files gf
+        ON res.id = gf.resource_id
+    JOIN `stash_engine_resource_states` sers
+        ON sers.resource_id = res.id
+    JOIN stash_engine_versions vers
+        ON res.id = vers.resource_id
+    JOIN stash_engine_identifiers ids
+        ON res.identifier_id = ids.id
+WHERE res.identifier_id = 27114 AND
+      gf.upload_file_name = 'kinesis & standard errors (by species).csv';
+```
+
+To examine the files in S3, you can look in the web console and brows to the correct bucket and path.
+
+When you're inside a path such as `13030` you may want to filter to something like `m500516c|1|producer` to
+see what files actually exist in different versions there.  (The `|` is a delimiter between the parts of the
+end of the ark, version and we're concerned with producer files here.

--- a/lib/stash/download/file_presigned.rb
+++ b/lib/stash/download/file_presigned.rb
@@ -30,16 +30,15 @@ module Stash
         if url.nil?
           cc.render status: 404, plain: 'Not found'
           error_text = "The file is not available for download. Most likely this is due to a mismatch in Merritt\n" \
-            "and Dryad versioning. The database information probably indicates a deposit in an earlier version\n" \
-            "than when the actual Merritt deposit took place. Or this could be caused by some other issues.\n" \
-            "\n" \
-            "File id: #{file.id}\n" \
-            "Filename: #{file.upload_file_name}\n"
+                       "and Dryad versioning. The database information probably indicates a deposit in an earlier version\n" \
+                       "than when the actual Merritt deposit took place. Or this could be caused by some other issues.\n" \
+                       "\n" \
+                       "File id: #{file.id}\n" \
+                       "Filename: #{file.upload_file_name}\n"
           StashEngine::UserMailer.general_error(file&.resource, error_text).deliver_now
         else
           cc.redirect_to url
         end
-
       rescue HTTP::Error => e
         raise S3CustomError, "HTTP Error while creating presigned URL from S3\n" \
                              "#{file.merritt_presign_info_url}\n" \

--- a/lib/stash/download/file_presigned.rb
+++ b/lib/stash/download/file_presigned.rb
@@ -27,7 +27,19 @@ module Stash
 
         url = file.s3_permanent_presigned_url
 
-        cc.redirect_to url
+        if url.nil?
+          cc.render status: 404, plain: 'Not found'
+          error_text = "The file is not available for download. Most likely this is due to a mismatch in Merritt\n" \
+            "and Dryad versioning. The database information probably indicates a deposit in an earlier version\n" \
+            "than when the actual Merritt deposit took place. Or this could be caused by some other issues.\n" \
+            "\n" \
+            "File id: #{file.id}\n" \
+            "Filename: #{file.upload_file_name}\n"
+          StashEngine::UserMailer.general_error(file&.resource, error_text).deliver_now
+        else
+          cc.redirect_to url
+        end
+
       rescue HTTP::Error => e
         raise S3CustomError, "HTTP Error while creating presigned URL from S3\n" \
                              "#{file.merritt_presign_info_url}\n" \


### PR DESCRIPTION
Also documents queries for troubleshooting these.

See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2848 .

These issues were caused by deposits that happened in a later version in Merritt/S3 than where we requested the deposit.  Often you can tell that some hacking went on to correct something because the dryad and merritt versions do not match in the versions table.

This returns a 404 instead of a server error and emails us the information instead of sending us the generic report.

You can test with the dataset https://dryad-dev.cdlib.org/stash/dataset/doi:10.7959/dryad.8931zct2 and the NIOO.svg file.  It is made to be bad like these so that the deposit took place into S3 in V2, but our database indicates V1 deposit.

I think it's somewhat important to have our "created" states line up with when files were actually deposited in Merritt or at least not point to an S3 version before something was actually deposited.



