### PR TITLE
Update documentation of setting PPR through the API

### DIFF
--- a/documentation/apis/submission.md
+++ b/documentation/apis/submission.md
@@ -202,7 +202,7 @@ To move a dataset into `peer_review` status, the dataset must have a
 `versionStatus` of `submitted`. Make a PATCH request as described
 above. Submit to /api/v2/datasets/&lt;encoded-doi&gt; with some json patch information
 that tells the server to set the /curationStatus value to
-'submitted': 
+'peer_review': 
 
 ```json
 [ { "op": "replace", "path": "/curationStatus", "value": "peer_review" } ]

--- a/documentation/apis/submission.md
+++ b/documentation/apis/submission.md
@@ -153,13 +153,11 @@ submit your dataset for curation.
 
 Submitting is accomplished by sending a PATCH request to
 /api/v2/datasets/&lt;encoded-doi&gt; with some json patch information
-that tells the server to try and set the /versionStatus value to
-'submitted' like below: 
+that tells the server to set the /versionStatus value to
+'submitted': 
 
 ```json
-[
-	{ "op": "replace", "path": "/versionStatus", "value": "submitted" }
-]
+[ { "op": "replace", "path": "/versionStatus", "value": "submitted" } ]
 ```
 You also need to set the Content-Type header to 'application/json-patch+json'
 
@@ -187,6 +185,35 @@ resp = RestClient.patch(
 
 return_hash = JSON.parse(resp)
 ```
+
+For an explanation of other `versionStatus` values, see the [Submission
+flow](../submission_flow.md) document.
+
+## Retaining a dataset in a private status for peer review purposes
+
+This step is optional.
+
+By default, datasets that are submitted are immediately eligible for
+curation. Dryad curators may evaluate and publish `submitted` datasets at any
+time. If you wish your dataset to remain private until an associated article is
+published, you may update the dataset's `curationStatus` to indicate this.
+
+To move a dataset into `peer_review` status, the dataset must have a
+`versionStatus` of `submitted`. Make a PATCH request as described
+above. Submit to /api/v2/datasets/&lt;encoded-doi&gt; with some json patch information
+that tells the server to set the /curationStatus value to
+'submitted': 
+
+```json
+[ { "op": "replace", "path": "/curationStatus", "value": "peer_review" } ]
+```
+
+Datasets in `peer_review` status will remain uncurated and unpublished until
+Dryad learns the associated article has been published. Reminders will
+occasionally be sent to the submitter.
+
+For an explanation of other `curationStatus` values, see the [Submission
+flow](../submission_flow.md) document.
 
 ## Revise your metadata in a new version
 

--- a/documentation/submission_flow.md
+++ b/documentation/submission_flow.md
@@ -35,10 +35,10 @@ Basic Dryad Submission Flow
     * Updates the total dataset size by querying Merritt
 
 
-Merritt States
-=================
+Resource States (aka versionStatus)
+====================================
 
-The Merritt status is stored in resource.current_resource_state (StashEngine::ResourceState).
+The resource state is stored in resource.current_resource_state (StashEngine::ResourceState).
 Allowable values:
 - in_progress = someone is editing and hasn't submitted this version to Merritt yet
 - processing = processing through Merritt as a submission right now (or maybe stalled in rare circumstances)

--- a/documentation/submission_flow.md
+++ b/documentation/submission_flow.md
@@ -15,24 +15,22 @@ Basic Dryad Submission Flow
     * Accept license
 4. Submission
     * Update metadata with EZID/DataCite for the submitted item.
-    * Uses SWORD to submit to Merritt in background process
-    * SWORD submission is currently synchronous within background process
+    * Submits to the storage system in a background process
     * Package sent contains manifest (for URLs) or zip file with metadata files and data files
-      * Mrt-datacite.xml, mrt-dataone-manifest.txt, mrt-embargo.txt, mrt-oaidc.xml, stash-wrapper.xml sent to merritt
-      * If sending a manifest, these xml files are hosted on the Dash server and picked up by Merritt as part of its ingest.
+      * Mrt-datacite.xml, mrt-dataone-manifest.txt, mrt-embargo.txt, mrt-oaidc.xml, stash-wrapper.xml
 5. Notifying of completion
-    * When Merritt has successfully ingested the dataset, the dataset
-      shows up in Merritt's [local id search](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/CDLUC3/mrt-dashboard/main/swagger.yml#/experimental/get_api__group__local_id_search)
+    * When the storage system has successfully ingested the dataset, the dataset
+      shows up in the [local id search](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/CDLUC3/mrt-dashboard/main/swagger.yml#/experimental/get_api__group__local_id_search)
     * A daemon in a rake task runs to check for updates can be
       started like `RAILS_ENV=development rails merritt_status:update` or
       likely will be added to systemd startup scripts on one server.
-    * With new updates it updates status for items that have gone through Merritt
+    * With new updates it updates status for items that have been stored
 6. UI finishes actions for successfully submitted dataset
     * Sets download_uri and update_uri if needed
     * Changes state to ‘submitted’
     * Cleans up staged, temporary files for this submission
     * Delivers invitations for co-authors without ORCIDs
-    * Updates the total dataset size by querying Merritt
+    * Updates the total dataset size
 
 
 Resource States (aka versionStatus)
@@ -40,10 +38,11 @@ Resource States (aka versionStatus)
 
 The resource state is stored in resource.current_resource_state (StashEngine::ResourceState).
 Allowable values:
-- in_progress = someone is editing and hasn't submitted this version to Merritt yet
-- processing = processing through Merritt as a submission right now (or maybe stalled in rare circumstances)
-- submitted = submitted to Merritt successfully
-- error = some error occurred while submitting to Merritt
+- in_progress = someone is editing and hasn't submitted this version to storage yet
+- processing = processing as a submission right now (or maybe stalled in rare circumstances)
+- submitted = submitted successfully
+- error = some error occurred while submitting
+
 
 Curation Status
 =====================


### PR DESCRIPTION
Expanded documentation at the request of the American Chemical Society. Also took the opportunity to remove some Merritt-specific language.