### PR TITLE
Adding script for comparison of our COUNTER logs vs DataCite tracking

### DIFF
--- a/script/counter_log_comparison/Gemfile
+++ b/script/counter_log_comparison/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "activerecord", "~> 6.0.0"
+gem "sqlite3", "~> 1.4.0"
+gem "byebug"

--- a/script/counter_log_comparison/Gemfile.lock
+++ b/script/counter_log_comparison/Gemfile.lock
@@ -1,0 +1,35 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (6.0.6.1)
+      activesupport (= 6.0.6.1)
+    activerecord (6.0.6.1)
+      activemodel (= 6.0.6.1)
+      activesupport (= 6.0.6.1)
+    activesupport (6.0.6.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    byebug (11.1.3)
+    concurrent-ruby (1.2.2)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    minitest (5.20.0)
+    sqlite3 (1.4.4)
+    thread_safe (0.3.6)
+    tzinfo (1.2.11)
+      thread_safe (~> 0.1)
+    zeitwerk (2.6.12)
+
+PLATFORMS
+  x86_64-darwin-21
+
+DEPENDENCIES
+  activerecord (~> 6.0.0)
+  byebug
+  sqlite3 (~> 1.4.0)
+
+BUNDLED WITH
+   2.4.10

--- a/script/counter_log_comparison/cdl_logs.rb
+++ b/script/counter_log_comparison/cdl_logs.rb
@@ -1,0 +1,127 @@
+#!/usr/bin/env ruby
+# call like ./cdl_logs.rb -a cdl -f dryad_raw_events_20231101_sorted.csv to import some CDL logs
+
+require 'bundler/setup'
+Bundler.require
+require "active_record"
+require_relative 'create_counter_table'
+require_relative 'counter_log'
+require 'optparse'
+require 'uri'
+require 'csv'
+require 'byebug'
+
+ActiveRecord::Base.establish_connection(
+  adapter:  'sqlite3',
+  database: 'cdl_logs.sqlite3.db'
+)
+
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'cdl_logs.sqlite3.db')
+CreateCounterTable.migrate(:up) unless ActiveRecord::Base.connection.table_exists? 'counter_log'
+
+VIEW = Regexp.new(%w(
+  ^\/api\/v2\/datasets\/[^\/]+$
+  ^\/api\/v2\/versions\/\d+$/
+  ^\/stash\/dataset\/\S+$
+  ^\/stash\/landing\/show$
+  ^\/stash\/data_paper\/\S+$
+  ^\/resource\/doi:[^/]+/dryad[^/]+$
+).join('|'))
+
+DOWNLOAD = Regexp.new(%w(
+  ^\/api\/v2\/datasets\/[^\/]+\/download$
+  ^\/api\/v2\/versions\/\d+\/download$
+  ^\/api\/v2\/downloads\/\d+$
+  ^\/stash\/downloads\/download_resource\/\d+$
+  ^\/stash\/downloads\/file_download\/\d+$
+  ^\/stash\/downloads\/file_stream\/\d+$
+  ^\/stash\/downloads\/async_request\/\d+$
+  ^\/stash\/downloads\/assembly_status\/\d+$
+  ^\/stash\/share/\S+$
+  ^\/stash\/downloads\/zip_assembly_info\/\d+$
+  ^\/resource\/doi:[^/]+\/dryad[^/]+/.+$
+).join('|'))
+
+def populate_cdl_file(file:)
+  File.readlines('counter_2023-11-01.log_combined').each_with_index do |line, i|
+    next if line.blank? || line.start_with?('#')
+
+    parts = line.split("\t")
+    path = URI(parts[5]).path
+
+    hit_type = 'unknown'
+    hit_type = 'download' if path.match?(DOWNLOAD)
+    hit_type = 'view' if path.match?(VIEW)
+
+    CounterLog.create(
+      time: parts[0],
+      ip: parts[1],
+      url: parts[5],
+      doi: parts[6],
+      user_agent: parts[9],
+      hit_type: hit_type,
+      matched: false)
+    puts "Crunched #{i+1} lines" if ((i+1) % 5000).zero?
+  end
+end
+
+# it looks like
+# "timestamp","metric_name","repo_id", "user_id", "session_id", "url", "pid"
+# "2023-11-01 15:32:20.721","view","da-80l49bsf",25990524582826763,3082643891120137357,"https://datadryad.org/stash/dataset/doi:10.6078/D1MS3X","10.6078/D1MS3X"
+def match_datacite_entries(file:)
+  count = 0
+  matched_count = 0
+
+  CSV.foreach((file), headers: true, encoding: "bom|utf-8", quote_char: '"', col_sep: ',') do |row|
+    the_time = Time.find_zone("UTC").parse(row['timestamp'])
+    doi = "doi:#{row['pid']}"
+    metric = row['metric_name']
+
+    log_entry = best_match(doi: doi, time: the_time, metric: metric)
+
+    count += 1
+    matched_count += 1 unless log_entry.nil?
+    puts "Processed #{count} entries, #{matched_count} matched" if (count % 500).zero?
+
+    if log_entry.nil?
+      puts "No match for #{doi} at #{the_time} for #{metric}"
+      next
+    end
+
+    log_entry.update(matched: true)
+  end
+end
+
+def best_match(doi:, time:, metric:)
+  # find the best match for the doi, time, and metric
+  # if there is a match, mark it as matched and return it
+  # if there is no match, return nil
+  items = CounterLog.where(doi: doi, hit_type: metric).where('time BETWEEN ? AND ?', time - 60.seconds, time + 30.seconds)
+  return nil if items.blank?
+
+  # if there is only one, then use it
+  return items.first if items.length == 1
+
+  # if there are more than one, then use the one with the closest time
+  items.sort_by { |item| (item.time - time).abs }.first
+end
+
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: cdl_logs.rb --file FILE --action [cdl|datacite]"
+
+  opts.on("-f", "--file FILE", "File to process") do |f|
+    options[:file] = f
+  end
+
+  opts.on("-a", "--action [cdl|datacite]", "Action to perform") do |a|
+    options[:action] = a
+  end
+end.parse!
+
+if options[:action] == 'cdl'
+  populate_cdl_file(file: options[:file])
+elsif options[:action] == 'datacite'
+  match_datacite_entries(file: options[:file])
+end

