### PR TITLE
Dataset zip download using AWS Lambda

### DIFF
--- a/app/controllers/stash_api/datasets_controller.rb
+++ b/app/controllers/stash_api/datasets_controller.rb
@@ -386,7 +386,13 @@ module StashApi
     # get /datasets/<id>/download
     def download
       res = @stash_identifier.latest_downloadable_resource(user: @user)
-      download_version(resource: res)
+      if res&.may_download?(ui_user: @user)
+        @zip_version_presigned = Stash::Download::ZipVersionPresigned.new(controller_context: self)
+        StashEngine::CounterLogger.version_download_hit(request: request, resource: res)
+        @zip_version_presigned.download(resource: res)
+      else
+        render plain: 'Download for this version of the dataset is unavailable', status: 404
+      end
     end
 
     # post /datasets/<id>/set_internal_datum

--- a/app/controllers/stash_api/datasets_controller.rb
+++ b/app/controllers/stash_api/datasets_controller.rb
@@ -386,8 +386,8 @@ module StashApi
     # get /datasets/<id>/download
     def download
       res = @stash_identifier.latest_downloadable_resource(user: @user)
-      if res&.may_download?(ui_user: @user)
-        @zip_version_presigned = Stash::Download::ZipVersionPresigned.new(controller_context: self)
+      @zip_version_presigned = Stash::Download::ZipVersionPresigned.new(controller_context: self, resource: res)
+      if res&.may_download?(ui_user: @user) && @zip_version_presigned.valid_resource?
         StashEngine::CounterLogger.version_download_hit(request: request, resource: res)
         @zip_version_presigned.download(resource: res)
       else

--- a/app/controllers/stash_api/versions_controller.rb
+++ b/app/controllers/stash_api/versions_controller.rb
@@ -44,6 +44,9 @@ module StashApi
     # get /versions/<id>/zip_assembly
     def zip_assembly
       @resource = StashEngine::Resource.find(params[:id])
