### PR TITLE
fix: downgrade Puma, because the new version doesn't work with our current setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'ed25519', '1.3.0'
 gem 'rdoc', '~> 6.1.1' # for some reason needs to be installed for capistrano to work right
 gem 'rubocop', '~> 1.38', require: false
 # Use Puma as the app server
-gem 'puma', '6.1.0', group: :puma, require: false  # puma 6.3.0 doesn't start
+gem 'puma', '6.1.0', group: :puma, require: false # puma 6.3.0 doesn't start
 
 # ############################################################
 # UI

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'ed25519', '1.3.0'
 gem 'rdoc', '~> 6.1.1' # for some reason needs to be installed for capistrano to work right
 gem 'rubocop', '~> 1.38', require: false
 # Use Puma as the app server
-gem 'puma', '6.3.1', group: :puma, require: false
+gem 'puma', '6.1.0', group: :puma, require: false  # puma 6.3.0 doesn't start
 
 # ############################################################
 # UI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -506,7 +506,7 @@ GEM
       pry (~> 0.9)
       slop (~> 3.0)
     public_suffix (5.0.3)
-    puma (6.3.1)
+    puma (6.1.0)
       nio4r (~> 2.0)
     pundit (2.3.1)
       activesupport (>= 3.0.0)
@@ -844,7 +844,7 @@ DEPENDENCIES
   pry
   pry-rails
   pry-remote
-  puma (= 6.3.1)
+  puma (= 6.1.0)
   pundit (~> 2.3)
   rack-attack
   rails (~> 6.1.0)


### PR DESCRIPTION

This reverts #1556, because Puma 6.3.1 doesn't start any better than 6.3.0 did.
