### PR TITLE
Fixes Zenodo presigned "RAT" url

### DIFF
--- a/lib/stash/zenodo_software/remote_access_token.rb
+++ b/lib/stash/zenodo_software/remote_access_token.rb
@@ -41,7 +41,7 @@ module Stash
         buck_url = get_bucket_url(deposition_id)
         return nil if buck_url.nil?
 
-        "#{buck_url}/#{ERB::Util.url_encode(filename)}?token=#{ERB::Util.url_encode(rat_token)}"
+        "#{buck_url}/#{ERB::Util.url_encode(filename)}?resource-token=#{ERB::Util.url_encode(rat_token)}"
       end
 
       def get_bucket_url(deposition_id)


### PR DESCRIPTION
See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2954 .

It seemed they changed the URL to have a parameter of `resource-token` instead of `token`.  IDK if this was documented anywhere (the URL wasn't documented at all when we put it in).  In any case, it was an easy fix once we got a reply.

To test, see the example from the ticket above.  Be sure to test using an incognito window if you're logged into Zenodo in your browser since it will work if you're logged in, no matter what.

I just made this change directly to our production code, also, since we still don't have a sandbox to test things at Zenodo before trying them in production.  It worked there. :-/