### PR TITLE
Removing scott from most email notifications within Dryad

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -46,7 +46,7 @@ defaults: &DEFAULTS
     access_token: <%= Rails.application.credentials[Rails.env.to_sym][:zenodo_access_token] %>
   payments:
     service: stripe
-    key: <%= Rails.application.credentials[Rails.env.to_sym][:stripe_key] %> 
+    key: <%= Rails.application.credentials[Rails.env.to_sym][:stripe_key] %>
     data_processing_charge: 12000 # charge in cents
     data_processing_charge_new: 15000 # charge in cents
     dpc_change_date: 2023-01-04
@@ -56,7 +56,7 @@ defaults: &DEFAULTS
   merritt_base_url: https://merritt-stage.cdlib.org
   merritt_max_submission_threads: 5
   crossref_base_url: https://api.crossref.org
-  crossref_mailto: scott.fisher@ucop.edu
+  crossref_mailto: ryan@datadryad.org
   # world bank low income or lower-middle income
   # DR Congo is there since ROR data seems to have both values for it
   # Same for Swaziland, East Timor
@@ -79,7 +79,7 @@ defaults: &DEFAULTS
     - 'Malawi'
     - 'Mali'
     - 'Mozambique'
-    - 'Niger'    
+    - 'Niger'
     - 'Rwanda'
     - 'Sierra Leone'
     - 'Somalia'
@@ -153,15 +153,15 @@ defaults: &DEFAULTS
     labslink:
       ftp_host: labslink.ebi.ac.uk
       ftp_dir: f24ml3c8
-      ftp_username: <%= Rails.application.credentials[Rails.env.to_sym][:labslink_ftp_username] %> 
-      ftp_password: <%= Rails.application.credentials[Rails.env.to_sym][:labslink_ftp_password] %> 
+      ftp_username: <%= Rails.application.credentials[Rails.env.to_sym][:labslink_ftp_username] %>
+      ftp_password: <%= Rails.application.credentials[Rails.env.to_sym][:labslink_ftp_password] %>
       ftp_provider_id: 1012
     # LinkOut FTP information for NCBI
     pubmed:
       ftp_host: sftp-private.ncbi.nlm.nih.gov
       ftp_dir: holdings
-      ftp_username: <%= Rails.application.credentials[Rails.env.to_sym][:pubmed_ftp_username] %> 
-      ftp_password: <%= Rails.application.credentials[Rails.env.to_sym][:pubmed_ftp_password] %> 
+      ftp_username: <%= Rails.application.credentials[Rails.env.to_sym][:pubmed_ftp_username] %>
+      ftp_password: <%= Rails.application.credentials[Rails.env.to_sym][:pubmed_ftp_password] %>
       ftp_provider_id: 7893
       api_key: <%= Rails.application.credentials[Rails.env.to_sym][:pubmed_api_key] %>
   s3:
@@ -205,7 +205,7 @@ defaults: &DEFAULTS
     server: https://dryad--cloudparti.sandbox.lightning.force.com
     login_host: test.salesforce.com
     username: admin@datadryad.org.cloudparti
-    password: <%= Rails.application.credentials[Rails.env.to_sym][:salesforce_password] %>    
+    password: <%= Rails.application.credentials[Rails.env.to_sym][:salesforce_password] %>
     security_token: <%= Rails.application.credentials[Rails.env.to_sym][:salesforce_security_token] %>
     client_id: <%= Rails.application.credentials[Rails.env.to_sym][:salesforce_client_id] %>
     client_secret: <%= Rails.application.credentials[Rails.env.to_sym][:salesforce_client_secret] %>
@@ -228,8 +228,8 @@ defaults: &DEFAULTS
 
 development: &DEVELOPMENT
   <<: *DEFAULTS
