### PR TITLE
fix: ensure a 400 Bad Request is returned if dataset parsing fails

### DIFF
--- a/app/models/stash_api/dataset_parser.rb
+++ b/app/models/stash_api/dataset_parser.rb
@@ -70,7 +70,7 @@ module StashApi
         begin
           StashEngine::User.find(@hash['userId']).id
         rescue ActiveRecord::RecordNotFound
-          raise 'The userId is not known to Dryad. Please supply the id of an existing Dryad user, or an orcid matching an author of the dataset.'
+          raise ActionController::BadRequest, 'The userId is not known to Dryad. Please supply the id of an existing Dryad user, or an orcid matching an author of the dataset.'
         end
       else
         # otherwise, give ownership to the API user
@@ -88,7 +88,7 @@ module StashApi
         @hash['authors'].each do |a|
           found_author = a if a['orcid']&.match(@hash['userId'])
         end
-        raise 'The userId orcid is not known to Dryad. Please supply a matching orcid in the dataset author list.' unless found_author
+        raise ActionController::BadRequest, 'The userId orcid is not known to Dryad. Please supply a matching orcid in the dataset author list.' unless found_author
 
         owning_user = StashEngine::User.create(orcid: @hash['userId'],
                                                first_name: found_author['firstName'],

--- a/app/models/stash_api/dataset_parser.rb
+++ b/app/models/stash_api/dataset_parser.rb
@@ -70,7 +70,8 @@ module StashApi
         begin
           StashEngine::User.find(@hash['userId']).id
         rescue ActiveRecord::RecordNotFound
-          raise ActionController::BadRequest, 'The userId is not known to Dryad. Please supply the id of an existing Dryad user, or an orcid matching an author of the dataset.'
+          raise ActionController::BadRequest,
+                'The userId is not known to Dryad. Please supply the id of an existing Dryad user, or an orcid matching an author of the dataset.'
         end
       else
         # otherwise, give ownership to the API user
@@ -88,7 +89,10 @@ module StashApi
         @hash['authors'].each do |a|
           found_author = a if a['orcid']&.match(@hash['userId'])
         end
-        raise ActionController::BadRequest, 'The userId orcid is not known to Dryad. Please supply a matching orcid in the dataset author list.' unless found_author
+        unless found_author
+          raise ActionController::BadRequest,
+                'The userId orcid is not known to Dryad. Please supply a matching orcid in the dataset author list.'
+        end
 
         owning_user = StashEngine::User.create(orcid: @hash['userId'],
                                                first_name: found_author['firstName'],

--- a/spec/models/stash_api/dataset_parser_spec.rb
+++ b/spec/models/stash_api/dataset_parser_spec.rb
@@ -330,7 +330,7 @@ module StashApi
         }.with_indifferent_access
 
         dp = DatasetParser.new(hash: test_metadata, id: nil, user: @user)
-        expect { dp.parse }.to raise_error(RuntimeError)
+        expect { dp.parse }.to raise_error(ActionController::BadRequest, 'The userId orcid is not known to Dryad. Please supply a matching orcid in the dataset author list.')
       end
 
     end

--- a/spec/models/stash_api/dataset_parser_spec.rb
+++ b/spec/models/stash_api/dataset_parser_spec.rb
@@ -330,7 +330,10 @@ module StashApi
         }.with_indifferent_access
 
         dp = DatasetParser.new(hash: test_metadata, id: nil, user: @user)
-        expect { dp.parse }.to raise_error(ActionController::BadRequest, 'The userId orcid is not known to Dryad. Please supply a matching orcid in the dataset author list.')
+        expect do
+          dp.parse
+        end.to raise_error(ActionController::BadRequest,
+                           'The userId orcid is not known to Dryad. Please supply a matching orcid in the dataset author list.')
       end
 
     end


### PR DESCRIPTION
- since the [original PR](https://github.com/CDL-Dryad/dryad-app/pull/1544) would change all API error responses, until we go through all of them and update the API docs accordingly, this should fix the issue without changing the response envelope.