### PR TITLE
Minor change to zenodo presigned

### DIFF
--- a/lib/stash/zenodo_software/remote_access_token.rb
+++ b/lib/stash/zenodo_software/remote_access_token.rb
@@ -54,7 +54,7 @@ module Stash
 
         if resp.try(:status).try(:code) < 400
           resp = resp.parse
-          return resp[:links][:bucket]
+          return resp['links']['bucket']
         end
 
         nil


### PR DESCRIPTION
Get with strings instead of symbols from json.

I already applied this manually to the production servers by editing the files.

It seems to retrieve the presigned things sometimes though it can be pretty slow to start the downloads if it works.