### PR TITLE
Add more neuroscience keywords

### DIFF
--- a/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
+++ b/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
@@ -38,7 +38,7 @@ module StashDatacite
       title = @resource.title || ''
       abstract = @metadata_entry.abstract.description || ''
       @neuro_data = false
-      bank = %w[neuro cogniti cereb]
+      bank = %w[neuro cogniti cereb memory consciousness amnesia]
       regex = bank.join('|')
       keywords = @metadata_entry.subjects.map(&:subject).join(', ')
       if !!title.match?(/#{regex}/i) || !!publication_name.match?(/#{regex}/i) || !!keywords.match?(/#{regex}/i) || !!abstract.match?(/#{regex}/i)


### PR DESCRIPTION
Followup to #1493 -- it was surprising that the CEDAR template didn't appear when editing [Zefan's dataset](https://doi.org/10.5061/dryad.b2rbnzsh9), so these are keywords that would have triggered it.