+      found = @resource&.download_token
+      render json: 'Unauthorized', status: 401 unless found.token == params[:token] && Time.now.utc < found.available
+
       info = @resource.data_files.present_files.map do |f|
         {
           size: f.upload_file_size,

--- a/app/controllers/stash_api/versions_controller.rb
+++ b/app/controllers/stash_api/versions_controller.rb
@@ -37,20 +37,15 @@ module StashApi
 
     # get /versions/<id>/zip_assembly
     def zip_assembly
-      respond_to do |format|
-        format.json do
-          # input is resource_id and output is json with keys size, filename and url for each entry
-          @resource = Resource.find(params[:id])
-          info = @resource.data_files.present_files.map do |f|
-            {
-              size: f.upload_file_size,
-              filename: f.upload_file_name,
-              url: f.s3_permanent_presigned_url
-            }
-          end
-          render json: info
-        end
+      @resource = StashEngine::Resource.find(params[:id])
+      info = @resource.data_files.present_files.map do |f|
+        {
+          size: f.upload_file_size,
+          filename: f.upload_file_name,
+          url: f.s3_permanent_presigned_url
+        }
       end
+      render json: info
     end
 
     private

--- a/app/controllers/stash_api/versions_controller.rb
+++ b/app/controllers/stash_api/versions_controller.rb
@@ -29,7 +29,9 @@ module StashApi
     def download
       if @stash_resources.length == 1
         res = @stash_resources.first
-        download_version(resource: res)
+        @zip_version_presigned = Stash::Download::ZipVersionPresigned.new(controller_context: self)
+        StashEngine::CounterLogger.version_download_hit(request: request, resource: res)
+        @zip_version_presigned.download(resource: res)
       else
         render text: 'not found', status: 404
       end

--- a/app/controllers/stash_api/versions_controller.rb
+++ b/app/controllers/stash_api/versions_controller.rb
@@ -29,11 +29,15 @@ module StashApi
     def download
       if @stash_resources.length == 1
         res = @stash_resources.first
-        @zip_version_presigned = Stash::Download::ZipVersionPresigned.new(controller_context: self)
-        StashEngine::CounterLogger.version_download_hit(request: request, resource: res)
-        @zip_version_presigned.download(resource: res)
+        @zip_version_presigned = Stash::Download::ZipVersionPresigned.new(controller_context: self, resource: res)
+        if res&.may_download?(ui_user: @user) && @zip_version_presigned.valid_resource?
+          StashEngine::CounterLogger.version_download_hit(request: request, resource: res)
+          @zip_version_presigned.download(resource: res)
+        else
+          render plain: 'Download for this version of the dataset is unavailable', status: 404
+        end
       else
-        render text: 'not found', status: 404
+        render plain: 'not found', status: 404
       end
     end
 

--- a/app/controllers/stash_api/versions_controller.rb
+++ b/app/controllers/stash_api/versions_controller.rb
@@ -43,7 +43,7 @@ module StashApi
 
     # get /versions/<id>/zip_assembly
     def zip_assembly
-      @resource = StashEngine::Resource.find(params[:id])
+      @resource = StashEngine::Resource.find(params[:version_id])
       found = @resource&.download_token
       render json: 'Unauthorized', status: 401 unless found.token == params[:token] && Time.now.utc < found.available
 

--- a/app/controllers/stash_api/versions_controller.rb
+++ b/app/controllers/stash_api/versions_controller.rb
@@ -45,16 +45,18 @@ module StashApi
     def zip_assembly
       @resource = StashEngine::Resource.find(params[:version_id])
       found = @resource&.download_token
-      render json: 'Unauthorized', status: 401 unless found.token == params[:token] && Time.now.utc < found.available
-
-      info = @resource.data_files.present_files.map do |f|
-        {
-          size: f.upload_file_size,
-          filename: f.upload_file_name,
-          url: f.s3_permanent_presigned_url
-        }
+      if found.token == params[:token] && Time.now.utc < found.available
+        info = @resource.data_files.present_files.map do |f|
+          {
+            size: f.upload_file_size,
+            filename: f.upload_file_name,
+            url: f.s3_permanent_presigned_url
+          }
+        end
+        render json: info
+      else
+        render json: 'Unauthorized', status: 401
       end
-      render json: info
     end
 
     private

--- a/app/controllers/stash_api/versions_controller.rb
+++ b/app/controllers/stash_api/versions_controller.rb
@@ -35,6 +35,24 @@ module StashApi
       end
     end
 
+    # get /versions/<id>/zip_assembly
+    def zip_assembly
+      respond_to do |format|
+        format.json do
+          # input is resource_id and output is json with keys size, filename and url for each entry
+          @resource = Resource.find(params[:id])
+          info = @resource.data_files.present_files.map do |f|
+            {
+              size: f.upload_file_size,
+              filename: f.upload_file_name,
+              url: f.s3_permanent_presigned_url
+            }
+          end
+          render json: info
+        end
+      end
+    end
+
     private
 
     def paged_versions_for_dataset

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -35,7 +35,7 @@ module StashEngine
     has_many :curation_activities, -> { order(id: :asc) }, class_name: 'StashEngine::CurationActivity', dependent: :destroy
     has_many :repo_queue_states, class_name: 'StashEngine::RepoQueueState', dependent: :destroy
     has_many :zenodo_copies, class_name: 'StashEngine::ZenodoCopy', dependent: :destroy
-    # download tokens are for Merritt version downloads with presigned URL caching
+    # download tokens are for validating zip assembly requests by the zipping lambda
     has_one :download_token, class_name: 'StashEngine::DownloadToken', dependent: :destroy
     has_many :publication_years, class_name: 'StashDatacite::PublicationYear', dependent: :destroy
     has_one :publisher, class_name: 'StashDatacite::Publisher', dependent: :destroy

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -170,6 +170,8 @@ defaults: &DEFAULTS
     merritt_bucket: dryad-assetstore-merritt-dev
     key: AKIA2KERHV5E3OITXZXC
     secret: <%= Rails.application.credentials[Rails.env.to_sym][:s3_secret] %>
+    lambda_id:
+      dataZip: w27i4vubmmwkssdf6xpszafmhq0rffog
   google_analytics_id: null
   matomo_analytics_id: null
   google_recaptcha_sitekey: 6Lfhn5kiAAAAAIzZPQEGRa43cDJz-rNVxRcQIkU4
@@ -190,7 +192,7 @@ defaults: &DEFAULTS
   frictionless:
     # 150 MB and below
     size_limit: 10_000_000
-    missing_values: "na,n/a,.,none,NA,N/A,N.A.,n.a.,-,empty,blank"
+    missing_values: ",NA,na,N/A,n/a,N.A.,n.a.,-,.,empty,blank"
   rate_limit:
     # number of requests allowed per minute
     all_requests: 120

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,7 +106,7 @@ Rails.application.routes.draw do
 
       resources :versions, shallow: true, path: '/versions' do
         get 'download', on: :member
-        get 'zip_assembly', on: :member
+        get 'zip_assembly(/:token)', token: %r{[^\s/]+?}, to: 'versions#zip_assembly', as: 'zip_assembly'
         resources :files, shallow: true, path: '/files' do
           get :download, on: :member
           resource :frictionless_report, path: '/frictionlessReport'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,6 +106,7 @@ Rails.application.routes.draw do
 
       resources :versions, shallow: true, path: '/versions' do
         get 'download', on: :member
+        get 'zip_assembly', on: :member
         resources :files, shallow: true, path: '/files' do
           get :download, on: :member
           resource :frictionless_report, path: '/frictionlessReport'

--- a/lib/stash/download/zip_version_presigned.rb
+++ b/lib/stash/download/zip_version_presigned.rb
@@ -13,8 +13,17 @@ module Stash
 
       # passing the controller context allows us to do actions the controller would normally do such as redirecting
       # or rendering within the rails context
-      def initialize(controller_context:)
+      def initialize(controller_context:, resource:)
         @cc = controller_context
+        @resource = resource
+        return if @resource.blank?
+
+        @tenant = @resource&.tenant
+        @version = @resource&.stash_version
+      end
+
+      def valid_resource?
+        !(@resource.blank? || @tenant.blank? || @version.blank?)
       end
 
       def download(resource:)

--- a/lib/stash/download/zip_version_presigned.rb
+++ b/lib/stash/download/zip_version_presigned.rb
@@ -26,24 +26,35 @@ module Stash
         !(@resource.blank? || @tenant.blank? || @version.blank?)
       end
 
+      def generate_token
+        token = @resource.download_token
+        token.token = SecureRandom.uuid if token.token.nil?
+        token.available = Time.now.utc + (1 * 60)
+        token.save
+        token.token
+      end
+
       def download(resource:)
-        if resource&.total_file_size&. < APP_CONFIG.maximums.zip_size
+        @resource ||= resource
+        if @resource&.total_file_size&. < APP_CONFIG.maximums.zip_size
           credentials = ::Aws::Credentials.new(APP_CONFIG[:s3][:key], APP_CONFIG[:s3][:secret])
           signer = ::Aws::Sigv4::Signer.new(service: 'lambda', region: APP_CONFIG[:s3][:region], credentials_provider: credentials)
 
-          time = resource.publication_date.present? && resource.publication_date < Time.now.utc ? resource.publication_date : resource.updated_at
+          time = @resource.publication_date.present? && @resource.publication_date < Time.now.utc ? @resource.publication_date : @resource.updated_at
 
           zip_name = "#{"doi_#{resource.identifier_value}__v#{time.strftime('%Y%m%d')}".gsub(
             %r{\.|:|/}, '_'
           )}.zip"
 
           h = Rails.application.routes.url_helpers
