### PR TITLE
Makes it clear that Zenodo items are not published until the dataset is published

### DIFF
--- a/app/views/stash_datacite/related_identifiers/_landing_related_works.html.erb
+++ b/app/views/stash_datacite/related_identifiers/_landing_related_works.html.erb
@@ -1,4 +1,3 @@
-
 <% # Article IDs %>
 
 <% prim_article_ids = @resource.related_identifiers.where(work_type: :primary_article).where(hidden: false).order(work_type: :desc) %>
@@ -21,14 +20,22 @@
 	<% other_ids.each do |r| %>
 	    <% bad_asterisk = ( (current_user&.limited_curator? && !r.verified?) ? ' *' : '') %>
 	    <li>
-		<% if r.work_type == 'undefined' %>
-		    This dataset <%= r.relation_name_english %>
-		    <%= display_id(type: r.related_identifier_type,
-				   my_id: r.related_identifier) %> <%= bad_asterisk %>
-		<% else %>
-		    <%= link_to r.related_identifier.ellipsisize(40), r.related_identifier, class: 'o-link__primary', title: r.related_identifier, target: "_blank" %>
-		    <%= bad_asterisk %><span class="screen-reader-only"> (opens in new window)</span>
-		<% end %>
+				<% if r.work_type == 'undefined' %>
+						This dataset <%= r.relation_name_english %>
+						<%= display_id(type: r.related_identifier_type,
+							 my_id: r.related_identifier) %> <%= bad_asterisk %>
+				<% else %>
+					<% if r.added_by != 'zenodo' || r&.resource&.file_view %> <!-- non-zenodo or published already -->
+						<%= link_to r.related_identifier.ellipsisize(40), r.related_identifier, class: 'o-link__primary', title: r.related_identifier, target: "_blank" %>
+						<%= bad_asterisk %><span class="screen-reader-only"> (opens in new window)</span>
+					<% else %> <!-- not put in the zenodo queue to publish until the dataset is actually published -->
+						<span title="<%= r.related_identifier %>"><%= r.related_identifier.ellipsisize(40) %></span>
+						<%= bad_asterisk %>
+					<% end %>
+				<% end %>
+				<% if r.added_by == 'zenodo' && !r&.resource&.file_view %>
+					<br/>(to be published with dataset)
+				<% end %>
 	    </li>
 	<% end %>
     </ul>


### PR DESCRIPTION
https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2933

1. A user or curator went in and re-entered their old Zenodo DOI links for a first published version of a dataset into a proposed v2 version. They also uploaded new items and changed the supplemental and software files in Zenodo which creates new DOIs for those uploads that will be used on publication of the new version.
2. They now had 4 links showing since they manually added 2 and the system added two for the new version at Zenodo.
3. The prospective Zenodo related works show as links before publication, even though they don't become registered and active until after publication (when they are also published on Zenodo).
4. They complained that they had 4 links and that two of them didn't work.

This change unlinks things at Zenodo that haven't been published yet and adds "(to be published with dataset)" text so that it's clear they shouldn't submit support tickets for links that don't work for something that is still unpublished.  (The screen shots have different URLs I hacked into the database since the Zenodo software is all still  broken in whatever dev/stage/qa server they want us to use.)

![Screenshot 2023-11-13 at 12 37 38 PM](https://github.com/CDL-Dryad/dryad-app/assets/105433/aafcdbcc-6abe-42ab-b82b-3ebdb1f8a43f)

PS. ONLY the related works specifically automatically added by the zenodo software layer is updated or removed by the Zenodo software layer later.  It sets a special flag in the database on these items.  If a user or curator decides to duplicate the related works that Zenodo already has--by typing them in the form--they will not be managed or updated by Zenodo since things typed into the UI do not receive that flag.  If you enter a related work by yourself, you're in charge of managing it and updating it yourself.

