### PR TITLE
Restores to using old access token

### DIFF
--- a/lib/stash/zenodo_replicate/zenodo_connection.rb
+++ b/lib/stash/zenodo_replicate/zenodo_connection.rb
@@ -104,13 +104,17 @@ module Stash
         APP_CONFIG[:zenodo][:base_url]
       end
 
+      # def self.access_token
+      #   state = StashEngine::GlobalState.where(key: 'zenodo_api')&.first&.state
+      #   state = state.with_indifferent_access if state.is_a?(Hash)
+      #
+      #   return new_access_token if state.nil? || state[:expires_at].blank? || state[:expires_at].to_time < (Time.new + 5.minutes)
+      #
+      #   state[:access_token]
+      # end
+
       def self.access_token
-        state = StashEngine::GlobalState.where(key: 'zenodo_api')&.first&.state
-        state = state.with_indifferent_access if state.is_a?(Hash)
-
-        return new_access_token if state.nil? || state[:expires_at].blank? || state[:expires_at].to_time < (Time.new + 5.minutes)
-
-        state[:access_token]
+        APP_CONFIG[:zenodo][:access_token]
       end
 
       # gets access token from api, stores access token to database, and also returns it


### PR DESCRIPTION
which does presigned RATs on production but not clear if it works on any other environment, but still not sure what environment we should be using now for their test environment.