-          download_url = h.zip_assembly_version_url(resource.id).gsub('http://localhost:3000', 'https://dryad-dev.cdlib.org').gsub(/^http:/, 'https:')
+          download_url = h.version_zip_assembly_url(@resource.id).gsub('http://localhost:3000', 'https://dryad-dev.cdlib.org').gsub(/^http:/, 'https:')
+
+          p generate_token
 
           zip_url = signer.presign_url(
             http_method: 'GET',
             expires_in: 3600,
-            url: "https://w27i4vubmmwkssdf6xpszafmhq0rffog.lambda-url.us-west-2.on.aws/?filename=#{zip_name}&download_url=#{CGI.escape(download_url)}"
+            url: "https://w27i4vubmmwkssdf6xpszafmhq0rffog.lambda-url.us-west-2.on.aws/?filename=#{zip_name}&download_url=#{CGI.escape("#{download_url}/#{generate_token}")}"
           )
           cc.redirect_to zip_url.to_s
         else

--- a/lib/stash/download/zip_version_presigned.rb
+++ b/lib/stash/download/zip_version_presigned.rb
@@ -36,7 +36,8 @@ module Stash
 
       def download(resource:)
         @resource ||= resource
-        if APP_CONFIG.maximums.zip_size > @resource&.total_file_size
+        # APP_CONFIG.maximums.zip_size
+        if @resource&.total_file_size&. < 200_000_000
           credentials = ::Aws::Credentials.new(APP_CONFIG[:s3][:key], APP_CONFIG[:s3][:secret])
           signer = ::Aws::Sigv4::Signer.new(service: 'lambda', region: APP_CONFIG[:s3][:region], credentials_provider: credentials)
 

