### PR TITLE
feat: add a dedicated `api_requests` log file

### DIFF
--- a/app/controllers/api_application_controller.rb
+++ b/app/controllers/api_application_controller.rb
@@ -8,6 +8,7 @@ class ApiApplicationController < StashEngine::ApplicationController
 
   layout 'layouts/stash_engine/application'
 
+  prepend_before_action :set_logger
   skip_before_action :verify_authenticity_token
 
   DEFAULT_PAGE_SIZE = 20
@@ -83,6 +84,8 @@ class ApiApplicationController < StashEngine::ApplicationController
               # Client Credentials Grant type
               doorkeeper_token.application.owner
             end
+
+    logger.info("User: #{@user&.id}")
   end
 
   def require_in_progress_resource
@@ -140,5 +143,9 @@ class ApiApplicationController < StashEngine::ApplicationController
 
   def force_json_content_type
     response.headers['Content-Type'] = 'application/json; charset=utf-8'
+  end
+
+  def set_logger
+    Rails.logger = Rails.application.config.api_logger
   end
 end

--- a/app/controllers/api_application_controller.rb
+++ b/app/controllers/api_application_controller.rb
@@ -162,4 +162,3 @@ class ApiApplicationController < StashEngine::ApplicationController
     logger.info("Body: #{request.body.read}")
   end
 end
-

--- a/app/controllers/api_application_controller.rb
+++ b/app/controllers/api_application_controller.rb
@@ -9,6 +9,7 @@ class ApiApplicationController < StashEngine::ApplicationController
   layout 'layouts/stash_engine/application'
 
   prepend_before_action :set_logger
+  before_action :log_request
   skip_before_action :verify_authenticity_token
 
   DEFAULT_PAGE_SIZE = 20
@@ -145,7 +146,20 @@ class ApiApplicationController < StashEngine::ApplicationController
     response.headers['Content-Type'] = 'application/json; charset=utf-8'
   end
 
+  def api_logger
+    Rails.application.config.api_logger
+  end
+
   def set_logger
     Rails.logger = Rails.application.config.api_logger
+    config.logger = Rails.logger
+  end
+
+  def log_request
+    logger.info('---')
+    logger.info("Path: #{request.path}")
+    logger.info("Params: #{request.params}")
+    logger.info("Body: #{request.body.read}")
   end
 end
+

--- a/app/controllers/api_application_controller.rb
+++ b/app/controllers/api_application_controller.rb
@@ -159,6 +159,6 @@ class ApiApplicationController < StashEngine::ApplicationController
     logger.info('---')
     logger.info("Path: #{request.path}")
     logger.info("Params: #{request.params}")
-    logger.info("Body: #{request.body.read}")
+    logger.info("Body: #{request.body}")
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,4 @@
 require_relative "boot"
-require_relative "../lib/api_logger_middleware"
 
 require "rails"
 # Pick the frameworks you want:
@@ -50,7 +49,5 @@ module Dash2
     # ryan used this in some manuscript parsing and gem updates break it.  See
     # https://stackoverflow.com/questions/72970170/upgrading-to-rails-6-1-6-1-causes-psychdisallowedclass-tried-to-load-unspecif
     config.active_record.yaml_column_permitted_classes = [ActiveSupport::HashWithIndifferentAccess]
-
-    config.middleware.use ApiLoggerMiddleware
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,5 @@
 require_relative "boot"
+require_relative "../lib/api_logger_middleware"
 
 require "rails"
 # Pick the frameworks you want:
@@ -50,5 +51,6 @@ module Dash2
     # https://stackoverflow.com/questions/72970170/upgrading-to-rails-6-1-6-1-causes-psychdisallowedclass-tried-to-load-unspecif
     config.active_record.yaml_column_permitted_classes = [ActiveSupport::HashWithIndifferentAccess]
 
+    config.middleware.use ApiLoggerMiddleware
   end
 end

--- a/config/initializers/api_logger.rb
+++ b/config/initializers/api_logger.rb
@@ -1,0 +1,8 @@
+api_logger = ActiveSupport::Logger.new(
+  Rails.root.join('log', 'api_requests.log'),
+  'daily',
+  7
+)
+api_logger.formatter = Logger::Formatter.new
+Rails.application.config.api_logger = api_logger
+

--- a/config/initializers/api_logger.rb
+++ b/config/initializers/api_logger.rb
@@ -4,5 +4,6 @@ api_logger = ActiveSupport::Logger.new(
   7
 )
 api_logger.formatter = Logger::Formatter.new
+api_logger.level = :debug
 Rails.application.config.api_logger = api_logger
 

--- a/lib/api_logger_middleware.rb
+++ b/lib/api_logger_middleware.rb
@@ -1,0 +1,22 @@
+require 'doorkeeper'
+
+class ApiLoggerMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    request = Rack::Request.new(env)
+    
+    if request.path.start_with?('/api')
+      logger = Rails.application.config.api_logger
+
+      logger.info('---')
+      logger.info("Path: #{request.path}")
+      logger.info("Params: #{request.params}")
+      logger.info("Body: #{request.body.read}")
+    end
+
+    @app.call(env)
+  end
+end

--- a/lib/api_logger_middleware.rb
+++ b/lib/api_logger_middleware.rb
@@ -7,7 +7,7 @@ class ApiLoggerMiddleware
 
   def call(env)
     request = Rack::Request.new(env)
-    
+
     if request.path.start_with?('/api')
       logger = Rails.application.config.api_logger
 

--- a/lib/api_logger_middleware.rb
+++ b/lib/api_logger_middleware.rb
@@ -1,5 +1,3 @@
-require 'doorkeeper'
-
 class ApiLoggerMiddleware
   def initialize(app)
     @app = app


### PR DESCRIPTION
- explicitly logs the path, params & body for API requests
- logs the user ID when possible as well

**Preview of the log output**
```
# Logfile created on 2023-12-22 14:14:45 +0200 by logger.rb/v1.4.3
I, [2023-12-22T14:14:47.497892 #88450]  INFO -- : Path: /api/v2/reports
I, [2023-12-22T14:14:47.498322 #88450]  INFO -- : Params: {}
I, [2023-12-22T14:14:47.498343 #88450]  INFO -- : Body: 
I, [2023-12-22T14:15:32.610860 #92348]  INFO -- : ---
I, [2023-12-22T14:15:32.611091 #92348]  INFO -- : Path: /api/v2
I, [2023-12-22T14:15:32.612135 #92348]  INFO -- : Params: {}
I, [2023-12-22T14:15:32.612175 #92348]  INFO -- : Body: {
    "foo": "bar"
}
I, [2023-12-22T14:17:14.778028 #95439]  INFO -- : ---
I, [2023-12-22T14:17:14.778077 #95439]  INFO -- : Path: /api/v2
I, [2023-12-22T14:17:14.778708 #95439]  INFO -- : Params: {"bar"=>"baz"}
I, [2023-12-22T14:17:14.778735 #95439]  INFO -- : Body: {
    "foo": "bar"
}
```

ref [Improve logging for API requests#2420](https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2420)