### PR TITLE
Allows specifying the exact filename for presigned urls

### DIFF
--- a/app/models/stash_engine/data_file.rb
+++ b/app/models/stash_engine/data_file.rb
@@ -98,7 +98,7 @@ module StashEngine
     # the permanent storage URL, not the staged storage URL
     def s3_permanent_presigned_url
       Stash::Aws::S3.new(s3_bucket_name: APP_CONFIG[:s3][:merritt_bucket])
-        .presigned_download_url(s3_key: s3_permanent_path)
+        .presigned_download_url(s3_key: s3_permanent_path, filename: upload_file_name)
     end
 
     # http://<merritt-url>/d/<ark>/<version>/<encoded-fn> is an example of the URLs Merritt takes

--- a/lib/stash/aws/s3.rb
+++ b/lib/stash/aws/s3.rb
@@ -50,11 +50,15 @@ module Stash
         obj.size
       end
 
-      def presigned_download_url(s3_key:)
+      def presigned_download_url(s3_key:, filename: nil)
         return unless s3_key
 
         object = s3_bucket.object(s3_key)
-        object.presigned_url(:get, expires_in: 1.day.to_i)
+        if filename.nil?
+          object.presigned_url(:get, expires_in: 1.day.to_i)
+        else
+          object.presigned_url(:get, expires_in: 1.day.to_i, response_content_disposition: "attachment; filename=#{filename}")
+        end
       end
 
       def delete_file(s3_key:)


### PR DESCRIPTION
In case s3 doesn't set it correctly from what the bucket has or if the browser wants to mangle it somehow.

Closes https://github.com/CDL-Dryad/dryad-product-roadmap/issues/969 for the new downloading outside of Merritt.

See http://localhost:3000/stash/dataset/doi:10.7959/dryad.0gb5mkm0 (dryad-dev.cdlib.org) which has an example filename that liked to get mangled by S3 or the browser.