--- a/lib/stash/download/zip_version_presigned.rb
+++ b/lib/stash/download/zip_version_presigned.rb
@@ -49,8 +49,6 @@ module Stash
           h = Rails.application.routes.url_helpers
           download_url = h.version_zip_assembly_url(@resource.id).gsub('http://localhost:3000', 'https://dryad-dev.cdlib.org').gsub(/^http:/, 'https:')
 
-          p generate_token
-
           zip_url = signer.presign_url(
             http_method: 'GET',
             expires_in: 3600,

--- a/lib/stash/download/zip_version_presigned.rb
+++ b/lib/stash/download/zip_version_presigned.rb
@@ -1,0 +1,47 @@
+require 'byebug'
+require 'http'
+
+# a significantly simplified class for dealing with Files instead of sending them through our server
+# and redirects to a S3 presigned URL
+module Stash
+  module Download
+
+    class S3CustomError < StandardError; end
+
+    class ZipVersionPresigned
+      attr_reader :cc
+
+      # passing the controller context allows us to do actions the controller would normally do such as redirecting
+      # or rendering within the rails context
+      def initialize(controller_context:)
+        @cc = controller_context
+      end
+
+      def download(resource:)
+        if resource&.total_file_size&. < APP_CONFIG.maximums.zip_size
+          credentials = ::Aws::Credentials.new(APP_CONFIG[:s3][:key], APP_CONFIG[:s3][:secret])
+          signer = ::Aws::Sigv4::Signer.new(service: 'lambda', region: APP_CONFIG[:s3][:region], credentials_provider: credentials)
+
+          time = resource.publication_date.present? && resource.publication_date < Time.now.utc ? resource.publication_date : resource.updated_at
+
+          zip_name = "#{"doi_#{resource.identifier_value}__v#{time.strftime('%Y%m%d')}".gsub(
+            %r{\.|:|/}, '_'
+          )}.zip"
+
+          h = Rails.application.routes.url_helpers
+          download_url = h.zip_assembly_version_url(resource.id).gsub('http://localhost:3000', 'https://dryad-dev.cdlib.org').gsub(/^http:/, 'https:')
+
+          zip_url = signer.presign_url(
+            http_method: 'GET',
+            expires_in: 3600,
+            url: "https://w27i4vubmmwkssdf6xpszafmhq0rffog.lambda-url.us-west-2.on.aws/?filename=#{zip_name}&download_url=#{CGI.escape(download_url)}"
+          )
+          cc.redirect_to zip_url.to_s
+        else
+          cc.render status: 405, plain: 'The dataset is too large for zip file generation. Please download each file individually.'
+        end
+      end
+
+    end
+  end
+end

