### PR TITLE
Fix rspec tests requiring abstract

### DIFF
--- a/spec/support/helpers/collection_helper.rb
+++ b/spec/support/helpers/collection_helper.rb
@@ -43,8 +43,9 @@ module CollectionHelper
     page.send_keys(:tab)
     page.has_css?('.use-text-entered')
     all(:css, '.use-text-entered').each { |i| i.set(true) }
-    fill_in_tinymce(field: 'abstract', content: Faker::Lorem.paragraph)
     fill_in_keywords
+    # fill_in_tinymce(field: 'abstract', content: Faker::Lorem.paragraph)
+    create(:description, resource: StashEngine::Resource.last)
     fill_in_collection
   end
 

--- a/spec/support/helpers/dataset_helper.rb
+++ b/spec/support/helpers/dataset_helper.rb
@@ -66,7 +66,8 @@ module DatasetHelper
     page.send_keys(:tab)
     page.has_css?('.use-text-entered')
     all(:css, '.use-text-entered').each { |i| i.set(true) }
-    fill_in_tinymce(field: 'abstract', content: Faker::Lorem.paragraph)
+    # fill_in_tinymce(field: 'abstract', content: Faker::Lorem.paragraph)
+    create(:description, resource: StashEngine::Resource.last)
     fill_in_keywords
   end
 


### PR DESCRIPTION
I believe that the abstract is being entered in the tinyMCE editor but not saved due to the new need for an API key. Rather than store a valid API key in our example config file, we can create the abstract directly and ignore the editor (something already being done for several other page elements) which allows these tests to pass.