### PR TITLE
feat: allow passing `holdForPeerReview` on `POST /api/v2/datasets`

### DIFF
--- a/app/models/stash_api/dataset_parser.rb
+++ b/app/models/stash_api/dataset_parser.rb
@@ -27,7 +27,7 @@ module StashApi
       user_note = "Created by API user, assigned ownership to #{owning_user&.name} (#{owning_user_id})"
       hold_for_peer_review = @hash['holdForPeerReview']
       @resource.curation_activities << StashEngine::CurationActivity.create(
-        status: hold_for_peer_review ? 'peer_review' : @resource.current_curation_status || 'in_progress',
+        status: @resource.current_curation_status || 'in_progress',
         user_id: @user.id,
         resource_id: @resource.id,
         note: user_note

--- a/app/models/stash_api/dataset_parser.rb
+++ b/app/models/stash_api/dataset_parser.rb
@@ -25,10 +25,13 @@ module StashApi
       owning_user_id = establish_owning_user_id
       owning_user = StashEngine::User.find(owning_user_id)
       user_note = "Created by API user, assigned ownership to #{owning_user&.name} (#{owning_user_id})"
-      @resource.curation_activities << StashEngine::CurationActivity.create(status: @resource.current_curation_status || 'in_progress',
-                                                                            user_id: @user.id,
-                                                                            resource_id: @resource.id,
-                                                                            note: user_note)
+      hold_for_peer_review = @hash['holdForPeerReview']
+      @resource.curation_activities << StashEngine::CurationActivity.create(
+        status: hold_for_peer_review ? 'peer_review' : @resource.current_curation_status || 'in_progress',
+        user_id: @user.id,
+        resource_id: @resource.id,
+        note: user_note
+      )
 
       @resource.update(
         title: remove_html(@hash['title']),
@@ -37,7 +40,8 @@ module StashApi
         skip_datacite_update: @hash['skipDataciteUpdate'] || false,
         skip_emails: @hash['skipEmails'] || false,
         preserve_curation_status: @hash['preserveCurationStatus'] || false,
-        loosen_validation: @hash['loosenValidation'] || false
+        loosen_validation: @hash['loosenValidation'] || false,
+        hold_for_peer_review: hold_for_peer_review # after ruby 3.1 this can be just hold_for_peer_review:
       )
 
       @hash[:authors]&.each { |author| add_author(json_author: author) }

--- a/documentation/apis/dataset_metadata.md
+++ b/documentation/apis/dataset_metadata.md
@@ -122,6 +122,8 @@ behavior:
   some basic validation of the dataset. This should only be used when
   datasets are being replicated from another system and it is not
   feasible to provide complete metadata.
+- `holdForPeerReview` - Defaults to false. Allows a dataset to be set in
+  hold for peer review status when it is created
 
 The above settings get carried with a dataset into future API
 submissions, but Dryad's web interface resets these values to `false` (except

--- a/documentation/apis/sample_dataset.json
+++ b/documentation/apis/sample_dataset.json
@@ -79,5 +79,6 @@
     "skipDataciteUpdate" : false,
     "skipEmails" : false,
     "loosenValidation" : false,
-    "preserveCurationStatus": false
+    "preserveCurationStatus": false,
+	"holdForPeerReview": false
 }

--- a/spec/models/stash_api/dataset_parser_spec.rb
+++ b/spec/models/stash_api/dataset_parser_spec.rb
@@ -45,7 +45,8 @@ module StashApi
         'publicationName' => 'Some Great Journal',
         'manuscriptNumber' => 'ABC123',
         'paymentId' => 'invoice-123',
-        'paymentType' => 'stripe'
+        'paymentType' => 'stripe',
+        'holdForPeerReview' => true
       }.with_indifferent_access
 
       @update_metadata = {
@@ -76,6 +77,7 @@ module StashApi
         expect(@stash_identifier.resources.count).to eq(1)
         resource = @stash_identifier.resources.first
         expect(resource.title).to eq(@basic_metadata[:title])
+        expect(resource.hold_for_peer_review).to be true
       end
 
       it 'creates the basic author metadata as specified' do


### PR DESCRIPTION
- updates the `Resource#hold_for_peer_review` based on this value
- update the associated curation activity created to be of `peer_review` status

ref https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2945