### PR TITLE
Improve neuro keywords

### DIFF
--- a/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
+++ b/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
@@ -38,7 +38,7 @@ module StashDatacite
       title = @resource.title || ''
       abstract = @metadata_entry.abstract.description || ''
       @neuro_data = false
-      bank = %w[neuro cognition cortex]
+      bank = %w[neuro cogniti cereb]
       regex = bank.join('|')
       keywords = @metadata_entry.subjects.map(&:subject).join(', ')
       if !!title.match?(/#{regex}/i) || !!publication_name.match?(/#{regex}/i) || !!keywords.match?(/#{regex}/i) || !!abstract.match?(/#{regex}/i)


### PR DESCRIPTION
An attempt to improve the keywords that trigger the neuroscience CEDAR template. `cortex` can describe many non-neuro structures, including plants. It's also useful to include words like `cerebral`, `cerebellum`, and `cognitive`.