### PR TITLE
Modify tinyMCE editor functionality to include less garbage HTML

### DIFF
--- a/app/javascript/react/components/MetadataEntry/Description.jsx
+++ b/app/javascript/react/components/MetadataEntry/Description.jsx
@@ -1,6 +1,7 @@
-import React, {useRef} from 'react';
+import React, {useRef, useCallback} from 'react';
 import {Editor} from '@tinymce/tinymce-react';
 import axios from 'axios';
+import {debounce} from 'lodash';
 import PropTypes from 'prop-types';
 import {showSavedMsg, showSavingMsg} from '../../../lib/utils';
 
@@ -50,14 +51,14 @@ const curatorTools = '| code strikethrough forecolor backcolor';
 export default function Description({
   dcsDescription, path, mceKey, mceLabel, isCurator,
 }) {
-  const csrf = document.querySelector("meta[name='csrf-token']")?.getAttribute('content');
+  const authenticity_token = document.querySelector("meta[name='csrf-token']")?.getAttribute('content');
 
   const editorRef = useRef(null);
 
   const submit = () => {
     if (editorRef.current) {
       const subJson = {
-        authenticity_token: csrf,
+        authenticity_token,
         description: {
           description: editorRef.current.getContent(),
           resource_id: dcsDescription.resource_id,
@@ -74,6 +75,8 @@ export default function Description({
         });
     }
   };
+
+  const checkSubmit = useCallback(debounce(submit, 900), []);
 
   // remove registration nag https://medium.com/@petehouston/remove-tinymce-warning-notification-on-cloud-api-key-70a4a352b8b0
 
@@ -107,7 +110,8 @@ export default function Description({
           paste_block_drop: true,
           paste_preprocess,
         }}
-        onBlur={() => { submit(); }}
+        onBlur={submit}
+        onEditorChange={checkSubmit}
       />
       <p>Press Alt 0 or Option 0 for help using the rich text editor with keyboard only.</p>
     </div>

--- a/app/javascript/react/components/MetadataEntry/Description.jsx
+++ b/app/javascript/react/components/MetadataEntry/Description.jsx
@@ -4,28 +4,44 @@ import axios from 'axios';
 import PropTypes from 'prop-types';
 import {showSavedMsg, showSavingMsg} from '../../../lib/utils';
 
+/* eslint-disable no-param-reassign */
+const removeStyle = (el) => {
+  const b = ['bold', '700'].includes(el.style.fontWeight);
+  const i = el.style.fontStyle === 'italic';
+  const sup = el.style.verticalAlign === 'super';
+  const sub = el.style.verticalAlign === 'sub';
+  [...el.attributes].forEach((attr) => attr.name !== 'href' && el.removeAttribute(attr.name));
+  if (b) {
+    const strong = document.createElement('strong');
+    strong.innerHTML = el.outerHTML;
+    el.replaceWith(strong);
+    el = strong;
+  }
+  if (i) {
+    const em = document.createElement('em');
+    em.innerHTML = el.outerHTML;
+    el.replaceWith(em);
+    el = em;
+  }
+  if (sup) {
+    const supEl = document.createElement('sup');
+    supEl.innerHTML = el.outerHTML;
+    el.replaceWith(supEl);
+  } else if (sub) {
+    const subEl = document.createElement('sub');
+    subEl.innerHTML = el.outerHTML;
+    el.replaceWith(subEl);
+  }
+  el.querySelectorAll('*').forEach((childEl) => removeStyle(childEl));
+};
+/* eslint-enable no-param-reassign */
+
 const paste_preprocess = (_editor, args) => {
+  // remove most style, replace important styles with semantic tags
   const {content} = args;
   const parser = new DOMParser();
   const doc = parser.parseFromString(content, 'text/html');
-  doc.body.querySelectorAll('*').forEach((el) => {
-    const b = ['bold', '700'].includes(el.style.fontWeight);
-    const em = el.style.fontStyle === 'italic';
-    const sup = el.style.verticalAlign === 'super';
-    const sub = el.style.verticalAlign === 'sub';
-    [...el.attributes].forEach((attr) => attr.name !== 'href' && el.removeAttribute(attr.name));
-    if (b) el.style.fontWeight = 700;
-    if (em) el.style.fontStyle = 'italic';
-    if (sup) {
-      const supp = document.createElement('sup');
-      sup.innerHTML = el.innerHTML;
-      el.replaceWith(supp);
-    } else if (sub) {
-      const subb = document.createElement('sub');
-      subb.innerHTML = el.innerHTML;
-      el.replaceWith(subb);
-    }
-  });
+  doc.body.querySelectorAll('*').forEach((el) => removeStyle(el));
   args.content = doc.body.innerHTML;
 };
 


### PR DESCRIPTION
Removes and restricts menu buttons according to the ticket, and strips almost all style (and attributes) out of pasted text.

Closes https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2916

Also add save-on-change functionality (so exiting the editor is no longer required to save, as mentioned in curator meeting)