### PR TITLE
Tweaks to EZID placeholder data submission

### DIFF
--- a/lib/tasks/ezid_transition.rake
+++ b/lib/tasks/ezid_transition.rake
@@ -81,6 +81,7 @@ namespace :ezid_transition do
       puts "#{idx} -- #{doi}"
       # sorry, I couldn't figure out how to stop the EZID gem from printing to stdout, even setting logggers and other things
       Tasks::EzidTransition::Register.register_doi(doi: doi)
+      sleep 1
     end
     puts 'Done'
   end

--- a/lib/tasks/ezid_transition/register.rb
+++ b/lib/tasks/ezid_transition/register.rb
@@ -16,16 +16,16 @@ module Tasks
                 </creator>
             </creators>
             <titles>
-                <title xml:lang="en">Dryad in-progress dataset</title>
+                <title xml:lang="en">Dryad dataset awaiting publication</title>
             </titles>
             <publisher>Dryad</publisher>
-            <publicationYear>2023</publicationYear>
+            <publicationYear>:unkn</publicationYear>
             <resourceType resourceTypeGeneral="Dataset">Dataset</resourceType>
             <sizes/>
             <formats/>
             <version/>
             <descriptions>
-                <description descriptionType="Abstract">A placeholder for an item to be published.</description>
+                <description descriptionType="Abstract">:unav</description>
             </descriptions>
         </resource>
       XML

--- a/lib/tasks/ezid_transition/register.rb
+++ b/lib/tasks/ezid_transition/register.rb
@@ -31,6 +31,7 @@ module Tasks
         </resource>
       XML
 
+      # rubocop:disable Metrics/MethodLength
       def self.register_doi(doi:)
         doi.gsub!(/^doi:/, '') # strip off the icky doi: at the first if it's there
 
@@ -48,7 +49,7 @@ module Tasks
           return
         end
 
-        if self.status(doi: doi) != 'reserved'
+        if status(doi: doi) != 'reserved'
           puts "  Not reserved, so not updating #{doi}"
           return
         end
@@ -73,18 +74,17 @@ module Tasks
         end
         puts "  Updated placeholder metadata at EZID for #{doi}"
       end
+      # rubocop:enable Metrics/MethodLength
 
       # we want status to be 'reserved' for the update to take place
       def self.status(doi:)
         resp = HTTP.accept('text/plain').timeout(15).get("https://ezid.cdlib.org/id/doi:#{doi}")
-        ezid_status = if resp.status == 200
-                        ezid_info = resp.body.to_s
-                        ezid_info.match(/^_status: (\S+)$/)[1]
-                      elsif resp.status == 400
-                        'not_found'
-                      end
-
-        ezid_status
+        if resp.status == 200
+          ezid_info = resp.body.to_s
+          ezid_info.match(/^_status: (\S+)$/)[1]
+        elsif resp.status == 400
+          'not_found'
+        end
       end
     end
   end


### PR DESCRIPTION
Closes https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2856 .

I also ran this against production so now all reserved items have some placeholder metadata. This should allow the transition to proceed whenever it is ready since no new EZID identifiers are being created by our system.

I couldn't replace the publication year with `:unas` or any of the other special datacite values and that was causing failures, I discovered after some trial and error.
