### PR TITLE
Fix lookup for S3 path of copied files

### DIFF
--- a/app/models/stash_engine/data_file.rb
+++ b/app/models/stash_engine/data_file.rb
@@ -118,15 +118,15 @@ module StashEngine
 
     # permanent storage rather than staging path
     def s3_permanent_path
-      # First, look for the file in the v3 hierarchy
-      s3 = Stash::Aws::S3.new(s3_bucket_name: APP_CONFIG[:s3][:merritt_bucket])
-      permanent_key = "v3/#{s3_staged_path}"
-      return permanent_key if s3.exists?(s3_key: permanent_key)
-
-      # If it's not in the v3 hierarchy, check in the Merritt/ark hierarchy
       f = original_deposit_file # this is the deposit in the series where this file was last re-uploaded fully by dryad
       return nil if f.nil?
 
+      # First, look for the file in the v3 hierarchy
+      s3 = Stash::Aws::S3.new(s3_bucket_name: APP_CONFIG[:s3][:merritt_bucket])
+      permanent_key = "v3/#{f.s3_staged_path}"
+      return permanent_key if s3.exists?(s3_key: permanent_key)
+
+      # If it's not in the v3 hierarchy, check in the Merritt/ark hierarchy
       f2 = DataFile.find_merritt_deposit_file(file: f) # find where Merritt has decided to store the file, may be an earlier creation
 
       return DataFile.mrt_bucket_path(file: f2) unless f2.nil?


### PR DESCRIPTION
For files stored in the new S3 storage, when they are "copied" to a new version, we need to ensure the lookup uses the original version in which the file was created, and not the current version.

Closes https://github.com/CDL-Dryad/dryad-product-roadmap/issues/3174
Closes https://github.com/CDL-Dryad/dryad-product-roadmap/issues/3161