### PR TITLE
chore: add annotations to all models & fixtures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -187,4 +187,3 @@ group :development, :test, :local_dev do
   # rspec command for spring (https://github.com/jonleighton/spring-commands-rspec)
   gem 'spring-commands-rspec'
 end
-

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem 'uglifier', '~> 4.2.0'
 
 gem 'amatch', '~> 0.4.0'
 gem 'amoeba', '~> 3.2.0'
+gem 'annotate', '~> 3.2'
 gem 'aws-sdk-lambda'
 gem 'aws-sdk-s3', '~> 1.113'
 gem 'blacklight'
@@ -186,3 +187,4 @@ group :development, :test, :local_dev do
   # rspec command for spring (https://github.com/jonleighton/spring-commands-rspec)
   gem 'spring-commands-rspec'
 end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,9 @@ GEM
       tins (~> 1.0)
     amoeba (3.2.0)
       activerecord (>= 4.2.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     ansi (1.5.0)
     ast (2.4.2)
     autoprefixer-rails (10.4.13.0)
@@ -787,6 +790,7 @@ PLATFORMS
 DEPENDENCIES
   amatch (~> 0.4.0)
   amoeba (~> 3.2.0)
+  annotate (~> 3.2)
   aws-sdk-lambda
   aws-sdk-s3 (~> 1.113)
   bcrypt_pbkdf (= 1.1.0)
@@ -903,4 +907,4 @@ DEPENDENCIES
   zaru (~> 0.3.0)
 
 BUNDLED WITH
-   2.3.22
+   2.4.22

--- a/app/models/stash_datacite/affiliation.rb
+++ b/app/models/stash_datacite/affiliation.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_affiliations
+#
+#  id           :integer          not null, primary key
+#  short_name   :text(65535)
+#  long_name    :text(65535)
+#  abbreviation :text(65535)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  ror_id       :string(191)
+#
 module StashDatacite
   class Affiliation < ApplicationRecord
 

--- a/app/models/stash_datacite/alternate_identifier.rb
+++ b/app/models/stash_datacite/alternate_identifier.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_alternate_identifiers
+#
+#  id                        :integer          not null, primary key
+#  alternate_identifier      :text(65535)
+#  alternate_identifier_type :text(65535)
+#  resource_id               :integer          not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#
 module StashDatacite
   class AlternateIdentifier < ApplicationRecord
     self.table_name = 'dcs_alternate_identifiers'

--- a/app/models/stash_datacite/contributor.rb
+++ b/app/models/stash_datacite/contributor.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_contributors
+#
+#  id                 :integer          not null, primary key
+#  contributor_name   :text(65535)
+#  contributor_type   :string           default("funder")
+#  identifier_type    :string
+#  name_identifier_id :string(191)
+#  resource_id        :integer
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  award_number       :text(65535)
+#  funder_order       :integer
+#  award_description  :string(191)
+#
 module StashDatacite
   class Contributor < ApplicationRecord
     self.table_name = 'dcs_contributors'

--- a/app/models/stash_datacite/contributor_grouping.rb
+++ b/app/models/stash_datacite/contributor_grouping.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: dcs_contributor_groupings
+#
+#  id                 :bigint           not null, primary key
+#  contributor_name   :text(65535)
+#  contributor_type   :integer          default("funder")
+#  identifier_type    :integer          default("crossref_funder_id")
+#  name_identifier_id :string(191)
+#  group_label        :string(191)
+#  json_contains      :json
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
 module StashDatacite
   class ContributorGrouping < ApplicationRecord
     self.table_name = 'dcs_contributor_groupings'

--- a/app/models/stash_datacite/datacite_date.rb
+++ b/app/models/stash_datacite/datacite_date.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_dates
+#
+#  id          :integer          not null, primary key
+#  date        :string(191)
+#  date_type   :string
+#  resource_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module StashDatacite
   class DataciteDate < ApplicationRecord
     self.table_name = 'dcs_dates'

--- a/app/models/stash_datacite/description.rb
+++ b/app/models/stash_datacite/description.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_descriptions
+#
+#  id               :integer          not null, primary key
+#  description      :text(16777215)
+#  description_type :string
+#  resource_id      :integer
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
 module StashDatacite
   class Description < ApplicationRecord
     self.table_name = 'dcs_descriptions'

--- a/app/models/stash_datacite/format.rb
+++ b/app/models/stash_datacite/format.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_formats
+#
+#  id          :integer          not null, primary key
+#  format      :text(65535)
+#  resource_id :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module StashDatacite
   class Format < ApplicationRecord
     self.table_name = 'dcs_formats'

--- a/app/models/stash_datacite/geolocation.rb
+++ b/app/models/stash_datacite/geolocation.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_geo_locations
+#
+#  id          :integer          not null, primary key
+#  place_id    :integer
+#  point_id    :integer
+#  box_id      :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  resource_id :integer
+#
 require 'datacite/mapping'
 
 module StashDatacite

--- a/app/models/stash_datacite/geolocation_box.rb
+++ b/app/models/stash_datacite/geolocation_box.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_geo_location_boxes
+#
+#  id           :integer          not null, primary key
+#  sw_latitude  :decimal(10, 6)
+#  ne_latitude  :decimal(10, 6)
+#  sw_longitude :decimal(10, 6)
+#  ne_longitude :decimal(10, 6)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 module StashDatacite
   class GeolocationBox < ApplicationRecord
     self.table_name = 'dcs_geo_location_boxes'

--- a/app/models/stash_datacite/geolocation_place.rb
+++ b/app/models/stash_datacite/geolocation_place.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_geo_location_places
+#
+#  id                 :integer          not null, primary key
+#  geo_location_place :text(65535)
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
 module StashDatacite
   class GeolocationPlace < ApplicationRecord
     self.table_name = 'dcs_geo_location_places'

--- a/app/models/stash_datacite/geolocation_point.rb
+++ b/app/models/stash_datacite/geolocation_point.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_geo_location_points
+#
+#  id         :integer          not null, primary key
+#  latitude   :decimal(10, 6)
+#  longitude  :decimal(10, 6)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 module StashDatacite
   class GeolocationPoint < ApplicationRecord
     self.table_name = 'dcs_geo_location_points'

--- a/app/models/stash_datacite/language.rb
+++ b/app/models/stash_datacite/language.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_languages
+#
+#  id          :integer          not null, primary key
+#  language    :text(65535)
+#  resource_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module StashDatacite
   class Language < ApplicationRecord
     self.table_name = 'dcs_languages'

--- a/app/models/stash_datacite/name_identifier.rb
+++ b/app/models/stash_datacite/name_identifier.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_name_identifiers
+#
+#  id                     :integer          not null, primary key
+#  name_identifier        :text(65535)
+#  name_identifier_scheme :text(65535)
+#  scheme_URI             :text(65535)
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
 # TODO: delete
 module StashDatacite
   class NameIdentifier < ApplicationRecord

--- a/app/models/stash_datacite/publication.rb
+++ b/app/models/stash_datacite/publication.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_internal_data
+#
+#  id            :integer          not null, primary key
+#  identifier_id :integer
+#  data_type     :string(191)
+#  value         :string(191)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
 module StashDatacite
   class Publication < ApplicationRecord
     self.table_name = 'stash_engine_internal_data'

--- a/app/models/stash_datacite/publication_year.rb
+++ b/app/models/stash_datacite/publication_year.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_publication_years
+#
+#  id               :integer          not null, primary key
+#  publication_year :string(191)
+#  resource_id      :integer
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
 module StashDatacite
   class PublicationYear < ApplicationRecord
     self.table_name = 'dcs_publication_years'

--- a/app/models/stash_datacite/publisher.rb
+++ b/app/models/stash_datacite/publisher.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_publishers
+#
+#  id          :integer          not null, primary key
+#  publisher   :text(65535)
+#  resource_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module StashDatacite
   class Publisher < ApplicationRecord
     self.table_name = 'dcs_publishers'

--- a/app/models/stash_datacite/related_identifier.rb
+++ b/app/models/stash_datacite/related_identifier.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_related_identifiers
+#
+#  id                      :integer          not null, primary key
+#  related_identifier      :text(65535)
+#  related_identifier_type :string
+#  relation_type           :string
+#  related_metadata_scheme :text(65535)
+#  scheme_URI              :text(65535)
+#  scheme_type             :text(65535)
+#  resource_id             :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  fixed_id                :text(65535)
+#  work_type               :integer          default("undefined")
+#  verified                :boolean          default(FALSE)
+#  hidden                  :boolean          default(FALSE)
+#  added_by                :integer          default("default")
+#
 require 'http'
 
 # rubocop:disable Metrics/ClassLength

--- a/app/models/stash_datacite/resource_type.rb
+++ b/app/models/stash_datacite/resource_type.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_resource_types
+#
+#  id                    :integer          not null, primary key
+#  resource_type_general :string
+#  resource_type         :text(65535)
+#  resource_id           :integer
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#
 module StashDatacite
   class ResourceType < ApplicationRecord
     self.table_name = 'dcs_resource_types'

--- a/app/models/stash_datacite/resources_subjects.rb
+++ b/app/models/stash_datacite/resources_subjects.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_subjects_stash_engine_resources
+#
+#  id          :integer          not null, primary key
+#  resource_id :integer
+#  subject_id  :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module StashDatacite
   class ResourcesSubjects < ApplicationRecord
     self.table_name = 'dcs_subjects_stash_engine_resources'

--- a/app/models/stash_datacite/right.rb
+++ b/app/models/stash_datacite/right.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_rights
+#
+#  id          :integer          not null, primary key
+#  rights      :text(65535)
+#  rights_uri  :text(65535)
+#  resource_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module StashDatacite
   class Right < ApplicationRecord
     self.table_name = 'dcs_rights'

--- a/app/models/stash_datacite/size.rb
+++ b/app/models/stash_datacite/size.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_sizes
+#
+#  id          :integer          not null, primary key
+#  size        :text(65535)
+#  resource_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module StashDatacite
   class Size < ApplicationRecord
     self.table_name = 'dcs_sizes'

--- a/app/models/stash_datacite/subject.rb
+++ b/app/models/stash_datacite/subject.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_subjects
+#
+#  id             :integer          not null, primary key
+#  subject        :text(65535)
+#  subject_scheme :text(65535)
+#  scheme_URI     :text(65535)
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 module StashDatacite
   class Subject < ApplicationRecord
     self.table_name = 'dcs_subjects'

--- a/app/models/stash_datacite/temporal_coverage.rb
+++ b/app/models/stash_datacite/temporal_coverage.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: stash_datacite_temporal_coverages
+#
+#  id          :integer          not null, primary key
+#  description :text(65535)
+#  resource_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module StashDatacite
   class TemporalCoverage < Description
     self.table_name = 'stash_datacite_temporal_coverages'

--- a/app/models/stash_datacite/version.rb
+++ b/app/models/stash_datacite/version.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: dcs_versions
+#
+#  id          :integer          not null, primary key
+#  version     :string(191)
+#  resource_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module StashDatacite
   class Version < ApplicationRecord
     self.table_name = 'dcs_versions'

--- a/app/models/stash_engine/api_token.rb
+++ b/app/models/stash_engine/api_token.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: stash_engine_api_tokens
+#
+#  id         :bigint           not null, primary key
+#  app_id     :string(191)
+#  secret     :string(191)
+#  token      :string(191)
+#  expires_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require 'http'
 
 module StashEngine

--- a/app/models/stash_engine/author.rb
+++ b/app/models/stash_engine/author.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: stash_engine_authors
+#
+#  id                 :integer          not null, primary key
+#  author_first_name  :string(191)
+#  author_last_name   :string(191)
+#  author_email       :string(191)
+#  author_orcid       :string(191)
+#  resource_id        :integer
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  stripe_customer_id :text(65535)
+#  author_order       :integer
+#
 require_relative '../../../app/models/stash_datacite/affiliation'
 
 module StashEngine

--- a/app/models/stash_engine/container_file.rb
+++ b/app/models/stash_engine/container_file.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: stash_engine_container_files
+#
+#  id           :bigint           not null, primary key
+#  data_file_id :bigint
+#  path         :text(65535)
+#  mime_type    :string(191)
+#  size         :bigint
+#
 module StashEngine
   class ContainerFile < ApplicationRecord
     self.table_name = 'stash_engine_container_files'

--- a/app/models/stash_engine/counter_citation.rb
+++ b/app/models/stash_engine/counter_citation.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_counter_citations
+#
+#  id            :integer          not null, primary key
+#  citation      :text(65535)
+#  doi           :text(65535)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  identifier_id :integer
+#
 module StashEngine
   class CounterCitation < ApplicationRecord
     self.table_name = 'stash_engine_counter_citations'

--- a/app/models/stash_engine/counter_stat.rb
+++ b/app/models/stash_engine/counter_stat.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: stash_engine_counter_stats
+#
+#  id                         :integer          not null, primary key
+#  identifier_id              :integer
+#  citation_count             :integer
+#  unique_investigation_count :integer
+#  unique_request_count       :integer
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  citation_updated           :datetime         default(Mon, 01 Jan 2018 00:00:00.000000000 UTC +00:00)
+#
 module StashEngine
   class CounterStat < ApplicationRecord
     self.table_name = 'stash_engine_counter_stats'

--- a/app/models/stash_engine/curation_activity.rb
+++ b/app/models/stash_engine/curation_activity.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: stash_engine_curation_activities
+#
+#  id          :integer          not null, primary key
+#  status      :string(191)      default("in_progress")
+#  user_id     :integer
+#  note        :text(65535)
+#  keywords    :string(191)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  resource_id :integer
+#
 require 'stash/doi/datacite_gen'
 require 'stash/payments/invoicer'
 module StashEngine

--- a/app/models/stash_engine/curation_stats.rb
+++ b/app/models/stash_engine/curation_stats.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: stash_engine_curation_stats
+#
+#  id                          :bigint           not null, primary key
+#  date                        :datetime
+#  datasets_curated            :integer
+#  new_datasets_to_submitted   :integer
+#  new_datasets_to_peer_review :integer
+#  datasets_to_aar             :integer
+#  datasets_to_published       :integer
+#  datasets_to_embargoed       :integer
+#  datasets_to_withdrawn       :integer
+#  author_revised              :integer
+#  author_versioned            :integer
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  datasets_to_be_curated      :integer
+#  ppr_to_curation             :integer
+#
 # CurationStats stores statistics about the submission/curation process
 # that rarely change and take a little time to calculate. This class may only be
 # instantiated once for each date. Rather than instantiating with `new` or `create`,

--- a/app/models/stash_engine/data_file.rb
+++ b/app/models/stash_engine/data_file.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: stash_engine_generic_files
+#
+#  id                  :integer          not null, primary key
+#  upload_file_name    :text(65535)
+#  upload_content_type :text(65535)
+#  upload_file_size    :bigint
+#  resource_id         :integer
+#  upload_updated_at   :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  validated_at        :datetime
+#  file_state          :string(7)
+#  url                 :text(65535)
+#  status_code         :integer
+#  timed_out           :boolean          default(FALSE)
+#  original_url        :text(65535)
+#  cloud_service       :string(191)
+#  digest              :string(191)
+#  digest_type         :string(8)
+#  description         :text(65535)
+#  original_filename   :text(65535)
+#  type                :string(191)
+#  compressed_try      :integer          default(0)
+#
 require 'byebug'
 module StashEngine
   class DataFile < GenericFile

--- a/app/models/stash_engine/download_token.rb
+++ b/app/models/stash_engine/download_token.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_download_tokens
+#
+#  id          :integer          not null, primary key
+#  resource_id :integer
+#  token       :string(191)
+#  available   :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module StashEngine
   class DownloadToken < ApplicationRecord
     self.table_name = 'stash_engine_download_tokens'

--- a/app/models/stash_engine/edit_history.rb
+++ b/app/models/stash_engine/edit_history.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: stash_engine_edit_histories
+#
+#  id           :integer          not null, primary key
+#  resource_id  :integer
+#  user_comment :text(65535)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 module StashEngine
   class EditHistory < ApplicationRecord
     self.table_name = 'stash_engine_edit_histories'

--- a/app/models/stash_engine/external_dependency.rb
+++ b/app/models/stash_engine/external_dependency.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: stash_engine_external_dependencies
+#
+#  id                 :integer          not null, primary key
+#  abbreviation       :string(191)
+#  name               :string(191)
+#  description        :string(191)
+#  status             :integer          default(1)
+#  documentation      :text(65535)
+#  error_message      :text(65535)
+#  internally_managed :boolean          default(FALSE)
+#  created_at         :datetime
+#  updated_at         :datetime
+#
 # Field list:
 #    abbreviation, name, description, status, documentation
 module StashEngine

--- a/app/models/stash_engine/external_reference.rb
+++ b/app/models/stash_engine/external_reference.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: stash_engine_external_references
+#
+#  id            :integer          not null, primary key
+#  identifier_id :integer
+#  source        :string(191)
+#  value         :text(4294967295)
+#  created_at    :datetime
+#  updated_at    :datetime
+#
 module StashEngine
   # This class is currently used to store identifiers for external GenBank databases
   # used by the LinkOut functionality. It is similar to the InternalDatum model except

--- a/app/models/stash_engine/frictionless_report.rb
+++ b/app/models/stash_engine/frictionless_report.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_frictionless_reports
+#
+#  id              :bigint           not null, primary key
+#  report          :text(4294967295)
+#  generic_file_id :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  status          :string
+#
 module StashEngine
   class FrictionlessReport < ApplicationRecord
     self.table_name = 'stash_engine_frictionless_reports'

--- a/app/models/stash_engine/funder_role.rb
+++ b/app/models/stash_engine/funder_role.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: stash_engine_funder_roles
+#
+#  id          :bigint           not null, primary key
+#  user_id     :bigint
+#  funder_id   :string(191)
+#  funder_name :string(191)
+#  role        :string(191)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module StashEngine
   class FunderRole < ApplicationRecord
     self.table_name = 'stash_engine_funder_roles'

--- a/app/models/stash_engine/generic_file.rb
+++ b/app/models/stash_engine/generic_file.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: stash_engine_generic_files
+#
+#  id                  :integer          not null, primary key
+#  upload_file_name    :text(65535)
+#  upload_content_type :text(65535)
+#  upload_file_size    :bigint
+#  resource_id         :integer
+#  upload_updated_at   :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  validated_at        :datetime
+#  file_state          :string(7)
+#  url                 :text(65535)
+#  status_code         :integer
+#  timed_out           :boolean          default(FALSE)
+#  original_url        :text(65535)
+#  cloud_service       :string(191)
+#  digest              :string(191)
+#  digest_type         :string(8)
+#  description         :text(65535)
+#  original_filename   :text(65535)
+#  type                :string(191)
+#  compressed_try      :integer          default(0)
+#
 require 'zaru'
 require 'cgi'
 require 'stash/download/file_presigned' # to import the Stash::Download::Merritt exception

--- a/app/models/stash_engine/global_state.rb
+++ b/app/models/stash_engine/global_state.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: stash_engine_global_states
+#
+#  id         :bigint           not null, primary key
+#  key        :string(191)
+#  state      :json
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 module StashEngine
   class GlobalState < ApplicationRecord
     self.table_name = 'stash_engine_global_states'

--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: stash_engine_identifiers
+#
+#  id                  :integer          not null, primary key
+#  identifier          :text(65535)
+#  identifier_type     :text(65535)
+#  storage_size        :bigint
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  latest_resource_id  :integer
+#  license_id          :string(191)      default("cc0")
+#  search_words        :text(65535)
+#  payment_type        :string(191)
+#  payment_id          :text(65535)
+#  waiver_basis        :string(191)
+#  pub_state           :string
+#  software_license_id :integer
+#  edit_code           :string(191)
+#  import_info         :integer          default("other")
+#
 require 'httparty'
 require 'http'
 

--- a/app/models/stash_engine/internal_datum.rb
+++ b/app/models/stash_engine/internal_datum.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_internal_data
+#
+#  id            :integer          not null, primary key
+#  identifier_id :integer
+#  data_type     :string(191)
+#  value         :string(191)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
 module StashEngine
   class InternalDatum < ApplicationRecord
     self.table_name = 'stash_engine_internal_data'

--- a/app/models/stash_engine/journal.rb
+++ b/app/models/stash_engine/journal.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: stash_engine_journals
+#
+#  id                      :integer          not null, primary key
+#  title                   :string(191)
+#  issn                    :string(191)
+#  website                 :string(191)
+#  description             :text(65535)
+#  payment_plan_type       :string
+#  payment_contact         :string(191)
+#  manuscript_number_regex :string(191)
+#  stripe_customer_id      :string(191)
+#  notify_contacts         :text(65535)
+#  review_contacts         :text(65535)
+#  allow_review_workflow   :boolean
+#  allow_embargo           :boolean
+#  allow_blackout          :boolean
+#  default_to_ppr          :boolean          default(FALSE)
+#  created_at              :datetime
+#  updated_at              :datetime
+#  journal_code            :string(191)
+#  sponsor_id              :integer
+#
 module StashEngine
   class Journal < ApplicationRecord
     self.table_name = 'stash_engine_journals'

--- a/app/models/stash_engine/journal_organization.rb
+++ b/app/models/stash_engine/journal_organization.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: stash_engine_journal_organizations
+#
+#  id            :bigint           not null, primary key
+#  name          :string(191)
+#  contact       :string(191)
+#  parent_org_id :integer
+#  type          :string(191)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
 module StashEngine
   class JournalOrganization < ApplicationRecord
     self.table_name = 'stash_engine_journal_organizations'

--- a/app/models/stash_engine/journal_role.rb
+++ b/app/models/stash_engine/journal_role.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: stash_engine_journal_roles
+#
+#  id                      :integer          not null, primary key
+#  journal_id              :integer
+#  user_id                 :integer
+#  role                    :string(191)
+#  created_at              :datetime
+#  updated_at              :datetime
+#  journal_organization_id :integer
+#
 module StashEngine
   class JournalRole < ApplicationRecord
     self.table_name = 'stash_engine_journal_roles'

--- a/app/models/stash_engine/journal_title.rb
+++ b/app/models/stash_engine/journal_title.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_journal_titles
+#
+#  id                   :bigint           not null, primary key
+#  title                :string(191)
+#  journal_id           :integer
+#  show_in_autocomplete :boolean
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
 module StashEngine
   class JournalTitle < ApplicationRecord
     self.table_name = 'stash_engine_journal_titles'

--- a/app/models/stash_engine/lock.rb
+++ b/app/models/stash_engine/lock.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: locks
+#
+#  id         :integer          not null, primary key
+#  name       :string(40)
+#  created_at :datetime
+#  updated_at :datetime
+#
 # see https://makandracards.com/makandra/1026-simple-database-lock-for-mysql for info about simple DB locking
 # rubocop:disable all
 module StashEngine

--- a/app/models/stash_engine/manuscript.rb
+++ b/app/models/stash_engine/manuscript.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: stash_engine_manuscripts
+#
+#  id                :bigint           not null, primary key
+#  journal_id        :bigint
+#  identifier_id     :bigint
+#  manuscript_number :string(191)
+#  status            :string(191)
+#  metadata          :text(16777215)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
 module StashEngine
   class Manuscript < ApplicationRecord
     self.table_name = 'stash_engine_manuscripts'

--- a/app/models/stash_engine/noid_state.rb
+++ b/app/models/stash_engine/noid_state.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: noid_states
+#
+#  id         :integer          not null, primary key
+#  state      :text(65535)
+#  created_at :datetime
+#  updated_at :datetime
+#
 require 'noid'
 require 'yaml'
 

--- a/app/models/stash_engine/orcid_invitation.rb
+++ b/app/models/stash_engine/orcid_invitation.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: stash_engine_orcid_invitations
+#
+#  id            :integer          not null, primary key
+#  email         :string(191)
+#  identifier_id :integer
+#  first_name    :string(191)
+#  last_name     :string(191)
+#  secret        :string(191)
+#  orcid         :string(191)
+#  invited_at    :datetime         not null
+#  accepted_at   :datetime
+#
 module StashEngine
   class OrcidInvitation < ApplicationRecord
     self.table_name = 'stash_engine_orcid_invitations'

--- a/app/models/stash_engine/processor_result.rb
+++ b/app/models/stash_engine/processor_result.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: stash_engine_processor_results
+#
+#  id               :bigint           not null, primary key
+#  resource_id      :integer
+#  processing_type  :integer
+#  parent_id        :integer
+#  completion_state :integer
+#  message          :text(16777215)
+#  structured_info  :text(4294967295)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
 module StashEngine
   class ProcessorResult < ApplicationRecord
     self.table_name = 'stash_engine_processor_results'

--- a/app/models/stash_engine/proposed_change.rb
+++ b/app/models/stash_engine/proposed_change.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: stash_engine_proposed_changes
+#
+#  id               :integer          not null, primary key
+#  identifier_id    :integer
+#  approved         :boolean
+#  rejected         :boolean
+#  user_id          :integer
+#  authors          :text(65535)
+#  provenance       :string(191)
+#  publication_date :datetime
+#  publication_doi  :string(191)
+#  publication_issn :string(191)
+#  publication_name :string(191)
+#  score            :float(24)
+#  provenance_score :float(24)
+#  title            :text(65535)
+#  url              :string(191)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  subjects         :text(65535)
+#  xref_type        :string(191)
+#
 require 'stash/import/crossref'
 
 module StashEngine

--- a/app/models/stash_engine/repo_queue_state.rb
+++ b/app/models/stash_engine/repo_queue_state.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_repo_queue_states
+#
+#  id          :integer          not null, primary key
+#  resource_id :integer
+#  state       :string
+#  hostname    :string(191)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module StashEngine
   class RepoQueueState < ApplicationRecord
     self.table_name = 'stash_engine_repo_queue_states'

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -1,3 +1,35 @@
+# == Schema Information
+#
+# Table name: stash_engine_resources
+#
+#  id                        :integer          not null, primary key
+#  user_id                   :integer
+#  current_resource_state_id :integer
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  has_geolocation           :boolean          default(FALSE)
+#  download_uri              :text(65535)
+#  identifier_id             :integer
+#  update_uri                :text(65535)
+#  title                     :text(65535)
+#  current_editor_id         :integer
+#  publication_date          :datetime
+#  accepted_agreement        :boolean
+#  tenant_id                 :string(100)
+#  skip_datacite_update      :boolean          default(FALSE)
+#  skip_emails               :boolean          default(FALSE)
+#  loosen_validation         :boolean          default(FALSE)
+#  solr_indexed              :boolean          default(FALSE)
+#  preserve_curation_status  :boolean          default(FALSE)
+#  hold_for_peer_review      :boolean          default(FALSE)
+#  peer_review_end_date      :datetime
+#  old_resource_id           :integer
+#  total_file_size           :bigint
+#  meta_view                 :boolean          default(FALSE)
+#  file_view                 :boolean          default(FALSE)
+#  last_curation_activity_id :integer
+#  cedar_json                :text(65535)
+#
 require 'stash/aws/s3'
 # require 'stash/indexer/indexing_resource'
 require 'stash/indexer/solr_indexer'

--- a/app/models/stash_engine/resource_state.rb
+++ b/app/models/stash_engine/resource_state.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_resource_states
+#
+#  id             :integer          not null, primary key
+#  user_id        :integer
+#  resource_state :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  resource_id    :integer
+#
 module StashEngine
   class ResourceState < ApplicationRecord
     self.table_name = 'stash_engine_resource_states'

--- a/app/models/stash_engine/ror_org.rb
+++ b/app/models/stash_engine/ror_org.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: stash_engine_ror_orgs
+#
+#  id         :bigint           not null, primary key
+#  ror_id     :string(191)
+#  name       :string(191)
+#  home_page  :string(191)
+#  country    :string(191)
+#  acronyms   :json
+#  aliases    :json
+#  isni_ids   :json
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 module StashEngine
   class RorOrg < ApplicationRecord
     self.table_name = 'stash_engine_ror_orgs'

--- a/app/models/stash_engine/share.rb
+++ b/app/models/stash_engine/share.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_shares
+#
+#  id            :integer          not null, primary key
+#  secret_id     :string(191)
+#  resource_id   :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  identifier_id :integer
+#
 require 'securerandom'
 
 module StashEngine

--- a/app/models/stash_engine/software_file.rb
+++ b/app/models/stash_engine/software_file.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: stash_engine_generic_files
+#
+#  id                  :integer          not null, primary key
+#  upload_file_name    :text(65535)
+#  upload_content_type :text(65535)
+#  upload_file_size    :bigint
+#  resource_id         :integer
+#  upload_updated_at   :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  validated_at        :datetime
+#  file_state          :string(7)
+#  url                 :text(65535)
+#  status_code         :integer
+#  timed_out           :boolean          default(FALSE)
+#  original_url        :text(65535)
+#  cloud_service       :string(191)
+#  digest              :string(191)
+#  digest_type         :string(8)
+#  description         :text(65535)
+#  original_filename   :text(65535)
+#  type                :string(191)
+#  compressed_try      :integer          default(0)
+#
 module StashEngine
   class SoftwareFile < GenericFile
 

--- a/app/models/stash_engine/software_license.rb
+++ b/app/models/stash_engine/software_license.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_software_licenses
+#
+#  id          :integer          not null, primary key
+#  name        :string(191)
+#  identifier  :string(191)
+#  details_url :string(191)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module StashEngine
   class SoftwareLicense < ActiveRecord::Base
     self.table_name = 'stash_engine_software_licenses'

--- a/app/models/stash_engine/submission_log.rb
+++ b/app/models/stash_engine/submission_log.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_submission_logs
+#
+#  id                         :integer          not null, primary key
+#  resource_id                :integer
+#  archive_response           :text(65535)
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  archive_submission_request :text(65535)
+#
 module StashEngine
   class SubmissionLog < ApplicationRecord
     self.table_name = 'stash_engine_submission_logs'

--- a/app/models/stash_engine/supp_file.rb
+++ b/app/models/stash_engine/supp_file.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: stash_engine_generic_files
+#
+#  id                  :integer          not null, primary key
+#  upload_file_name    :text(65535)
+#  upload_content_type :text(65535)
+#  upload_file_size    :bigint
+#  resource_id         :integer
+#  upload_updated_at   :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  validated_at        :datetime
+#  file_state          :string(7)
+#  url                 :text(65535)
+#  status_code         :integer
+#  timed_out           :boolean          default(FALSE)
+#  original_url        :text(65535)
+#  cloud_service       :string(191)
+#  digest              :string(191)
+#  digest_type         :string(8)
+#  description         :text(65535)
+#  original_filename   :text(65535)
+#  type                :string(191)
+#  compressed_try      :integer          default(0)
+#
 module StashEngine
   class SuppFile < GenericFile
 

--- a/app/models/stash_engine/user.rb
+++ b/app/models/stash_engine/user.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: stash_engine_users
+#
+#  id               :integer          not null, primary key
+#  first_name       :text(65535)
+#  last_name        :text(65535)
+#  email            :text(65535)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  tenant_id        :text(65535)
+#  last_login       :datetime
+#  role             :string
+#  orcid            :string(191)
+#  migration_token  :string(191)
+#  old_dryad_email  :string(191)
+#  eperson_id       :integer
+#  validation_tries :integer          default(0)
+#  affiliation_id   :integer
+#
 module StashEngine
   class User < ApplicationRecord
     self.table_name = 'stash_engine_users'

--- a/app/models/stash_engine/version.rb
+++ b/app/models/stash_engine/version.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: stash_engine_versions
+#
+#  id              :integer          not null, primary key
+#  version         :integer
+#  zip_filename    :text(65535)
+#  resource_id     :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  merritt_version :integer
+#
 module StashEngine
   class Version < ApplicationRecord
     self.table_name = 'stash_engine_versions'

--- a/app/models/stash_engine/xref_funder_to_ror.rb
+++ b/app/models/stash_engine/xref_funder_to_ror.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: stash_engine_xref_funder_to_rors
+#
+#  id       :bigint           not null, primary key
+#  xref_id  :string(191)
+#  ror_id   :string(191)
+#  org_name :text(65535)
+#
 module StashEngine
   class XrefFunderToRor < ApplicationRecord
     self.table_name = 'stash_engine_xref_funder_to_rors'

--- a/app/models/stash_engine/zenodo_copy.rb
+++ b/app/models/stash_engine/zenodo_copy.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: stash_engine_zenodo_copies
+#
+#  id            :integer          not null, primary key
+#  state         :string           default("enqueued")
+#  deposition_id :integer
+#  error_info    :text(16777215)
+#  identifier_id :integer
+#  resource_id   :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  retries       :integer          default(0)
+#  copy_type     :string           default("data")
+#  software_doi  :string(191)
+#  conceptrecid  :string(191)
+#  note          :text(65535)
+#
 module StashEngine
   # this class has a bit of a peculiar structure and there could be multple third copy items for an identifier,
   # however there should only be one per resource (update the status and we'll have updated timestamps which is really all we need)

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.local?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin' => 'false',
+      'additional_file_patterns' => [],
+      'routes' => 'false',
+      'models' => 'true',
+      'position_in_routes' => 'before',
+      'position_in_class' => 'before',
+      'position_in_test' => 'before',
+      'position_in_fixture' => 'before',
+      'position_in_factory' => 'before',
+      'position_in_serializer' => 'before',
+      'show_foreign_keys' => 'true',
+      'show_complete_foreign_keys' => 'false',
+      'show_indexes' => 'true',
+      'simple_indexes' => 'false',
+      'model_dir' => 'app/models',
+      'root_dir' => '',
+      'include_version' => 'false',
+      'require' => '',
+      'exclude_tests' => 'false',
+      'exclude_fixtures' => 'false',
+      'exclude_factories' => 'false',
+      'exclude_serializers' => 'false',
+      'exclude_scaffolds' => 'true',
+      'exclude_controllers' => 'true',
+      'exclude_helpers' => 'true',
+      'exclude_sti_subclasses' => 'false',
+      'ignore_model_sub_dir' => 'false',
+      'ignore_columns' => nil,
+      'ignore_routes' => nil,
+      'ignore_unknown_models' => 'false',
+      'hide_limit_column_types' => 'integer,bigint,boolean',
+      'hide_default_column_types' => 'json,jsonb,hstore',
+      'skip_on_db_migrate' => 'false',
+      'format_bare' => 'true',
+      'format_rdoc' => 'false',
+      'format_yard' => 'false',
+      'format_markdown' => 'false',
+      'sort' => 'false',
+      'force' => 'false',
+      'frozen' => 'false',
+      'classified_sort' => 'true',
+      'trace' => 'false',
+      'wrapper_open' => nil,
+      'wrapper_close' => nil,
+      'with_comment' => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/factories/stash_datacite/affiliations.rb
+++ b/spec/factories/stash_datacite/affiliations.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: dcs_affiliations
+#
+#  id           :integer          not null, primary key
+#  short_name   :text(65535)
+#  long_name    :text(65535)
+#  abbreviation :text(65535)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  ror_id       :string(191)
+#
 FactoryBot.define do
 
   factory :affiliation, class: StashDatacite::Affiliation do

--- a/spec/factories/stash_datacite/contributor_groupings.rb
+++ b/spec/factories/stash_datacite/contributor_groupings.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: dcs_contributor_groupings
+#
+#  id                 :bigint           not null, primary key
+#  contributor_name   :text(65535)
+#  contributor_type   :integer          default("funder")
+#  identifier_type    :integer          default("crossref_funder_id")
+#  name_identifier_id :string(191)
+#  group_label        :string(191)
+#  json_contains      :json
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
 require 'json'
 FactoryBot.define do
 

--- a/spec/factories/stash_datacite/contributors.rb
+++ b/spec/factories/stash_datacite/contributors.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: dcs_contributors
+#
+#  id                 :integer          not null, primary key
+#  contributor_name   :text(65535)
+#  contributor_type   :string           default("funder")
+#  identifier_type    :string
+#  name_identifier_id :string(191)
+#  resource_id        :integer
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  award_number       :text(65535)
+#  funder_order       :integer
+#  award_description  :string(191)
+#
 FactoryBot.define do
 
   factory :contributor, class: StashDatacite::Contributor do

--- a/spec/factories/stash_datacite/descriptions.rb
+++ b/spec/factories/stash_datacite/descriptions.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: dcs_descriptions
+#
+#  id               :integer          not null, primary key
+#  description      :text(16777215)
+#  description_type :string
+#  resource_id      :integer
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
 FactoryBot.define do
 
   factory :description, class: StashDatacite::Description do

--- a/spec/factories/stash_datacite/geolocation_boxes.rb
+++ b/spec/factories/stash_datacite/geolocation_boxes.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: dcs_geo_location_boxes
+#
+#  id           :integer          not null, primary key
+#  sw_latitude  :decimal(10, 6)
+#  ne_latitude  :decimal(10, 6)
+#  sw_longitude :decimal(10, 6)
+#  ne_longitude :decimal(10, 6)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 FactoryBot.define do
   factory :geolocation_box, class: StashDatacite::GeolocationBox do
     sw_latitude { Faker::Address.latitude }

--- a/spec/factories/stash_datacite/geolocation_places.rb
+++ b/spec/factories/stash_datacite/geolocation_places.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: dcs_geo_location_places
+#
+#  id                 :integer          not null, primary key
+#  geo_location_place :text(65535)
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
 FactoryBot.define do
   factory :geolocation_place, class: StashDatacite::GeolocationPlace do
     geo_location_place { Faker::Address.city }

--- a/spec/factories/stash_datacite/geolocation_points.rb
+++ b/spec/factories/stash_datacite/geolocation_points.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: dcs_geo_location_points
+#
+#  id         :integer          not null, primary key
+#  latitude   :decimal(10, 6)
+#  longitude  :decimal(10, 6)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
 
   factory :geolocation_point, class: StashDatacite::GeolocationPoint do

--- a/spec/factories/stash_datacite/geolocations.rb
+++ b/spec/factories/stash_datacite/geolocations.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: dcs_geo_locations
+#
+#  id          :integer          not null, primary key
+#  place_id    :integer
+#  point_id    :integer
+#  box_id      :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  resource_id :integer
+#
 FactoryBot.define do
   factory :geolocation, class: StashDatacite::Geolocation do
     place_id { nil }

--- a/spec/factories/stash_datacite/publication_years.rb
+++ b/spec/factories/stash_datacite/publication_years.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: dcs_publication_years
+#
+#  id               :integer          not null, primary key
+#  publication_year :string(191)
+#  resource_id      :integer
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
 FactoryBot.define do
 
   factory :publication_year, class: StashDatacite::PublicationYear do

--- a/spec/factories/stash_datacite/related_identifiers.rb
+++ b/spec/factories/stash_datacite/related_identifiers.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: dcs_related_identifiers
+#
+#  id                      :integer          not null, primary key
+#  related_identifier      :text(65535)
+#  related_identifier_type :string
+#  relation_type           :string
+#  related_metadata_scheme :text(65535)
+#  scheme_URI              :text(65535)
+#  scheme_type             :text(65535)
+#  resource_id             :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  fixed_id                :text(65535)
+#  work_type               :integer          default("undefined")
+#  verified                :boolean          default(FALSE)
+#  hidden                  :boolean          default(FALSE)
+#  added_by                :integer          default("default")
+#
 FactoryBot.define do
 
   factory :related_identifier, class: StashDatacite::RelatedIdentifier do

--- a/spec/factories/stash_datacite/resource_types.rb
+++ b/spec/factories/stash_datacite/resource_types.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: dcs_resource_types
+#
+#  id                    :integer          not null, primary key
+#  resource_type_general :string
+#  resource_type         :text(65535)
+#  resource_id           :integer
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#
 FactoryBot.define do
 
   factory :resource_type, class: StashDatacite::ResourceType do

--- a/spec/factories/stash_datacite/rights.rb
+++ b/spec/factories/stash_datacite/rights.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: dcs_rights
+#
+#  id          :integer          not null, primary key
+#  rights      :text(65535)
+#  rights_uri  :text(65535)
+#  resource_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 FactoryBot.define do
 
   factory :right, class: StashDatacite::Right do

--- a/spec/factories/stash_datacite/subjects.rb
+++ b/spec/factories/stash_datacite/subjects.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: dcs_subjects
+#
+#  id             :integer          not null, primary key
+#  subject        :text(65535)
+#  subject_scheme :text(65535)
+#  scheme_URI     :text(65535)
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 FactoryBot.define do
 
   factory :subject, class: StashDatacite::Subject do

--- a/spec/factories/stash_engine/api_tokens.rb
+++ b/spec/factories/stash_engine/api_tokens.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: stash_engine_api_tokens
+#
+#  id         :bigint           not null, primary key
+#  app_id     :string(191)
+#  secret     :string(191)
+#  token      :string(191)
+#  expires_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
 
   factory :api_token, class: StashEngine::ApiToken do

--- a/spec/factories/stash_engine/authors.rb
+++ b/spec/factories/stash_engine/authors.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: stash_engine_authors
+#
+#  id                 :integer          not null, primary key
+#  author_first_name  :string(191)
+#  author_last_name   :string(191)
+#  author_email       :string(191)
+#  author_orcid       :string(191)
+#  resource_id        :integer
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  stripe_customer_id :text(65535)
+#  author_order       :integer
+#
 FactoryBot.define do
 
   factory :author, class: StashEngine::Author do

--- a/spec/factories/stash_engine/container_files.rb
+++ b/spec/factories/stash_engine/container_files.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: stash_engine_container_files
+#
+#  id           :bigint           not null, primary key
+#  data_file_id :bigint
+#  path         :text(65535)
+#  mime_type    :string(191)
+#  size         :bigint
+#
 FactoryBot.define do
   factory :container_file, class: StashEngine::ContainerFile do
     data_file

--- a/spec/factories/stash_engine/counter_citations.rb
+++ b/spec/factories/stash_engine/counter_citations.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_counter_citations
+#
+#  id            :integer          not null, primary key
+#  citation      :text(65535)
+#  doi           :text(65535)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  identifier_id :integer
+#
 FactoryBot.define do
 
   factory :counter_citation, class: StashEngine::CounterCitation do

--- a/spec/factories/stash_engine/counter_stats.rb
+++ b/spec/factories/stash_engine/counter_stats.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: stash_engine_counter_stats
+#
+#  id                         :integer          not null, primary key
+#  identifier_id              :integer
+#  citation_count             :integer
+#  unique_investigation_count :integer
+#  unique_request_count       :integer
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  citation_updated           :datetime         default(Mon, 01 Jan 2018 00:00:00.000000000 UTC +00:00)
+#
 FactoryBot.define do
 
   factory :counter_stat, class: StashEngine::CounterStat do

--- a/spec/factories/stash_engine/curation_activities.rb
+++ b/spec/factories/stash_engine/curation_activities.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: stash_engine_curation_activities
+#
+#  id          :integer          not null, primary key
+#  status      :string(191)      default("in_progress")
+#  user_id     :integer
+#  note        :text(65535)
+#  keywords    :string(191)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  resource_id :integer
+#
 FactoryBot.define do
 
   factory :curation_activity, class: StashEngine::CurationActivity do

--- a/spec/factories/stash_engine/data_files.rb
+++ b/spec/factories/stash_engine/data_files.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: stash_engine_generic_files
+#
+#  id                  :integer          not null, primary key
+#  upload_file_name    :text(65535)
+#  upload_content_type :text(65535)
+#  upload_file_size    :bigint
+#  resource_id         :integer
+#  upload_updated_at   :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  validated_at        :datetime
+#  file_state          :string(7)
+#  url                 :text(65535)
+#  status_code         :integer
+#  timed_out           :boolean          default(FALSE)
+#  original_url        :text(65535)
+#  cloud_service       :string(191)
+#  digest              :string(191)
+#  digest_type         :string(8)
+#  description         :text(65535)
+#  original_filename   :text(65535)
+#  type                :string(191)
+#  compressed_try      :integer          default(0)
+#
 FactoryBot.define do
 
   factory :data_file, class: StashEngine::DataFile do

--- a/spec/factories/stash_engine/download_tokens.rb
+++ b/spec/factories/stash_engine/download_tokens.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_download_tokens
+#
+#  id          :integer          not null, primary key
+#  resource_id :integer
+#  token       :string(191)
+#  available   :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 FactoryBot.define do
 
   factory :download_token, class: StashEngine::DownloadToken do

--- a/spec/factories/stash_engine/frictionless_reports.rb
+++ b/spec/factories/stash_engine/frictionless_reports.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_frictionless_reports
+#
+#  id              :bigint           not null, primary key
+#  report          :text(4294967295)
+#  generic_file_id :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  status          :string
+#
 FactoryBot.define do
 
   factory :frictionless_report, class: StashEngine::FrictionlessReport do

--- a/spec/factories/stash_engine/funder_roles.rb
+++ b/spec/factories/stash_engine/funder_roles.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: stash_engine_funder_roles
+#
+#  id          :bigint           not null, primary key
+#  user_id     :bigint
+#  funder_id   :string(191)
+#  funder_name :string(191)
+#  role        :string(191)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 FactoryBot.define do
 
   factory :funder_role, class: StashEngine::FunderRole do

--- a/spec/factories/stash_engine/generic_files.rb
+++ b/spec/factories/stash_engine/generic_files.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: stash_engine_generic_files
+#
+#  id                  :integer          not null, primary key
+#  upload_file_name    :text(65535)
+#  upload_content_type :text(65535)
+#  upload_file_size    :bigint
+#  resource_id         :integer
+#  upload_updated_at   :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  validated_at        :datetime
+#  file_state          :string(7)
+#  url                 :text(65535)
+#  status_code         :integer
+#  timed_out           :boolean          default(FALSE)
+#  original_url        :text(65535)
+#  cloud_service       :string(191)
+#  digest              :string(191)
+#  digest_type         :string(8)
+#  description         :text(65535)
+#  original_filename   :text(65535)
+#  type                :string(191)
+#  compressed_try      :integer          default(0)
+#
 FactoryBot.define do
 
   factory :generic_file, class: StashEngine::GenericFile do

--- a/spec/factories/stash_engine/identifiers.rb
+++ b/spec/factories/stash_engine/identifiers.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: stash_engine_identifiers
+#
+#  id                  :integer          not null, primary key
+#  identifier          :text(65535)
+#  identifier_type     :text(65535)
+#  storage_size        :bigint
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  latest_resource_id  :integer
+#  license_id          :string(191)      default("cc0")
+#  search_words        :text(65535)
+#  payment_type        :string(191)
+#  payment_id          :text(65535)
+#  waiver_basis        :string(191)
+#  pub_state           :string
+#  software_license_id :integer
+#  edit_code           :string(191)
+#  import_info         :integer          default("other")
+#
 FactoryBot.define do
 
   factory :identifier, class: StashEngine::Identifier do

--- a/spec/factories/stash_engine/internal_data.rb
+++ b/spec/factories/stash_engine/internal_data.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_internal_data
+#
+#  id            :integer          not null, primary key
+#  identifier_id :integer
+#  data_type     :string(191)
+#  value         :string(191)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
 FactoryBot.define do
 
   factory :internal_datum, class: StashEngine::InternalDatum do

--- a/spec/factories/stash_engine/journal_organizations.rb
+++ b/spec/factories/stash_engine/journal_organizations.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: stash_engine_journal_organizations
+#
+#  id            :bigint           not null, primary key
+#  name          :string(191)
+#  contact       :string(191)
+#  parent_org_id :integer
+#  type          :string(191)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
 FactoryBot.define do
 
   factory :journal_organization, class: StashEngine::JournalOrganization do

--- a/spec/factories/stash_engine/journal_roles.rb
+++ b/spec/factories/stash_engine/journal_roles.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: stash_engine_journal_roles
+#
+#  id                      :integer          not null, primary key
+#  journal_id              :integer
+#  user_id                 :integer
+#  role                    :string(191)
+#  created_at              :datetime
+#  updated_at              :datetime
+#  journal_organization_id :integer
+#
 FactoryBot.define do
 
   factory :journal_role, class: StashEngine::JournalRole do

--- a/spec/factories/stash_engine/journals.rb
+++ b/spec/factories/stash_engine/journals.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: stash_engine_journals
+#
+#  id                      :integer          not null, primary key
+#  title                   :string(191)
+#  issn                    :string(191)
+#  website                 :string(191)
+#  description             :text(65535)
+#  payment_plan_type       :string
+#  payment_contact         :string(191)
+#  manuscript_number_regex :string(191)
+#  stripe_customer_id      :string(191)
+#  notify_contacts         :text(65535)
+#  review_contacts         :text(65535)
+#  allow_review_workflow   :boolean
+#  allow_embargo           :boolean
+#  allow_blackout          :boolean
+#  default_to_ppr          :boolean          default(FALSE)
+#  created_at              :datetime
+#  updated_at              :datetime
+#  journal_code            :string(191)
+#  sponsor_id              :integer
+#
 FactoryBot.define do
 
   factory :journal, class: StashEngine::Journal do

--- a/spec/factories/stash_engine/manuscripts.rb
+++ b/spec/factories/stash_engine/manuscripts.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: stash_engine_manuscripts
+#
+#  id                :bigint           not null, primary key
+#  journal_id        :bigint
+#  identifier_id     :bigint
+#  manuscript_number :string(191)
+#  status            :string(191)
+#  metadata          :text(16777215)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
 FactoryBot.define do
 
   factory :manuscript, class: StashEngine::Manuscript do

--- a/spec/factories/stash_engine/processor_results.rb
+++ b/spec/factories/stash_engine/processor_results.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: stash_engine_processor_results
+#
+#  id               :bigint           not null, primary key
+#  resource_id      :integer
+#  processing_type  :integer
+#  parent_id        :integer
+#  completion_state :integer
+#  message          :text(16777215)
+#  structured_info  :text(4294967295)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
 FactoryBot.define do
 
   factory :processor_result, class: StashEngine::ProcessorResult do

--- a/spec/factories/stash_engine/resource_states.rb
+++ b/spec/factories/stash_engine/resource_states.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_resource_states
+#
+#  id             :integer          not null, primary key
+#  user_id        :integer
+#  resource_state :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  resource_id    :integer
+#
 FactoryBot.define do
 
   factory :resource_state, class: StashEngine::ResourceState do

--- a/spec/factories/stash_engine/resources.rb
+++ b/spec/factories/stash_engine/resources.rb
@@ -1,3 +1,35 @@
+# == Schema Information
+#
+# Table name: stash_engine_resources
+#
+#  id                        :integer          not null, primary key
+#  user_id                   :integer
+#  current_resource_state_id :integer
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  has_geolocation           :boolean          default(FALSE)
+#  download_uri              :text(65535)
+#  identifier_id             :integer
+#  update_uri                :text(65535)
+#  title                     :text(65535)
+#  current_editor_id         :integer
+#  publication_date          :datetime
+#  accepted_agreement        :boolean
+#  tenant_id                 :string(100)
+#  skip_datacite_update      :boolean          default(FALSE)
+#  skip_emails               :boolean          default(FALSE)
+#  loosen_validation         :boolean          default(FALSE)
+#  solr_indexed              :boolean          default(FALSE)
+#  preserve_curation_status  :boolean          default(FALSE)
+#  hold_for_peer_review      :boolean          default(FALSE)
+#  peer_review_end_date      :datetime
+#  old_resource_id           :integer
+#  total_file_size           :bigint
+#  meta_view                 :boolean          default(FALSE)
+#  file_view                 :boolean          default(FALSE)
+#  last_curation_activity_id :integer
+#  cedar_json                :text(65535)
+#
 FactoryBot.define do
 
   factory :resource, class: StashEngine::Resource do

--- a/spec/factories/stash_engine/ror_orgs.rb
+++ b/spec/factories/stash_engine/ror_orgs.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: stash_engine_ror_orgs
+#
+#  id         :bigint           not null, primary key
+#  ror_id     :string(191)
+#  name       :string(191)
+#  home_page  :string(191)
+#  country    :string(191)
+#  acronyms   :json
+#  aliases    :json
+#  isni_ids   :json
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
 
   factory :ror_org, class: StashEngine::RorOrg do

--- a/spec/factories/stash_engine/shares.rb
+++ b/spec/factories/stash_engine/shares.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_shares
+#
+#  id            :integer          not null, primary key
+#  secret_id     :string(191)
+#  resource_id   :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  identifier_id :integer
+#
 FactoryBot.define do
 
   factory :share, class: StashEngine::Share do

--- a/spec/factories/stash_engine/software_files.rb
+++ b/spec/factories/stash_engine/software_files.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: stash_engine_generic_files
+#
+#  id                  :integer          not null, primary key
+#  upload_file_name    :text(65535)
+#  upload_content_type :text(65535)
+#  upload_file_size    :bigint
+#  resource_id         :integer
+#  upload_updated_at   :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  validated_at        :datetime
+#  file_state          :string(7)
+#  url                 :text(65535)
+#  status_code         :integer
+#  timed_out           :boolean          default(FALSE)
+#  original_url        :text(65535)
+#  cloud_service       :string(191)
+#  digest              :string(191)
+#  digest_type         :string(8)
+#  description         :text(65535)
+#  original_filename   :text(65535)
+#  type                :string(191)
+#  compressed_try      :integer          default(0)
+#
 FactoryBot.define do
 
   factory :software_file, class: StashEngine::SoftwareFile do

--- a/spec/factories/stash_engine/supp_files.rb
+++ b/spec/factories/stash_engine/supp_files.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: stash_engine_generic_files
+#
+#  id                  :integer          not null, primary key
+#  upload_file_name    :text(65535)
+#  upload_content_type :text(65535)
+#  upload_file_size    :bigint
+#  resource_id         :integer
+#  upload_updated_at   :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  validated_at        :datetime
+#  file_state          :string(7)
+#  url                 :text(65535)
+#  status_code         :integer
+#  timed_out           :boolean          default(FALSE)
+#  original_url        :text(65535)
+#  cloud_service       :string(191)
+#  digest              :string(191)
+#  digest_type         :string(8)
+#  description         :text(65535)
+#  original_filename   :text(65535)
+#  type                :string(191)
+#  compressed_try      :integer          default(0)
+#
 FactoryBot.define do
 
   factory :supp_file, class: StashEngine::SuppFile do

--- a/spec/factories/stash_engine/users.rb
+++ b/spec/factories/stash_engine/users.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: stash_engine_users
+#
+#  id               :integer          not null, primary key
+#  first_name       :text(65535)
+#  last_name        :text(65535)
+#  email            :text(65535)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  tenant_id        :text(65535)
+#  last_login       :datetime
+#  role             :string
+#  orcid            :string(191)
+#  migration_token  :string(191)
+#  old_dryad_email  :string(191)
+#  eperson_id       :integer
+#  validation_tries :integer          default(0)
+#  affiliation_id   :integer
+#
 FactoryBot.define do
 
   factory :user, class: StashEngine::User do

--- a/spec/factories/stash_engine/versions.rb
+++ b/spec/factories/stash_engine/versions.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: stash_engine_versions
+#
+#  id              :integer          not null, primary key
+#  version         :integer
+#  zip_filename    :text(65535)
+#  resource_id     :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  merritt_version :integer
+#
 FactoryBot.define do
 
   factory :version, class: StashEngine::Version do

--- a/spec/factories/stash_engine/zenodo_copies.rb
+++ b/spec/factories/stash_engine/zenodo_copies.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: stash_engine_zenodo_copies
+#
+#  id            :integer          not null, primary key
+#  state         :string           default("enqueued")
+#  deposition_id :integer
+#  error_info    :text(16777215)
+#  identifier_id :integer
+#  resource_id   :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  retries       :integer          default(0)
+#  copy_type     :string           default("data")
+#  software_doi  :string(191)
+#  conceptrecid  :string(191)
+#  note          :text(65535)
+#
 FactoryBot.define do
 
   factory :zenodo_copy, class: StashEngine::ZenodoCopy do

--- a/spec/models/stash_datacite/affiliation_spec.rb
+++ b/spec/models/stash_datacite/affiliation_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: dcs_affiliations
+#
+#  id           :integer          not null, primary key
+#  short_name   :text(65535)
+#  long_name    :text(65535)
+#  abbreviation :text(65535)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  ror_id       :string(191)
+#
 require 'rails_helper'
 
 module StashDatacite

--- a/spec/models/stash_datacite/contributor_spec.rb
+++ b/spec/models/stash_datacite/contributor_spec.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: dcs_contributors
+#
+#  id                 :integer          not null, primary key
+#  contributor_name   :text(65535)
+#  contributor_type   :string           default("funder")
+#  identifier_type    :string
+#  name_identifier_id :string(191)
+#  resource_id        :integer
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  award_number       :text(65535)
+#  funder_order       :integer
+#  award_description  :string(191)
+#
 require 'rails_helper'
 
 module StashDatacite

--- a/spec/models/stash_datacite/datacite_date_spec.rb
+++ b/spec/models/stash_datacite/datacite_date_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: dcs_dates
+#
+#  id          :integer          not null, primary key
+#  date        :string(191)
+#  date_type   :string
+#  resource_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 require 'rails_helper'
 
 module StashDatacite

--- a/spec/models/stash_datacite/description_spec.rb
+++ b/spec/models/stash_datacite/description_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: dcs_descriptions
+#
+#  id               :integer          not null, primary key
+#  description      :text(16777215)
+#  description_type :string
+#  resource_id      :integer
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
 require 'rails_helper'
 
 module StashDatacite

--- a/spec/models/stash_datacite/geolocation_box_spec.rb
+++ b/spec/models/stash_datacite/geolocation_box_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: dcs_geo_location_boxes
+#
+#  id           :integer          not null, primary key
+#  sw_latitude  :decimal(10, 6)
+#  ne_latitude  :decimal(10, 6)
+#  sw_longitude :decimal(10, 6)
+#  ne_longitude :decimal(10, 6)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 require 'rails_helper'
 
 module StashDatacite

--- a/spec/models/stash_datacite/geolocation_place_spec.rb
+++ b/spec/models/stash_datacite/geolocation_place_spec.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: dcs_geo_location_places
+#
+#  id                 :integer          not null, primary key
+#  geo_location_place :text(65535)
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
 require 'rails_helper'
 
 module StashDatacite

--- a/spec/models/stash_datacite/geolocation_point_spec.rb
+++ b/spec/models/stash_datacite/geolocation_point_spec.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: dcs_geo_location_points
+#
+#  id         :integer          not null, primary key
+#  latitude   :decimal(10, 6)
+#  longitude  :decimal(10, 6)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require 'rails_helper'
 
 module StashDatacite

--- a/spec/models/stash_datacite/geolocation_spec.rb
+++ b/spec/models/stash_datacite/geolocation_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: dcs_geo_locations
+#
+#  id          :integer          not null, primary key
+#  place_id    :integer
+#  point_id    :integer
+#  box_id      :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  resource_id :integer
+#
 require 'rails_helper'
 
 module StashDatacite

--- a/spec/models/stash_datacite/publication_year_spec.rb
+++ b/spec/models/stash_datacite/publication_year_spec.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: dcs_publication_years
+#
+#  id               :integer          not null, primary key
+#  publication_year :string(191)
+#  resource_id      :integer
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
 require 'rails_helper'
 
 module StashDatacite

--- a/spec/models/stash_datacite/related_identifier_spec.rb
+++ b/spec/models/stash_datacite/related_identifier_spec.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: dcs_related_identifiers
+#
+#  id                      :integer          not null, primary key
+#  related_identifier      :text(65535)
+#  related_identifier_type :string
+#  relation_type           :string
+#  related_metadata_scheme :text(65535)
+#  scheme_URI              :text(65535)
+#  scheme_type             :text(65535)
+#  resource_id             :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  fixed_id                :text(65535)
+#  work_type               :integer          default("undefined")
+#  verified                :boolean          default(FALSE)
+#  hidden                  :boolean          default(FALSE)
+#  added_by                :integer          default("default")
+#
 require 'rails_helper'
 
 module StashDatacite

--- a/spec/models/stash_datacite/resource_type_spec.rb
+++ b/spec/models/stash_datacite/resource_type_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: dcs_resource_types
+#
+#  id                    :integer          not null, primary key
+#  resource_type_general :string
+#  resource_type         :text(65535)
+#  resource_id           :integer
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#
 require 'rails_helper'
 
 module StashDatacite

--- a/spec/models/stash_datacite/subject_spec.rb
+++ b/spec/models/stash_datacite/subject_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: dcs_subjects
+#
+#  id             :integer          not null, primary key
+#  subject        :text(65535)
+#  subject_scheme :text(65535)
+#  scheme_URI     :text(65535)
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 module StashDatacite
   module Resource
     describe Subject do

--- a/spec/models/stash_datacite/temporal_coverage_spec.rb
+++ b/spec/models/stash_datacite/temporal_coverage_spec.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: stash_datacite_temporal_coverages
+#
+#  id          :integer          not null, primary key
+#  description :text(65535)
+#  resource_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 require 'rails_helper'
 
 module StashDatacite

--- a/spec/models/stash_engine/api_token_spec.rb
+++ b/spec/models/stash_engine/api_token_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: stash_engine_api_tokens
+#
+#  id         :bigint           not null, primary key
+#  app_id     :string(191)
+#  secret     :string(191)
+#  token      :string(191)
+#  expires_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require 'rails_helper'
 
 module StashEngine

--- a/spec/models/stash_engine/author_spec.rb
+++ b/spec/models/stash_engine/author_spec.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: stash_engine_authors
+#
+#  id                 :integer          not null, primary key
+#  author_first_name  :string(191)
+#  author_last_name   :string(191)
+#  author_email       :string(191)
+#  author_orcid       :string(191)
+#  resource_id        :integer
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  stripe_customer_id :text(65535)
+#  author_order       :integer
+#
 module StashEngine
   describe Author do
 

--- a/spec/models/stash_engine/counter_citation_spec.rb
+++ b/spec/models/stash_engine/counter_citation_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_counter_citations
+#
+#  id            :integer          not null, primary key
+#  citation      :text(65535)
+#  doi           :text(65535)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  identifier_id :integer
+#
 module StashEngine
   describe CounterCitation do
 

--- a/spec/models/stash_engine/counter_stat_spec.rb
+++ b/spec/models/stash_engine/counter_stat_spec.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: stash_engine_counter_stats
+#
+#  id                         :integer          not null, primary key
+#  identifier_id              :integer
+#  citation_count             :integer
+#  unique_investigation_count :integer
+#  unique_request_count       :integer
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  citation_updated           :datetime         default(Mon, 01 Jan 2018 00:00:00.000000000 UTC +00:00)
+#
 require 'ostruct'
 require 'byebug'
 

--- a/spec/models/stash_engine/curation_activity_spec.rb
+++ b/spec/models/stash_engine/curation_activity_spec.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: stash_engine_curation_activities
+#
+#  id          :integer          not null, primary key
+#  status      :string(191)      default("in_progress")
+#  user_id     :integer
+#  note        :text(65535)
+#  keywords    :string(191)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  resource_id :integer
+#
 require 'ostruct'
 require_relative '../../../stash/spec_helpers/factory_helper'
 require 'byebug'

--- a/spec/models/stash_engine/curation_stats_spec.rb
+++ b/spec/models/stash_engine/curation_stats_spec.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: stash_engine_curation_stats
+#
+#  id                          :bigint           not null, primary key
+#  date                        :datetime
+#  datasets_curated            :integer
+#  new_datasets_to_submitted   :integer
+#  new_datasets_to_peer_review :integer
+#  datasets_to_aar             :integer
+#  datasets_to_published       :integer
+#  datasets_to_embargoed       :integer
+#  datasets_to_withdrawn       :integer
+#  author_revised              :integer
+#  author_versioned            :integer
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  datasets_to_be_curated      :integer
+#  ppr_to_curation             :integer
+#
 module StashEngine
   describe CurationStats do
 

--- a/spec/models/stash_engine/data_file_spec.rb
+++ b/spec/models/stash_engine/data_file_spec.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: stash_engine_generic_files
+#
+#  id                  :integer          not null, primary key
+#  upload_file_name    :text(65535)
+#  upload_content_type :text(65535)
+#  upload_file_size    :bigint
+#  resource_id         :integer
+#  upload_updated_at   :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  validated_at        :datetime
+#  file_state          :string(7)
+#  url                 :text(65535)
+#  status_code         :integer
+#  timed_out           :boolean          default(FALSE)
+#  original_url        :text(65535)
+#  cloud_service       :string(191)
+#  digest              :string(191)
+#  digest_type         :string(8)
+#  description         :text(65535)
+#  original_filename   :text(65535)
+#  type                :string(191)
+#  compressed_try      :integer          default(0)
+#
 require 'fileutils'
 require 'byebug'
 require 'cgi'

--- a/spec/models/stash_engine/download_token_spec.rb
+++ b/spec/models/stash_engine/download_token_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_download_tokens
+#
+#  id          :integer          not null, primary key
+#  resource_id :integer
+#  token       :string(191)
+#  available   :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 require 'rails_helper'
 
 module StashEngine

--- a/spec/models/stash_engine/external_reference_spec.rb
+++ b/spec/models/stash_engine/external_reference_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_external_references
+#
+#  id            :integer          not null, primary key
+#  identifier_id :integer
+#  source        :string(191)
+#  value         :text(4294967295)
+#  created_at    :datetime
+#  updated_at    :datetime
+#
 module StashEngine
   describe ExternalReference do
 

--- a/spec/models/stash_engine/frictionless_report_spec.rb
+++ b/spec/models/stash_engine/frictionless_report_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_frictionless_reports
+#
+#  id              :bigint           not null, primary key
+#  report          :text(4294967295)
+#  generic_file_id :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  status          :string
+#
 require 'rails_helper'
 
 module StashEngine

--- a/spec/models/stash_engine/funder_role_spec.rb
+++ b/spec/models/stash_engine/funder_role_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: stash_engine_funder_roles
+#
+#  id          :bigint           not null, primary key
+#  user_id     :bigint
+#  funder_id   :string(191)
+#  funder_name :string(191)
+#  role        :string(191)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 require 'rails_helper'
 
 module StashEngine

--- a/spec/models/stash_engine/generic_file_spec.rb
+++ b/spec/models/stash_engine/generic_file_spec.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: stash_engine_generic_files
+#
+#  id                  :integer          not null, primary key
+#  upload_file_name    :text(65535)
+#  upload_content_type :text(65535)
+#  upload_file_size    :bigint
+#  resource_id         :integer
+#  upload_updated_at   :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  validated_at        :datetime
+#  file_state          :string(7)
+#  url                 :text(65535)
+#  status_code         :integer
+#  timed_out           :boolean          default(FALSE)
+#  original_url        :text(65535)
+#  cloud_service       :string(191)
+#  digest              :string(191)
+#  digest_type         :string(8)
+#  description         :text(65535)
+#  original_filename   :text(65535)
+#  type                :string(191)
+#  compressed_try      :integer          default(0)
+#
 require 'fileutils'
 require 'byebug'
 require 'cgi'

--- a/spec/models/stash_engine/identifier_spec.rb
+++ b/spec/models/stash_engine/identifier_spec.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: stash_engine_identifiers
+#
+#  id                  :integer          not null, primary key
+#  identifier          :text(65535)
+#  identifier_type     :text(65535)
+#  storage_size        :bigint
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  latest_resource_id  :integer
+#  license_id          :string(191)      default("cc0")
+#  search_words        :text(65535)
+#  payment_type        :string(191)
+#  payment_id          :text(65535)
+#  waiver_basis        :string(191)
+#  pub_state           :string
+#  software_license_id :integer
+#  edit_code           :string(191)
+#  import_info         :integer          default("other")
+#
 require 'webmock/rspec'
 require 'byebug'
 

--- a/spec/models/stash_engine/internal_datum_spec.rb
+++ b/spec/models/stash_engine/internal_datum_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_internal_data
+#
+#  id            :integer          not null, primary key
+#  identifier_id :integer
+#  data_type     :string(191)
+#  value         :string(191)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
 require 'ostruct'
 require 'byebug'
 

--- a/spec/models/stash_engine/journal_organization_spec.rb
+++ b/spec/models/stash_engine/journal_organization_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: stash_engine_journal_organizations
+#
+#  id            :bigint           not null, primary key
+#  name          :string(191)
+#  contact       :string(191)
+#  parent_org_id :integer
+#  type          :string(191)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
 require 'rails_helper'
 
 module StashEngine

--- a/spec/models/stash_engine/journal_role_spec.rb
+++ b/spec/models/stash_engine/journal_role_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: stash_engine_journal_roles
+#
+#  id                      :integer          not null, primary key
+#  journal_id              :integer
+#  user_id                 :integer
+#  role                    :string(191)
+#  created_at              :datetime
+#  updated_at              :datetime
+#  journal_organization_id :integer
+#
 require 'rails_helper'
 
 module StashEngine

--- a/spec/models/stash_engine/journal_spec.rb
+++ b/spec/models/stash_engine/journal_spec.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: stash_engine_journals
+#
+#  id                      :integer          not null, primary key
+#  title                   :string(191)
+#  issn                    :string(191)
+#  website                 :string(191)
+#  description             :text(65535)
+#  payment_plan_type       :string
+#  payment_contact         :string(191)
+#  manuscript_number_regex :string(191)
+#  stripe_customer_id      :string(191)
+#  notify_contacts         :text(65535)
+#  review_contacts         :text(65535)
+#  allow_review_workflow   :boolean
+#  allow_embargo           :boolean
+#  allow_blackout          :boolean
+#  default_to_ppr          :boolean          default(FALSE)
+#  created_at              :datetime
+#  updated_at              :datetime
+#  journal_code            :string(191)
+#  sponsor_id              :integer
+#
 require 'rails_helper'
 
 module StashEngine

--- a/spec/models/stash_engine/lock_spec.rb
+++ b/spec/models/stash_engine/lock_spec.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: locks
+#
+#  id         :integer          not null, primary key
+#  name       :string(40)
+#  created_at :datetime
+#  updated_at :datetime
+#
 module StashEngine
   describe Lock, '.acquire' do
 

--- a/spec/models/stash_engine/manuscript_spec.rb
+++ b/spec/models/stash_engine/manuscript_spec.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: stash_engine_manuscripts
+#
+#  id                :bigint           not null, primary key
+#  journal_id        :bigint
+#  identifier_id     :bigint
+#  manuscript_number :string(191)
+#  status            :string(191)
+#  metadata          :text(16777215)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
 require 'webmock/rspec'
 require 'byebug'
 

--- a/spec/models/stash_engine/noid_state_spec.rb
+++ b/spec/models/stash_engine/noid_state_spec.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: noid_states
+#
+#  id         :integer          not null, primary key
+#  state      :text(65535)
+#  created_at :datetime
+#  updated_at :datetime
+#
 module StashEngine
   describe NoidState do
     before(:each) do

--- a/spec/models/stash_engine/proposed_change_spec.rb
+++ b/spec/models/stash_engine/proposed_change_spec.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: stash_engine_proposed_changes
+#
+#  id               :integer          not null, primary key
+#  identifier_id    :integer
+#  approved         :boolean
+#  rejected         :boolean
+#  user_id          :integer
+#  authors          :text(65535)
+#  provenance       :string(191)
+#  publication_date :datetime
+#  publication_doi  :string(191)
+#  publication_issn :string(191)
+#  publication_name :string(191)
+#  score            :float(24)
+#  provenance_score :float(24)
+#  title            :text(65535)
+#  url              :string(191)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  subjects         :text(65535)
+#  xref_type        :string(191)
+#
 require 'rails_helper'
 
 module StashEngine

--- a/spec/models/stash_engine/repo_queue_state_spec.rb
+++ b/spec/models/stash_engine/repo_queue_state_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_repo_queue_states
+#
+#  id          :integer          not null, primary key
+#  resource_id :integer
+#  state       :string
+#  hostname    :string(191)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 module StashEngine
   describe User do
     attr_reader :user

--- a/spec/models/stash_engine/ror_org_spec.rb
+++ b/spec/models/stash_engine/ror_org_spec.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: stash_engine_ror_orgs
+#
+#  id         :bigint           not null, primary key
+#  ror_id     :string(191)
+#  name       :string(191)
+#  home_page  :string(191)
+#  country    :string(191)
+#  acronyms   :json
+#  aliases    :json
+#  isni_ids   :json
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require 'rails_helper'
 
 module StashEngine

--- a/spec/models/stash_engine/share_spec.rb
+++ b/spec/models/stash_engine/share_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stash_engine_shares
+#
+#  id            :integer          not null, primary key
+#  secret_id     :string(191)
+#  resource_id   :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  identifier_id :integer
+#
 module StashEngine
   describe Share do
 

--- a/spec/models/stash_engine/software_file_spec.rb
+++ b/spec/models/stash_engine/software_file_spec.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: stash_engine_generic_files
+#
+#  id                  :integer          not null, primary key
+#  upload_file_name    :text(65535)
+#  upload_content_type :text(65535)
+#  upload_file_size    :bigint
+#  resource_id         :integer
+#  upload_updated_at   :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  validated_at        :datetime
+#  file_state          :string(7)
+#  url                 :text(65535)
+#  status_code         :integer
+#  timed_out           :boolean          default(FALSE)
+#  original_url        :text(65535)
+#  cloud_service       :string(191)
+#  digest              :string(191)
+#  digest_type         :string(8)
+#  description         :text(65535)
+#  original_filename   :text(65535)
+#  type                :string(191)
+#  compressed_try      :integer          default(0)
+#
 require 'fileutils'
 require 'byebug'
 require 'cgi'

--- a/spec/models/stash_engine/supp_file_spec.rb
+++ b/spec/models/stash_engine/supp_file_spec.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: stash_engine_generic_files
+#
+#  id                  :integer          not null, primary key
+#  upload_file_name    :text(65535)
+#  upload_content_type :text(65535)
+#  upload_file_size    :bigint
+#  resource_id         :integer
+#  upload_updated_at   :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  validated_at        :datetime
+#  file_state          :string(7)
+#  url                 :text(65535)
+#  status_code         :integer
+#  timed_out           :boolean          default(FALSE)
+#  original_url        :text(65535)
+#  cloud_service       :string(191)
+#  digest              :string(191)
+#  digest_type         :string(8)
+#  description         :text(65535)
+#  original_filename   :text(65535)
+#  type                :string(191)
+#  compressed_try      :integer          default(0)
+#
 require 'fileutils'
 require 'byebug'
 require 'cgi'

--- a/spec/models/stash_engine/zenodo_copy_spec.rb
+++ b/spec/models/stash_engine/zenodo_copy_spec.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: stash_engine_zenodo_copies
+#
+#  id            :integer          not null, primary key
+#  state         :string           default("enqueued")
+#  deposition_id :integer
+#  error_info    :text(16777215)
+#  identifier_id :integer
+#  resource_id   :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  retries       :integer          default(0)
+#  copy_type     :string           default("data")
+#  software_doi  :string(191)
+#  conceptrecid  :string(191)
+#  note          :text(65535)
+#
 module StashEngine
   describe ZenodoCopy, type: :model do
 


### PR DESCRIPTION
These are automagically updated on every `db:migrate` command (run in dev -- `local`), so no need to touch it once set up.