### PR TITLE
Add a storage_version_id to stash_engine_generic_files

### DIFF
--- a/db/migrate/20240119144939_add_storage_version_id.rb
+++ b/db/migrate/20240119144939_add_storage_version_id.rb
@@ -1,0 +1,5 @@
+class AddStorageVersionId < ActiveRecord::Migration[6.1]
+  def change
+     add_column :stash_engine_generic_files, :storage_version_id, :integer, after: :resource_id
+  end
+end


### PR DESCRIPTION
As described in https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2940, this provides a place to indicate the storage location of a file, so the file can be easily located, regardless of which version/resource the file was originally created for.

Initially, we can leave the old "walk through the versions" code in place, and use it whenever `storage_version_id` is null, until we have completely transitioned to the new process.