-  submission_error_email: [dryad.submission.error.emails@mailinator.com, sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
-  zenodo_error_email: [dryad.submission.error.emails@mailinator.com, sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
+  submission_error_email: [dryad.submission.error.emails@mailinator.com, ryan@datadryad.org, audrey@datadryad.org]
+  zenodo_error_email: [dryad.submission.error.emails@mailinator.com, ryan@datadryad.org, audrey@datadryad.org]
   zenodo:
     access_token: <%= Rails.application.credentials[Rails.env.to_sym][:zenodo_access_token] %>
     base_url: https://zenodo-rdm-qa.web.cern.ch
@@ -246,7 +246,7 @@ development: &DEVELOPMENT
   matomo_analytics_id: datadryad-dev
   payments:
     service: stripe
-    key: <%= Rails.application.credentials[Rails.env.to_sym][:stripe_key] %> 
+    key: <%= Rails.application.credentials[Rails.env.to_sym][:stripe_key] %>
     # Very small limit for large files to facilitate testing (500KB)
     large_file_size: 5.0e+5
     data_processing_charge: 12000 # charge in cents
@@ -266,7 +266,7 @@ development: &DEVELOPMENT
 
 v3_development:
   <<: *DEVELOPMENT
-    
+
 aws_db:
   <<: *DEVELOPMENT
   send_journal_published_notices: false
@@ -281,10 +281,10 @@ local_dev:
 
 stage: &STAGE
   <<: *DEFAULTS
-  submission_error_email: [dryad.submission.error.emails@mailinator.com, sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
-  zenodo_error_email: [dryad.submission.error.emails@mailinator.com, sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
+  submission_error_email: [dryad.submission.error.emails@mailinator.com, ryan@datadryad.org, audrey@datadryad.org]
+  zenodo_error_email: [dryad.submission.error.emails@mailinator.com, ryan@datadryad.org, audrey@datadryad.org]
   shib_sp_host: dryad-stg.cdlib.org
-  page_error_email: [scott.fisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
+  page_error_email: [ryan@datadryad.org, audrey@datadryad.org]
   feedback_email_from: no-reply-dryad-stg@datadryad.org
   google_analytics_id: UA-145629338-3
   matomo_analytics_id: datadryad-stg
@@ -314,26 +314,26 @@ v3_stage:
 
 migration:
   <<: *DEFAULTS
-  submission_error_email: [sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
-  zenodo_error_email: [sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
+  submission_error_email: [ryan@datadryad.org, audrey@datadryad.org]
+  zenodo_error_email: [ryan@datadryad.org, audrey@datadryad.org]
   shib_sp_host: dryad-stg.cdlib.org
-  page_error_email: ["scott.fisher@ucop.edu"]
+  page_error_email: ["ryan@datadryad.org"]
   feedback_email_from: no-reply-dryad-migration@datadryad.org
 
 demo:
   <<: *DEFAULTS
   shib_sp_host: dryaddemo.cdlib.org
-  page_error_email: [scott.fisher@ucop.edu]
-  submission_error_email: [sfisher@ucop.edu, ryan@datadryad.org]
-  zenodo_error_email: [sfisher@ucop.edu, ryan@datadryad.org]
+  page_error_email: [ryan@datadryad.org]
+  submission_error_email: [ryan@datadryad.org]
+  zenodo_error_email: [ryan@datadryad.org]
   feedback_email_from: no-reply-dryaddemo@cdlib.org
 
 production: &PRODUCTION
   <<: *DEFAULTS
   shib_sp_host: datadryad.org
-  page_error_email: [scott.fisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
+  page_error_email: [ryan@datadryad.org, audrey@datadryad.org]
   submission_error_email: [sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org, Steve.Diggs@ucop.edu]
-  zenodo_error_email: [sfisher@ucop.edu, ryan@datadryad.org, audrey@datadryad.org]
+  zenodo_error_email: [ryan@datadryad.org, audrey@datadryad.org]
   helpdesk_email: help@datadryad.org
   feedback_email_from: no-reply-dryad@datadryad.org
   repository:

--- a/config/environments/development.rb.stagelike
+++ b/config/environments/development.rb.stagelike
@@ -22,9 +22,9 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  # config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?	
-  config.public_file_server.enabled = true					
-    
+  # config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
+
   # Compress JavaScripts and CSS, default is sassc without being specified for css
   config.assets.js_compressor = :uglifier
 
@@ -82,7 +82,7 @@ Rails.application.configure do
     # :deliver_with => :deliver, # Rails >= 4.2.1 do not need this option since it defaults to :deliver_now
     :email_prefix => "[Dash2 Exception]",
     :sender_address => %{"Dash2 Notifier" <no-reply-dash2-stg@ucop.edu>},
-    :exception_recipients => %w{marisa.strong@ucop.edu scott.fisher@ucop.edu bhavi.vedula@ucop.edu}
+    :exception_recipients => %w{ryan@datadryad.org}
   }
 
   config.action_mailer.delivery_method = :sendmail

--- a/config/environments/migration.rb
+++ b/config/environments/migration.rb
@@ -85,7 +85,7 @@ Rails.application.configure do
     # :deliver_with => :deliver, # Rails >= 4.2.1 do not need this option since it defaults to :deliver_now
     :email_prefix => "[Dryad Exception]",
     :sender_address => %{"Dryad Notifier" <no-reply-dryad-migration@ucop.edu>},
-    :exception_recipients => %w{scott.fisher@ucop.edu ryan@datadryad.org}
+    :exception_recipients => %w{ryan@datadryad.org}
   },
   :error_grouping => true,
   :error_grouping_period => 3.hours

--- a/config/tenants/dataone.yml
+++ b/config/tenants/dataone.yml
@@ -13,7 +13,7 @@ default: &default
     strategy: none
   default_license: cc0
   dash_logo_after_tenant: false
-  campus_contacts: ["scott.fisher@ucop.edu"]
+  campus_contacts: ["ryan@datadryad.org"]
   data_deposit_agreement: false
   partner_display: false
   covers_dps: true

--- a/config/tenants/dryad.yml
+++ b/config/tenants/dryad.yml
@@ -10,7 +10,7 @@ default: &default
   authentication:
     strategy: none
   default_license: cc0
-  campus_contacts: ["scott.fisher@ucop.edu"] # for testing
+  campus_contacts: ["ryan@datadryad.org"] # for testing
   data_deposit_agreement: false
   partner_display: false
   covers_dpc: false

--- a/config/tenants/dryad_iptest.yml
+++ b/config/tenants/dryad_iptest.yml
@@ -11,7 +11,7 @@ default: &default
     strategy: ip_address
     ranges: ["128.48.67.15/255.255.255.0", "127.0.0.1/255.255.255.0"]
   default_license: cc0
-  campus_contacts: ["scott.fisher@ucop.edu"] # for testing
+  campus_contacts: ["ryan@datadryad.org"] # for testing
   data_deposit_agreement: false
   partner_display: false
   covers_dpc: true

--- a/config/tenants/ucop.yml
+++ b/config/tenants/ucop.yml
@@ -14,7 +14,7 @@ default: &default
     entity_id: urn:mace:incommon:ucop.edu
     entity_domain: .ucop.edu
   default_license: cc0
-  campus_contacts: ["scott.fisher@ucop.edu"] # for testing
+  campus_contacts: ["ryan@datadryad.org"] # for testing
   data_deposit_agreement: false
   partner_display: true
   covers_dpc: true

--- a/lib/stash/event_data/usage.rb
+++ b/lib/stash/event_data/usage.rb
@@ -14,7 +14,7 @@ module Stash
       # BASE_URL = 'https://api.test.datacite.org/events'.freeze
       BASE_URL = 'https://api.datacite.org/events'.freeze
       HEARTBEAT_URL = 'https://api.datacite.org/heartbeat'.freeze
-      EMAIL = 'scott.fisher@ucop.edu'.freeze
+      EMAIL = 'ryan@datadryad.org'.freeze
       UNIQUE_INVESTIGATIONS = %w[unique-dataset-investigations-regular unique-dataset-investigations-machine].freeze
       UNIQUE_REQUESTS = %w[unique-dataset-requests-regular unique-dataset-requests-machine].freeze
 


### PR DESCRIPTION
I went through and removed myself from most email notifications within Dryad.  There were quite a few places, including some environments that I don't think are used anymore.  Where there was no one else's email, I substituted ryan instead for now.

I left myself on the production submission errors since it will still be useful for me to see if things are failing to go through Merritt in production and I can check in with them as needed.

This is sort of sad, 😞 but it will be nice to have a cleaner inbox. 

![mailbox](https://images.wsj.net/im-887735/?width=200)

