### PR TITLE
fix: correct automatic peer review settings

### DIFF
--- a/app/controllers/stash_datacite/publications_controller.rb
+++ b/app/controllers/stash_datacite/publications_controller.rb
@@ -77,9 +77,10 @@ module StashDatacite
         @msid = manage_internal_datum(identifier: @se_id, data_type: 'manuscriptNumber', value: parsed_msid)
       end
 
-      if @resource.identifier.allow_review? && @resource.previous_curated_resource.blank? && @resource.curation_start_date.blank?
-        # if the newly-set journal wants PPR by default, set the PPR value for this resource
-        @resource.update(hold_for_peer_review: @se_id.journal&.default_to_ppr)
+      if @resource.identifier.allow_review? && @resource.previous_curated_resource.blank? &&
+        @resource.curation_start_date.blank? && @se_id.journal&.default_to_ppr?
+        # if the newly-set journal wants PPR by default, and it is allowed, set the PPR value for this resource
+        @resource.update(hold_for_peer_review: @se_id.journal.default_to_ppr)
       end
 
       save_doi

--- a/app/controllers/stash_datacite/resources_controller.rb
+++ b/app/controllers/stash_datacite/resources_controller.rb
@@ -29,6 +29,10 @@ module StashDatacite
           check_required_fields(@resource)
           @review = Resource::Review.new(@resource)
           @resource.has_geolocation = @review.geolocation_data?
+          unless @resource.identifier.allow_review? && @resource.previous_curated_resource.blank? && @resource.curation_start_date.blank?
+            @resource.hold_for_peer_review = false
+            @resource.peer_review_end_date = nil
+          end
           @resource.save!
         end
       end

--- a/app/views/stash_datacite/peer_review/_review.html.erb
+++ b/app/views/stash_datacite/peer_review/_review.html.erb
@@ -1,4 +1,4 @@
-<% if @resource.identifier.allow_review? && @resource.previous_curated_resource.nil? && @resource.curation_start_date.nil? %>
+<% if @resource.identifier.allow_review? && @resource.previous_curated_resource.blank? && @resource.curation_start_date.blank? %>
   <!-- This is only available if the id has not been curated AND
      the associated journal allows a review workflow -->
   <div>


### PR DESCRIPTION
Closes https://github.com/CDL-Dryad/dryad-product-roadmap/issues/3005
Closes https://github.com/CDL-Dryad/dryad-product-roadmap/issues/3015
Closes https://github.com/CDL-Dryad/dryad-product-roadmap/issues/2899

When the review page is accessed, if the submitter is unable to set PPR (because a previous version of the submission has already been curated, published, etc.) the system will also save that false PPR setting in the database, so it will no longer go into PPR unexpectedly.