### PR TITLE
chore: add `curationStatus` to list of available parameters for `GET /api/v2/datasets`

### DIFF
--- a/public/openapi.yml
+++ b/public/openapi.yml
@@ -99,6 +99,7 @@ paths:
         - $ref: '#/components/parameters/publicationISSN'
         - $ref: '#/components/parameters/publicationName'
         - $ref: '#/components/parameters/manuscriptNumber'
+        - $ref: '#/components/parameters/curationStatus'
       responses:
         '200':
           description: A list of datasets.
@@ -1396,7 +1397,14 @@ components:
       description:
         Manuscript number associated with the dataset.
 
-      
+    curationStatus:
+      in: query
+      name: curationStatus
+      schema:
+        type: string
+      description:
+        Curation Status
+
   securitySchemes:
     bearerAuth:
       type: http


### PR DESCRIPTION
As seen in the screenshot, the docs don't include the [`curatorStatus` optional parameter](https://github.com/CDL-Dryad/dryad-app/blob/5fc5980d168d6e569c8c69dabab04cc5c9832036/app/controllers/stash_api/datasets_controller.rb#L298-L300)

<img width="1212" alt="Screenshot 2024-01-10 at 15 18 04" src="https://github.com/CDL-Dryad/dryad-app/assets/1225100/77c8d05b-252d-469b-a1d5-deee6f592af0">
