### PR TITLE
Update config instructions for v3 servers

### DIFF
--- a/documentation/external_services/datadryad.org.conf
+++ b/documentation/external_services/datadryad.org.conf
@@ -1,0 +1,89 @@
+#
+#  Virtual Host Context for Apache
+#
+<VirtualHost *:80>
+
+    #   General setup for the virtual host
+    DocumentRoot "/var/www/html"
+    ServerName stage.datadryad.org
+    ServerAlias v3-stage.datadryad.org
+    ServerAlias v3-stage.datadryad.com
+    ServerAdmin admin@datadryad.org
+    ErrorLog "logs/datadryad.org-error_log"
+    CustomLog "logs/datadryad.org-access_log" common
+    RequestReadTimeout handshake=5 header=20-40,MinRate=500 body=30,MinRate=500
+    
+    # SSL is handled by load balancer, so it is not configured here
+    
+    #   Encoding
+    AllowEncodedSlashes On
+    AllowEncodedSlashes NoDecode
+
+    
+    BrowserMatch "MSIE [2-5]" \
+             nokeepalive ssl-unclean-shutdown \
+             downgrade-1.0 force-response-1.0
+    
+    
+    #   Shibboleth
+    #<Location /Shibboleth.sso>
+    #  AuthType shibboleth
+    #  require shibboleth
+    #  SSLRequireSSL
+    #</Location>
+    
+    #<Location /auth/shibboleth/callback>
+    #  AuthType shibboleth
+    #  require shibboleth
+    #  ShibUseHeaders On
+    #  SSLRequireSSL
+    #</Location>
+    
+    #<Location /stash/auth/shibboleth/callback>
+    #  AuthType shibboleth
+    #  require shibboleth
+    #  ShibUseHeaders On
+    #  SSLRequireSSL
+    #</Location>
+    
+    #<Location /shibtest>
+    #   AuthType shibboleth
+    #   ShibRequestSetting requireSession 1
+    #   require valid-user
+    #   ShibUseHeaders On
+    #   SSLRequireSSL
+    #</Location>
+    
+    #   CGI under shibboleth
+    #ScriptAlias /cgi-bin/ /dryad/apps/apache/cgi-bin/
+    #<Location /cgi-bin>
+    #   AuthType shibboleth
+    #   ShibRequestSetting requireSession 1
+    #   require shibboleth
+    #   ShibUseHeaders On
+    #   SSLRequireSSL
+    #   Allow from all
+    #</Location>
+
+
+    #
+    # Redirect all connections to the Rails server at port 3000
+    # except /cgi-bin/, /shibtest/, /Shibboleth.sso/ /shibboleth-ds/
+    #
+    RewriteEngine On
+    LogLevel warn rewrite:info
+    RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_FILENAME} !-f
+    RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_URI} !-f
+    RewriteCond %{REQUEST_URI} !/cgi-bin/
+    RewriteCond %{REQUEST_URI} !/shibtest/
+    RewriteCond %{REQUEST_URI} !/Shibboleth.sso
+    RewriteCond %{REQUEST_URI} !/shibboleth-ds/
+
+    # Send everything else to port 3000, the Rails application
+    RewriteRule ^/(.*)$ balancer://puma_cluster%{REQUEST_URI} [P,QSA,L,NE]
+  
+    <Proxy balancer://puma_cluster>
+      BalancerMember http://localhost:3000 max=64 acquire=10 timeout=600 Keepalive=On
+    </Proxy>
+
+</VirtualHost>


### PR DESCRIPTION
- Adds some steps to avoid a rogue version of Ruby running on the server, which can cause the dreaded `ffi` error. 
- Adds instructions for installing and configuring Apache, so Rails can respond to port 80 while allowing the Shibboleth library to run as well.