### PR TITLE
Remove merritt presigned URL attempt for 'created' README

### DIFF
--- a/app/models/stash_engine/data_file.rb
+++ b/app/models/stash_engine/data_file.rb
@@ -139,7 +139,7 @@ module StashEngine
     # the presigned URL for a file that was "directly" uploaded to Dryad,
     # rather than a file that was indicated by a URL reference
     def s3_staged_presigned_url
-      Stash::Aws::S3.new.presigned_download_url(s3_key: "#{resource.s3_dir_name(type: 'data')}/#{original_filename}")
+      Stash::Aws::S3.new.presigned_download_url(s3_key: "#{resource.s3_dir_name(type: 'data')}/#{upload_file_name}")
     end
 
     # the URL we use for replication to zenodo, for software it's always the merritt url, but for software we have the same

--- a/spec/models/stash_engine/data_file_spec.rb
+++ b/spec/models/stash_engine/data_file_spec.rb
@@ -285,8 +285,8 @@ module StashEngine
         stub_request(:get, %r{https://a-test-bucket.s3.us-west-2.amazonaws.com/+.})
           .to_return(status: 200, body: '### This is a test README title!', headers: {})
 
-        stub_request(:get, %r{https://a-test-bucket.s3.us-west-2.amazonaws.com/.+}).
-          to_return(status: 200, body: '### This is a test README title!', headers: {})
+        stub_request(:get, %r{https://a-test-bucket.s3.us-west-2.amazonaws.com/.+})
+          .to_return(status: 200, body: '### This is a test README title!', headers: {})
 
         expect(@upload2.file_content).to eql('### This is a test README title!')
       end

--- a/spec/models/stash_engine/data_file_spec.rb
+++ b/spec/models/stash_engine/data_file_spec.rb
@@ -285,6 +285,9 @@ module StashEngine
         stub_request(:get, %r{https://a-merritt-test-bucket.s3.us-west-2.amazonaws.com/ark+.})
           .to_return(status: 200, body: '### This is a test README title!', headers: {})
 
+        stub_request(:get, %r{https://a-test-bucket.s3.us-west-2.amazonaws.com/.+}).
+          to_return(status: 200, body: '### This is a test README title!', headers: {})
+
         expect(@upload2.file_content).to eql('### This is a test README title!')
       end
     end


### PR DESCRIPTION
There's a new bug when the README editor attempts to load content from files. It seems like this is being caused by an attempt at downloading from a merritt bucket that (I think?) the files are no longer actually going to (please correct me if I've got the wrong end of the stick there!).

If this corrects the bug and we could get this merged and released that would be great, as it is preventing some users from proceeding.