### PR TITLE
Increase efficiency for URL uploads and checksums

### DIFF
--- a/lib/stash/aws/s3.rb
+++ b/lib/stash/aws/s3.rb
@@ -75,6 +75,12 @@ module Stash
         s3_bucket.objects(prefix: "#{s3_key}/").batch_delete!
       end
 
+      def object(s3_key:)
+        return unless s3_key
+
+        s3_bucket.object(s3_key)
+      end
+
       def objects(starts_with:)
         return unless starts_with
 

--- a/lib/stash/checksums.rb
+++ b/lib/stash/checksums.rb
@@ -1,6 +1,6 @@
 require 'digest'
 require 'logger'
-require 'open-uri'
+require 'down'
 
 module Stash
   class Checksums
@@ -88,8 +88,14 @@ module Stash
     private
 
     def process_url(url)
-      URI.parse(url).open do |f|
-        process_stream(f)
+      Down.open(url).each_chunk do |chunk|
+        @input_size += chunk.length
+        @digest_list.each { |digest| digest.algorithm.update(chunk) }
+      end
+
+      @digest_list.each do |digest|
+        finish_digest(digest)
+        digest.input_size = @input_size
       end
     end
 

--- a/lib/stash/repo/submission_job.rb
+++ b/lib/stash/repo/submission_job.rb
@@ -118,7 +118,7 @@ module Stash
 
           update[:digest_type] = digest_type
           update[:digest] = sums.get_checksum(digest_type)
-          updated[:validated_at] = Time.now.utc
+          update[:validated_at] = Time.now.utc
         end
         data_file.update(update)
       end
@@ -150,7 +150,7 @@ module Stash
 
           update[:digest_type] = digest_type
           update[:digest] = algorithm.hexdigest
-          updated[:validated_at] = Time.now.utc
+          update[:validated_at] = Time.now.utc
         end
 
         data_file.update(update)

--- a/lib/stash/repo/submission_job.rb
+++ b/lib/stash/repo/submission_job.rb
@@ -118,6 +118,7 @@ module Stash
 
           update[:digest_type] = digest_type
           update[:digest] = sums.get_checksum(digest_type)
+          updated[:validated_at] = Time.now.utc
         end
         data_file.update(update)
       end
@@ -149,6 +150,7 @@ module Stash
 
           update[:digest_type] = digest_type
           update[:digest] = algorithm.hexdigest
+          updated[:validated_at] = Time.now.utc
         end
 
         data_file.update(update)

--- a/lib/stash/repo/submission_job.rb
+++ b/lib/stash/repo/submission_job.rb
@@ -139,7 +139,7 @@ module Stash
         algorithm = sums.get_algorithm(digest_type).new
 
         logger.info("    #{data_file.url} ==> #{permanent_bucket}/#{permanent_key}")
-        s3_perm.object(s3_key: permanent_key).upload_stream do |write_stream|
+        s3_perm.object(s3_key: permanent_key).upload_stream(part_size: CHUNK_SIZE) do |write_stream|
           write_stream.binmode
           read_stream = Down.open(data_file.url, rewindable: false)
           chunk = read_stream.read(CHUNK_SIZE)


### PR DESCRIPTION
Closes https://github.com/CDL-Dryad/dryad-product-roadmap/issues/3212

I got the down gem to work to process URLs for checksums, and then to load files via external URL to S3, without overloading memory or using disk space. I then restructured the implementation so that the S3 copy and S3 URL upload files are handled more separately, and the checksum generation and upload to S3 are handled in a single stream of the URL uploads.