### PR TITLE
fix: the rake task fails if the associated identifier could not be found

### DIFF
--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -149,7 +149,7 @@ namespace :identifiers do
 
       ident = res.identifier
       s3_dir = res.s3_dir_name(type: 'base')
-      puts "ident #{ident.id} Res #{res.id} -- updated_at #{res.updated_at}"
+      puts "ident #{ident&.id || 'MISSING'} Res #{res.id} -- updated_at #{res.updated_at}"
       puts "   DESTROY s3 #{s3_dir}"
       Stash::Aws::S3.new.delete_dir(s3_key: s3_dir) unless dry_run
       puts "   DESTROY resource #{res.id}"

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -143,7 +143,7 @@ namespace :identifiers do
     end
 
     # Remove resources that have been "in progress" for more than a year without updates
-    StashEngine::Resource.in_progress.each do |res|
+    StashEngine::Resource.in_progress.where('updated_at < ?', 1.year.ago).each do |res|
       next unless res.updated_at < 1.year.ago
       next unless res.current_curation_status == 'in_progress'
 


### PR DESCRIPTION
Based on my investigation on a dump of the prod db, it looks like the the reason the dataset mentioned in the associated ticket was not processed is because the rake task exits before it gets to it.

The task exits when trying to process the dataset (`Resource`) with ID: `159211`
- this dataset has an associated `identifier_id` with the value of `82980`
- however, this identifier does not exist in the db, so when trying to call `Resource#identifier#id` we get a `NoMethodError` and the process exits
