### PR TITLE
Reduce number of files not being found for download

### DIFF
--- a/app/controllers/stash_engine/downloads_controller.rb
+++ b/app/controllers/stash_engine/downloads_controller.rb
@@ -102,7 +102,7 @@ module StashEngine
         CounterLogger.general_hit(request: request, file: data_file)
         @file_presigned.download(file: data_file)
       else
-        render status: 403, plain: 'You are not authorized to download this file until it has been published.'
+        render status: 403, plain: 'You may not download this file.'
       end
     end
 

--- a/app/controllers/stash_engine/downloads_controller.rb
+++ b/app/controllers/stash_engine/downloads_controller.rb
@@ -97,7 +97,7 @@ module StashEngine
 
     # uses presigned
     def file_stream
-      data_file = DataFile.find(params[:file_id])
+      data_file = DataFile.where(id: params[:file_id]).present_files.first
       if data_file&.resource&.may_download?(ui_user: current_user)
         CounterLogger.general_hit(request: request, file: data_file)
         @file_presigned.download(file: data_file)


### PR DESCRIPTION
This addresses an aspect of https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2850 and also https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2848 .

There are two problems this addresses related to many emails telling us about files that are not available to download.

1. One problem was that the controller allowed loading file records for deleted files.  The deleted files didn't actually load anything, but it's clear from our recent notifications that bad bots are just trying different file numbers on the end of the URL and some are not valid files.  Add the "present_files" scope prevents these from loading into the controller.
2. There are some cases like in ticket 2848 where files have been actually deposited in a later version in Merritt than where we sent them to be "created."  I think almost all of these had some problems with ugly cleanup and we had to shift our versions vs Merritt versions around (so the normal Stash version == Merritt version is false).  If the versions don't match, this allows looking for the file in up to two subsequent versions of storage.

I don't love the second point and I think ideally we should really know the exact details of where files are really deposited and our records should exactly match Merritt's information.

For the first point, if I were to design it again, I wouldn't use integers for file identifiers and instead an identifier that couldn't be easily predicted so that random annoying bad actors can't just iterate through everything to try and download everything they can find.