### PR TITLE
Fixes problems with the Zenodo re-submission queue dashboard

### DIFF
--- a/app/controllers/stash_engine/zenodo_queue_controller.rb
+++ b/app/controllers/stash_engine/zenodo_queue_controller.rb
@@ -63,9 +63,9 @@ module StashEngine
           copy_type = @zenodo_copy.copy_type.gsub('_publish', '')
 
           previous_unfinished = ZenodoCopy.where('id < ?', params[:id])
-                                          .where(identifier_id: @zenodo_copy.identifier_id)
-                                          .where('copy_type LIKE ?', "%#{copy_type}%")
-                                          .where("state != 'finished'").count
+            .where(identifier_id: @zenodo_copy.identifier_id)
+            .where('copy_type LIKE ?', "%#{copy_type}%")
+            .where("state != 'finished'").count
 
           @sub_status = ''
           @sub_status = 'prerequisite' if previous_unfinished.positive?

--- a/app/views/stash_engine/zenodo_queue/_status_table.html.erb
+++ b/app/views/stash_engine/zenodo_queue/_status_table.html.erb
@@ -26,30 +26,26 @@
     <th class="c-lined-table__sort <%= sort_display('size') %>">
       <%= sortable_column_head sort_field: 'size', title: 'Size' %>
     </th>
-    <th class="c-lined-table__sort <%= sort_display('error_info') %>">
-      <%= sortable_column_head sort_field: 'error_info', title: 'Error info' %>
-    </th>
     <th>Actions</th>
   </tr>
   </thead>
   <tbody>
   <% @zenodo_copies.each do |zc| %>
-    <tr class="c-lined-table__row">
-      <td class="c-lined-table__digits"><%= link_to(zc.id, zenodo_queue_item_details_path(zc.id)) %></td>
+    <tr class="c-lined-table__row" id="tr_<%= zc.id %>">
+      <td class="c-lined-table__digits"><%= link_to(zc.id, zenodo_queue_item_details_path(zc.id), target: '_blank') %></td>
       <td class="c-lined-table__digits">
         <% unless zc.identifier_id.blank? %>
-          <%= link_to(zc.identifier_id, zenodo_queue_identifier_details_path(zc.identifier_id)) %>
+          <%= link_to(zc.identifier_id, zenodo_queue_identifier_details_path(zc.identifier_id), target: '_blank') %>
         <% end %>
       </td class="c-lined-table__digits">
       <td><%= zc.resource_id %></td>
-      <td><%= zc.state %></td>
+      <td id="job_state_<%= zc.id %>"><%= zc.state %></td>
       <td class="c-lined-table__digits"><%= formatted_datetime(zc.updated_at) %></td>
       <td class="c-lined-table__digits"><%= formatted_datetime(zc.created_at) %></td>
       <td><%= zc.copy_type.gsub('_', ' ') %></td>
       <td class="c-lined-table__digits"><%= filesize(zc.size) %></td>
-      <td><%= link_to truncate(zc.error_info || 'null', length: 20), zenodo_queue_item_details_path(zc.id), title: zc.error_info %></td>
       <td>
-        <%= button_to('resend', zenodo_queue_resubmit_job_path(id: zc.id)) %>
+        <%= button_to('resend', zenodo_queue_resubmit_job_path(id: zc.id), remote: true) %>
       </td>
     </tr>
   <% end %>

--- a/app/views/stash_engine/zenodo_queue/index.html.erb
+++ b/app/views/stash_engine/zenodo_queue/index.html.erb
@@ -26,15 +26,12 @@
 
 <ul>
   <li>
-    Click an <em>id</em> or <em>error</em> to see the full information in the Zenodo Copies table as
+    Click an <em>id</em> to see the full information in the Zenodo Copies table and errors as
     well as any delayed job worker queue information.
   </li>
   <li>
     Clicking an identifier id shows all the errored submissions for one dataset.  This can be useful if you want to troubleshoot
     just one dataset or resubmit items in order.
-  </li>
-  <li>
-    Hovering over an error displays more information.
   </li>
   <li>
     Clicking <em>resend</em> will re-insert a job into the delayed job worker queue to send to Zenodo again.

--- a/app/views/stash_engine/zenodo_queue/index.html.erb
+++ b/app/views/stash_engine/zenodo_queue/index.html.erb
@@ -1,7 +1,19 @@
 <h1>Zenodo submission queue</h1>
 <p>
-  <%= @zenodo_copies.count %> items in list
+  <%= @zenodo_copies.count %> items in list.
 </p>
+
+<p>
+  Look at the <strong>state</strong> column after clicking <strong>resend</strong> to see that action was taken:
+</p>
+<ul>
+  <li><strong style="color: #F00">prerequisite</strong> means another items in the series must be submitted first</li>
+  <li>
+    <strong style="color: #F00">in runner</strong> means the item is already in the delayed job runner (though you may want to clear it in
+    the database if the execution has expired or it received a SIGTERM and then "reset stalled" below)
+  </li>
+  <li><strong style="color: #0F0">...submitting</strong> means you just successfully re-enqueued a submission</li>
+</ul>
 
 <p>
   <%= button_to('Reset stalled to error state', zenodo_queue_set_errored_path, class: 'o-button__plain-text2') %>

--- a/app/views/stash_engine/zenodo_queue/resubmit_job.js.erb
+++ b/app/views/stash_engine/zenodo_queue/resubmit_job.js.erb
@@ -1,0 +1,5 @@
+<% if @sub_status.blank? %>
+  document.getElementById('job_state_<%= @zenodo_copy.id %>').innerHTML = '<span style="color: #0F0">...submitting</span>';
+<% else %>
+  document.getElementById('job_state_<%= @zenodo_copy.id %>').innerHTML = '<span style="color: #F00"><%= @sub_status %></span>';
+<% end %>


### PR DESCRIPTION
See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2900 .

This does the following:

- Makes all links in the table open in new windows
- Removes the error info as a column since it didn't display usefully and was making the page not load with the long text and delays getting it from the database.
- Makes the *resend* button not navigate away from the page but instead resubmit by AJAX/JS.
  - The results of the resubmission show in the *state* column instead of on a new page (prerequisite, in runner, ...submitting)
  - All this makes it much easier to go through individual items to resubmit without any big delays and without losing your place in the table.

This should make it possible to get the page to load quickly and also go through and resubmit things without confusion and delay as we hassle trying to get Zenodo stuff to go back through.

BTW, if you need to test there are still things in our development database stuck from our zenodo issues.