### PR TITLE
Correct file size calculations for new storage

### DIFF
--- a/app/models/stash_engine/repo_queue_state.rb
+++ b/app/models/stash_engine/repo_queue_state.rb
@@ -112,7 +112,7 @@ module StashEngine
       id = resource.identifier
       total_dataset_size = 0
       resource.data_files.each do |data_file|
-        total_dataset_size += data_file.upload_file_size
+        total_dataset_size += data_file.upload_file_size unless data_file.file_state == 'deleted'
       end
       id.update(storage_size: total_dataset_size)
       ::StashEngine.repository.cleanup_files(resource)

--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -37,7 +37,7 @@ namespace :dev_ops do
       puts "Adding size to #{i}"
       total_dataset_size = 0
       resource.data_files.each do |data_file|
-        total_dataset_size += data_file.upload_file_size
+        total_dataset_size += data_file.upload_file_size unless data_file.file_state == 'deleted'
       end
       i.update(storage_size: total_dataset_size)
     end


### PR DESCRIPTION
After running some tests, I saw that file size calculations were improperly including files that had been deleted from the version. This ignores them.