--- a/script/counter_log_comparison/counter_log.rb
+++ b/script/counter_log_comparison/counter_log.rb
@@ -1,0 +1,4 @@
+class CounterLog < ActiveRecord::Base
+  self.table_name = 'counter_log'
+  self.primary_key = 'id'
+end

--- a/script/counter_log_comparison/create_counter_table.rb
+++ b/script/counter_log_comparison/create_counter_table.rb
@@ -1,0 +1,14 @@
+class CreateCounterTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :counter_log do |table|
+      table.timestamp :time, index: true
+      table.string :ip
+      table.text :url
+      table.string :doi, index: true
+      table.text :user_agent
+      table.string :hit_type, index: true # view or download
+      table.boolean :matched, index: true
+    end
+  end
+end
+

--- a/script/counter_log_comparison/readme.MD
+++ b/script/counter_log_comparison/readme.MD
@@ -1,0 +1,47 @@
+# Counter log comparison
+
+The files in this directory are used to compare our raw counter logs
+with the DataCite Tracker events which were sent to us as a CSV
+after requesting it from them.  It has these column headers.
+
+```csv
+"timestamp","metric_name","repo_id","user_id","session_id","url","pid"
+```
+
+## Technical info about scripts.
+
+- This is a standalone ruby script, it doesn't require rails.
+- This populates  the information into a SQLite database (which is a file).
+- It will create the SQLite database if it doesn't exist on running.
+- Uses ActiveRecord and automatically migrates the one table it creates.
+- bundle install inside this directory to get dependencies.
+
+## Running the script
+
+Usage: `ruby cdl_logs.rb --file FILE --action [cdl|datacite]`
+
+- To make use of this first run the script with the `cdl` action to
+  populate the database with the counter log file from our own logs
+  for a log date.
+- Then run the script with the `datacite` action to attempt matching events
+  from the DataCite tracker CSV file.  That will set the `matched` column to
+  1 (true) if it believes it has found a match.
+- It will output to the terminal items that it couldn't match to our logs.  I was able 
+  to get an over 90% "match" rate.
+
+## What a "match" means
+
+The data that we get from DataCite doesn't have an identifier that matches exactly
+with the things we log.  We also don't have an IP address or anything in their data.
+
+Matches are based on:
+
+- Same DOI
+- Same type (view or download)
+- Our item was logged up to 60 seconds before or 30 seconds after the DataCite event log
+  to take into account time skew between the systems.
+- Closest time match between the two if there is more than one within that time window.
+
+Clearly this matching isn't very exact, but it does seem to work a lot of the time and
+roughly line up with some events.
+


### PR DESCRIPTION
This script was just to analyze our log events vs the ones that DataCite gets.

Please see the readme.MD here for full information.  I can share the files I used non-publicly (because of privacy) and also the SQLite database it creates.

I was able to get a best guess match rate of  over 90% for DataCite events being matched in our logs.  Matching is pretty speculative.  We have a lot more events than the DataCite tracker in general.

I didn't do any in-depth analysis, but just looked over the database which shows our logs and where it believes matches occur.  I looked over the first 1,000-2,000 rows.  The pattern I see is that there are a whole lot of bots (as seen by the user agent) crawling our site constantly.  The items that are matched generally look like real browsers and users and the other traffic not as much.

We have had a very static approach to bot and machine identification with an initial list we got from the Counter project early on from a github repository and it was rarely updated (or it was moved on to someplace else without us being aware).

It seems like this difference is a major reason that the items are so different and the differences make some sense.

The tracker doesn't work with non-JS agents (such as many bots and also the API).  For tracking API usage, we got a suggestion to log and combine somehow.  But I think an simpler solution may be to make a request from our server to the tracker at DataCite to log these events with an HTTP request if that is allowed. Or perhaps we can get those events and batch them to DataCite at some frequency instead.

I'm not sure what the stance on tracking API usage is for COUNTER, really, but their tracker doesn't do it out of the box.