--- a/script/dataZip/index.mjs
+++ b/script/dataZip/index.mjs
@@ -1,0 +1,52 @@
+import stream, {PassThrough} from 'stream';
+import fetch from 'node-fetch';
+import util from 'util';
+import archiver from 'archiver';
+
+const pipeline = util.promisify(stream.pipeline);
+
+export const handler = awslambda.streamifyResponse(async (event, responseStream) => {
+  const {filename, download_url} = event.queryStringParameters;
+  const headers = {
+    'Content-Type': 'application/zip',
+    'Content-Disposition': `attachment;filename="${filename}"`
+  };
+  const requestStream = new PassThrough();
+  const streamResponse = awslambda.HttpResponseStream.from(responseStream, {
+    statusCode: 200,
+    headers,
+  });
+  const archive = archiver('zip', {forceZip64: true, zlib: {level: 0}});
+  streamResponse.on('close', () => {
+    console.log('The archive is complete and the stream is closed');
+  });
+  streamResponse.on('finish', () => {
+    console.log('Stream is finished');
+  });
+  streamResponse.on('end', () => {
+    console.log('Data has been drained');
+  });
+  streamResponse.on('error', (err) => {
+    throw err;
+  })
+  archive.on('error', (err) => {
+    throw err;
+  });
+  archive.pipe(streamResponse);
+  const response = await fetch(download_url, {
+    method: 'GET', 
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+    }
+  })
+  if (!response.ok) throw new Error('Unable to retrieve dataset file URLs');
+  const files = await response.json();
+  for (const f of files) {
+    const content = await fetch(f.url);
+    archive.append(content.body, {name: f.filename});
+    requestStream.pipe(content.body);
+  }
+  archive.finalize();
+  await pipeline(requestStream, streamResponse);
+});

--- a/script/dataZip/index.mjs
+++ b/script/dataZip/index.mjs
@@ -7,46 +7,60 @@ const pipeline = util.promisify(stream.pipeline);
 
 export const handler = awslambda.streamifyResponse(async (event, responseStream) => {
   const {filename, download_url} = event.queryStringParameters;
-  const headers = {
-    'Content-Type': 'application/zip',
-    'Content-Disposition': `attachment;filename="${filename}"`
-  };
   const requestStream = new PassThrough();
-  const streamResponse = awslambda.HttpResponseStream.from(responseStream, {
-    statusCode: 200,
-    headers,
-  });
-  const archive = archiver('zip', {forceZip64: true, zlib: {level: 0}});
-  streamResponse.on('close', () => {
-    console.log('The archive is complete and the stream is closed');
-  });
-  streamResponse.on('finish', () => {
-    console.log('Stream is finished');
-  });
-  streamResponse.on('end', () => {
-    console.log('Data has been drained');
-  });
-  streamResponse.on('error', (err) => {
-    throw err;
-  })
-  archive.on('error', (err) => {
-    throw err;
-  });
-  archive.pipe(streamResponse);
   const response = await fetch(download_url, {
     method: 'GET', 
     headers: {
       'Accept': 'application/json',
       'Content-Type': 'application/json',
     }
-  })
-  if (!response.ok) throw new Error('Unable to retrieve dataset file URLs');
-  const files = await response.json();
-  for (const f of files) {
-    const content = await fetch(f.url);
-    archive.append(content.body, {name: f.filename});
-    requestStream.pipe(content.body);
+  });
+  if (!response.ok) {
+    const streamResponse = awslambda.HttpResponseStream.from(responseStream, {
+      statusCode: 500,
+    });
+    streamResponse.write(JSON.stringify('Unable to retrieve dataset file URLs (Unauthorized)'));
+    requestStream.end();
+    streamResponse.end();
+    await pipeline(requestStream, streamResponse);
+  } else {
+    const headers = {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': `attachment;filename="${filename}"`
+    };
+    const streamResponse = awslambda.HttpResponseStream.from(responseStream, {
+      statusCode: 200,
+      headers,
+    });
+    const archive = archiver('zip', {forceZip64: true, zlib: {level: 0}});
+    streamResponse.on('close', () => {
+      console.log('The archive is complete and the stream is closed');
+    });
+    streamResponse.on('finish', () => {
+      console.log('Stream is finished');
+      requestStream.end();
+    });
+    requestStream.on('end', () => {
+      console.log('Data has been drained');
+      streamResponse.end();
+    });
+    requestStream.on('error', (err) => {
+      throw err;
+    })
+    streamResponse.on('error', (err) => {
+      throw err;
+    })
+    archive.on('error', (err) => {
+      throw err;
+    });
+    archive.pipe(streamResponse);
+    const files = await response.json();
+    for (const f of files) {
+      const content = await fetch(f.url);
+      archive.append(content.body, {name: f.filename});
+      requestStream.pipe(content.body);
+    }
+    archive.finalize();
+    await pipeline(requestStream, streamResponse);
   }
-  archive.finalize();
-  await pipeline(requestStream, streamResponse);
 });

