### PR TITLE
Stop error messages for invalid presigned URLs

### DIFF
--- a/app/controllers/stash_engine/downloads_controller.rb
+++ b/app/controllers/stash_engine/downloads_controller.rb
@@ -138,7 +138,7 @@ module StashEngine
     # Also may need to enable passing secret token for sharing access and right now we only supply Zenodo downloads for
     # private access, not to the general public which should go to Zenodo to examine the full info and downloads.
     def zenodo_file
-      zen_upload = GenericFile.where(id: params[:file_id]).first
+      zen_upload = GenericFile.where(id: params[:file_id]).first # gets cast to the specific type
       res = zen_upload&.resource
       share = (params[:share].blank? ? nil : StashEngine::Share.where(secret_id: params[:share]).first)
 

--- a/app/controllers/stash_engine/downloads_controller.rb
+++ b/app/controllers/stash_engine/downloads_controller.rb
@@ -143,7 +143,8 @@ module StashEngine
       share = (params[:share].blank? ? nil : StashEngine::Share.where(secret_id: params[:share]).first)
 
       # can see if they had permission or the Share matches the identifier
-      if res && (res&.may_download?(ui_user: current_user) || share&.identifier_id == res&.identifier&.id)
+      if res && (res&.may_download?(ui_user: current_user) || share&.identifier_id == res&.identifier&.id) &&
+          [StashEngine::SuppFile, StashEngine::SoftwareFile].include?(zen_upload.class)
         if res.zenodo_published?
           redirect_to zen_upload.public_zenodo_download_url
         else


### PR DESCRIPTION
Invalid because they are DataFiles which we don't give RAT urls for Zenodo for.

Closes https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2729 