### PR TITLE
Intermittently failing tests fix

### DIFF
--- a/spec/features/stash_datacite/dataset_versioning_spec.rb
+++ b/spec/features/stash_datacite/dataset_versioning_spec.rb
@@ -380,7 +380,7 @@ RSpec.feature 'DatasetVersioning', type: :feature do
   def update_dataset(curator: false)
     # Add a value to the dataset, submit it and then mock a successful submission
     navigate_to_metadata
-    3.times { fill_in_keyword }
+    fill_in_keywords
     all('[id^=instit_affil_]').last.set('test institution')
     page.send_keys(:tab)
     page.has_css?('.use-text-entered')

--- a/spec/features/stash_datacite/new_collection_spec.rb
+++ b/spec/features/stash_datacite/new_collection_spec.rb
@@ -152,7 +152,7 @@ RSpec.feature 'NewCollection', type: :feature do
       page.send_keys(:tab)
       page.has_css?('.use-text-entered')
       all(:css, '.use-text-entered').each { |i| i.set(true) }
-      3.times { fill_in_keyword }
+      fill_in_keywords
       fill_in_collection
       navigate_to_review
       agree_to_everything

--- a/spec/features/stash_datacite/review_dataset_spec.rb
+++ b/spec/features/stash_datacite/review_dataset_spec.rb
@@ -142,7 +142,7 @@ RSpec.feature 'ReviewDataset', type: :feature do
       page.send_keys(:tab)
       page.has_css?('.use-text-entered')
       all(:css, '.use-text-entered').each { |i| i.set(true) }
-      3.times { fill_in_keyword }
+      fill_in_keywords
       navigate_to_review
       agree_to_everything
       fill_in 'user_comment', with: Faker::Lorem.sentence

--- a/spec/features/stash_engine/admin_datasets_spec.rb
+++ b/spec/features/stash_engine/admin_datasets_spec.rb
@@ -200,7 +200,7 @@ RSpec.feature 'AdminDatasets', type: :feature do
         page.send_keys(:tab)
         page.has_css?('.use-text-entered')
         all(:css, '.use-text-entered').each { |i| i.set(true) }
-        3.times { fill_in_keyword }
+        fill_in_keywords
         navigate_to_readme
         add_required_data_files
         navigate_to_review

--- a/spec/support/helpers/collection_helper.rb
+++ b/spec/support/helpers/collection_helper.rb
@@ -53,7 +53,7 @@ module CollectionHelper
   end
 
   def fill_in_keywords
-    fill_in 'keyword_ac', with: Faker::Lorem.words(number: 3).join(',')
+    fill_in 'keyword_ac', with: Faker::Lorem.unique.words(number: 3).join(',')
     page.send_keys(:tab)
   end
 

--- a/spec/support/helpers/collection_helper.rb
+++ b/spec/support/helpers/collection_helper.rb
@@ -44,7 +44,7 @@ module CollectionHelper
     page.has_css?('.use-text-entered')
     all(:css, '.use-text-entered').each { |i| i.set(true) }
     fill_in_tinymce(field: 'abstract', content: Faker::Lorem.paragraph)
-    3.times { fill_in_keyword }
+    fill_in_keywords
     fill_in_collection
   end
 
@@ -52,8 +52,8 @@ module CollectionHelper
     click_button 'Submit', wait: 5
   end
 
-  def fill_in_keyword(keyword: Faker::Creature::Animal.name)
-    fill_in 'keyword_ac', with: keyword
+  def fill_in_keywords
+    fill_in 'keyword_ac', with: Faker::Lorem.words(number: 3).join(',')
     page.send_keys(:tab)
   end
 

--- a/spec/support/helpers/dataset_helper.rb
+++ b/spec/support/helpers/dataset_helper.rb
@@ -97,7 +97,7 @@ module DatasetHelper
   end
 
   def fill_in_keywords
-    fill_in 'keyword_ac', with: Faker::Lorem.words(number: 3).join(',')
+    fill_in 'keyword_ac', with: Faker::Lorem.unique.words(number: 3).join(',')
     page.send_keys(:tab)
   end
 

--- a/spec/support/helpers/dataset_helper.rb
+++ b/spec/support/helpers/dataset_helper.rb
@@ -67,7 +67,7 @@ module DatasetHelper
     page.has_css?('.use-text-entered')
     all(:css, '.use-text-entered').each { |i| i.set(true) }
     fill_in_tinymce(field: 'abstract', content: Faker::Lorem.paragraph)
-    3.times { fill_in_keyword }
+    fill_in_keywords
   end
 
   def add_required_data_files
@@ -96,8 +96,8 @@ module DatasetHelper
     fill_in 'primary_article_doi', with: doi
   end
 
-  def fill_in_keyword(keyword: Faker::Creature::Animal.name)
-    fill_in 'keyword_ac', with: keyword
+  def fill_in_keywords
+    fill_in 'keyword_ac', with: Faker::Lorem.words(number: 3).join(',')
     page.send_keys(:tab)
   end
 


### PR DESCRIPTION
Using the method by which keywords were created in the tests, very occasionally there were unintentional duplicates, which were then purged, which then blocked submission tests because of insufficient # of keywords (this is conveniently demonstrated below in the test of the first commit)