--- a/script/dataZip/package.json
+++ b/script/dataZip/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "dryad-dataZip-lambda",
+  "version": "1.0.0",
+  "dependencies": {
+    "archiver": "^6.0.1",
+    "node-fetch": "^3.3.2",
+    "stream": "^0.0.2",
+    "util": "^0.12.5"
+  }
+}

--- a/spec/requests/stash_api/versions_controller_spec.rb
+++ b/spec/requests/stash_api/versions_controller_spec.rb
@@ -256,13 +256,17 @@ module StashApi
 
         @resources[1].current_state = 'submitted' # has to show submitted to merritt in order to download
 
-        allow_any_instance_of(Stash::Download::VersionPresigned).to receive('valid_resource?').and_return(true)
+        allow_any_instance_of(Stash::Download::ZipVersionPresigned).to receive('valid_resource?').and_return(true)
       end
 
       describe 'permissions' do
         before(:each) do
-          allow_any_instance_of(Stash::Download::VersionPresigned).to receive(:download)
-            .and_return({ status: 200, url: 'http://example.com/fun' }.with_indifferent_access)
+          allow_any_instance_of(Stash::Download::ZipVersionPresigned).to receive(:download) do |o|
+            # o is the object instance and cc is the controller context
+            # o.cc.response.headers['Location'] = 'http://example.com'
+            # o.cc.render -- this isn't needed in the tests and causes a double-render which is different than the actual method
+            o.cc.redirect_to 'http://example.com/fun'
+          end
         end
 
         it 'downloads a public version' do
@@ -324,7 +328,7 @@ module StashApi
 
       describe 'response codes' do
 
-        it 'handles 202 from Merritt presigned library' do
+        xit 'handles 202 from Merritt presigned library' do
           allow_any_instance_of(Stash::Download::VersionPresigned).to receive(:download)
             .and_return({ status: 202, url: 'http://example.com/fun' }.with_indifferent_access)
           # some horrific callback or something that is untraceable keeps resetting file_view to false
@@ -338,7 +342,7 @@ module StashApi
           expect(response.body).to include('less than a minute')
         end
 
-        it 'handles 408 from Merritt presigned library' do
+        xit 'handles 408 from Merritt presigned library' do
           allow_any_instance_of(Stash::Download::VersionPresigned).to receive(:download)
             .and_return({ status: 408 }.with_indifferent_access)
           # some horrific callback or something that is untraceable keeps resetting file_view to false
@@ -351,7 +355,7 @@ module StashApi
           expect(response.body).to include('Download Service Unavailable for this request')
         end
 
-        it 'handles other random code from Merritt presigned library' do
+        xit 'handles other random code from Merritt presigned library' do
           allow_any_instance_of(Stash::Download::VersionPresigned).to receive(:download)
             .and_return({ status: 417 }.with_indifferent_access)
           # some horrific callback or something that is untraceable keeps resetting file_view to false


### PR DESCRIPTION
Closes (?) https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2939

I have created an AWS lambda function that creates and streams a zip file to the client, and edited the version download in our API to use it. There are several remaining things to be done.

- For streamed lambda responses, "There is an initial maximum response size of 20 MB, which is a soft limit you can increase." To meet the target of up to 10GB downloads, the size of downloads (streamed response size) allowed by the lambda will need to be increased, which looks like it will require contacting Amazon ("The payload size for streamed responses can be increased from default values. Contact AWS Support to inquire further.")
- When we're satisfied with the functionality, we can also set up the browser zip download to use this for those users without serviceworkers enabled in their browser (JS limitations).
