### PR TITLE
Fix typo that could prevent submissions from processing

### DIFF
--- a/lib/stash/repo/submission_job.rb
+++ b/lib/stash/repo/submission_job.rb
@@ -31,7 +31,7 @@ module Stash
         elsif previously_submitted
           # Do not send to the repo again if it has already been sent. If we need to re-send we'll have to delete the statuses
           # and re-submit manually.  This should be an exceptional case that we send the same resource more than once.
-          latest_queue = StashEngine::RepoQueueState.latest(resource_id: @resource__id)
+          latest_queue = StashEngine::RepoQueueState.latest(resource_id: @resource_id)
           latest_queue.destroy if latest_queue.present? && (latest_queue.state == 'enqueued')
         else
           Stash::Repo::Repository.update_repo_queue_state(resource_id: @resource_id, state: 'processing')


### PR DESCRIPTION
We never noticed that this typo was causing exceptions, because there is an exception handler in the method that treats the exception as an external error.