### PR TITLE
fix: update paths used by cron scripts

### DIFF
--- a/cron/daily.sh
+++ b/cron/daily.sh
@@ -2,21 +2,19 @@
 
 : ${1:?"Need to pass in environment (e.g. development, stage, production)"}
 
-PATH=$PATH:/apps/dryad/local/bin
+cd /home/ec2-user/deploy/current/
 
-cd /apps/dryad/apps/ui/current/
-
-bundle exec rails identifiers:publish_datasets RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/publish_datasets.log 2>&1
-bundle exec rails identifiers:peer_review_reminder RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/peer_review_reminder.log 2>&1
-bundle exec rails identifiers:doi_linking_invitation RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/doi_linking_invitation.log 2>&1
-bundle exec rails identifiers:in_progess_reminder RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/in_progess_reminder.log 2>&1
-bundle exec rails identifiers:update_missing_search_words RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/update_search_words.log 2>&1
-# bundle exec rails identifiers:action_required_reminder RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/action_required_reminders.log 2>&1
-bundle exec rails dev_ops:retry_zenodo_errors RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/retry_zenodo_errors.log 2>&1
-bundle exec rails curation_stats:update_recent RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/curation_stats.log 2>&1
-bundle exec rails journal_email:clean_old_manuscripts RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/manuscripts_clean.log 2>&1
-bundle exec rails compressed:update_contents RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/compressed_contents.log 2>&1
-bundle exec rails identifiers:datasets_without_primary_articles_report  RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/datasets_without_primary_articles_report.log 2>&1
+bundle exec rails identifiers:publish_datasets RAILS_ENV=$1 >> /home/ec2-user/deploy/shared/log/publish_datasets.log 2>&1
+bundle exec rails identifiers:peer_review_reminder RAILS_ENV=$1 >> /home/ec2-user/deploy/shared/log/peer_review_reminder.log 2>&1
+bundle exec rails identifiers:doi_linking_invitation RAILS_ENV=$1 >> /home/ec2-user/deploy/shared/log/doi_linking_invitation.log 2>&1
+bundle exec rails identifiers:in_progess_reminder RAILS_ENV=$1 >> /home/ec2-user/deploy/shared/log/in_progess_reminder.log 2>&1
+bundle exec rails identifiers:update_missing_search_words RAILS_ENV=$1 >> /home/ec2-user/deploy/shared/log/update_search_words.log 2>&1
+# bundle exec rails identifiers:action_required_reminder RAILS_ENV=$1 >> /home/ec2-user/deploy/shared/log/action_required_reminders.log 2>&1
+bundle exec rails dev_ops:retry_zenodo_errors RAILS_ENV=$1 >> /home/ec2-user/deploy/shared/log/retry_zenodo_errors.log 2>&1
+bundle exec rails curation_stats:update_recent RAILS_ENV=$1 >> /home/ec2-user/deploy/shared/log/curation_stats.log 2>&1
+bundle exec rails journal_email:clean_old_manuscripts RAILS_ENV=$1 >> /home/ec2-user/deploy/shared/log/manuscripts_clean.log 2>&1
+bundle exec rails compressed:update_contents RAILS_ENV=$1 >> /home/ec2-user/deploy/shared/log/compressed_contents.log 2>&1
+bundle exec rails identifiers:datasets_without_primary_articles_report  RAILS_ENV=$1 >> /home/ec2-user/deploy/shared/log/datasets_without_primary_articles_report.log 2>&1
 
 # Download & validate file digests
-bundle exec rails checksums:validate_files >> /apps/dryad/apps/ui/shared/cron/logs/validate_files.log 2>&1
+bundle exec rails checksums:validate_files >> /home/ec2-user/deploy/shared/log/validate_files.log 2>&1

--- a/cron/every_30.sh
+++ b/cron/every_30.sh
@@ -2,9 +2,7 @@
 
 : ${1:?"Need to pass in environment (e.g. development, stage, production)"}
 
-PATH=$PATH:/apps/dryad/local/bin
-
-cd /apps/dryad/apps/ui/current/
+cd /home/ec2-user/deploy/current/
 
 # Opting not to record output in logs since it would display the command in clear text
 nice -n 19 ionice -c 3 bundle exec rails dev_ops:backup RAILS_ENV=$1

--- a/cron/every_5.sh
+++ b/cron/every_5.sh
@@ -2,9 +2,7 @@
 
 : ${1:?"Need to pass in environment (e.g. development, stage, production)"}
 
-PATH=$PATH:/apps/dryad/local/bin
+cd /home/ec2-user/deploy/current/
 
-cd /apps/dryad/apps/ui/current/
-
-bundle exec rails status_dashboard:check RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/status_dashboard_check.log 2>&1
-bundle exec rails journal_email:process RAILS_ENV=$1 >> /apps/dryad/apps/ui/shared/cron/logs/journal_email.log 2>&1
+bundle exec rails status_dashboard:check RAILS_ENV=$1 >> /home/ec2-user/deploy/shared/log/status_dashboard_check.log 2>&1
+bundle exec rails journal_email:process RAILS_ENV=$1 >> /home/ec2-user/deploy/shared/log/journal_email.log 2>&1

--- a/cron/every_hour.sh
+++ b/cron/every_hour.sh
@@ -2,9 +2,7 @@
 
 : ${1:?"Need to pass in environment (e.g. development, stage, production)"}
 
-PATH=$PATH:/apps/dryad/local/bin
-
-cd /apps/dryad/apps/ui/current/
+cd /home/ec2-user/deploy/current/
 
 # Opting not to record output in logs since it would display the command in clear text
 nice -n 19 ionice -c 3 bundle exec rails dev_ops:backup RAILS_ENV=$1

--- a/cron/monthly.sh
+++ b/cron/monthly.sh
@@ -4,27 +4,25 @@
 
 export RAILS_ENV="$1"
 
-PATH=$PATH:/apps/dryad/local/bin
+cd /home/ec2-user/deploy/current/
 
-cd /apps/dryad/apps/ui/current/
-
-export REPORT_DIR="/apps/dryad/apps/ui/shared/cron/counter-json"
+export REPORT_DIR="/home/ec2-user/deploy/shared/cron/counter-json"
 
 # force counter submissions for last month (and will submit other missing months)
 # export FORCE_SUBMISSION="`date --date="$(date +%Y-%m-15) - 1 month" "+%Y-%m"`"
 
 # run the script with the above settings (RAILS_ENV, REPORT_DIR, FORCE_SUBMISSION)
 # this script is no longer used since we don't routinely update and force reports based on logs/json files
-# bundle exec rails counter:datacite_pusher >> /apps/dryad/apps/ui/shared/cron/logs/counter-uploader.log 2>&1
+# bundle exec rails counter:datacite_pusher >> /home/ec2-user/deploy/shared/log/counter-uploader.log 2>&1
 
 # Clean outdated content from the database and temporary S3 store
-bundle exec rails identifiers:remove_old_versions >> /apps/dryad/apps/ui/shared/cron/logs/remove_old_versions.log 2>&1
+bundle exec rails identifiers:remove_old_versions >> /home/ec2-user/deploy/shared/log/remove_old_versions.log 2>&1
 
 # Update Genbank IDs and PubMedIDs related to Dryad datasets,
 # then send them to LinkOut (NCBI) and LabsLink (Europe PMC)
-bundle exec rails link_out:seed_pmids >> /apps/dryad/apps/ui/shared/cron/logs/link_out_seed_pmids.log 2>&1
-bundle exec rails link_out:seed_genbank_ids >> /apps/dryad/apps/ui/shared/cron/logs/link_out_seed_pmids.log 2>&1
-bundle exec rails link_out:publish >> /apps/dryad/apps/ui/shared/cron/logs/link_out_publish.log 2>&1
+bundle exec rails link_out:seed_pmids >> /home/ec2-user/deploy/shared/log/link_out_seed_pmids.log 2>&1
+bundle exec rails link_out:seed_genbank_ids >> /home/ec2-user/deploy/shared/log/link_out_seed_pmids.log 2>&1
+bundle exec rails link_out:publish >> /home/ec2-user/deploy/shared/log/link_out_publish.log 2>&1
 
 # Update ROR organizations
-bundle exec rails affiliation_import:update_ror_orgs >>/apps/dryad/apps/ui/shared/cron/logs/ror_update.log 2>&1
+bundle exec rails affiliation_import:update_ror_orgs >>/home/ec2-user/deploy/shared/log/ror_update.log 2>&1

--- a/cron/weekly.sh
+++ b/cron/weekly.sh
@@ -4,25 +4,23 @@
 
 export RAILS_ENV="$1"
 
-PATH=$PATH:/apps/dryad/local/bin
-
-cd /apps/dryad/apps/ui/current/
+cd /home/ec2-user/deploy/current/
 
 # clear out cache older than 3 weeks old, remove empty directories in cache
-find /apps/dryad/apps/ui/shared/tmp/cache -mtime +21 -type f -exec rm {} \;
-find /apps/dryad/apps/ui/shared/tmp/cache -empty -type d -delete
+find /home/ec2-user/deploy/shared/tmp/cache -mtime +21 -type f -exec rm {} \;
+find /home/ec2-user/deploy/shared/tmp/cache -empty -type d -delete
 
-bundle exec rails publication_updater:crossref >> /apps/dryad/apps/ui/shared/cron/logs/publication_updater_crossref.log 2>&1
+bundle exec rails publication_updater:crossref >> /home/ec2-user/deploy/shared/log/publication_updater_crossref.log 2>&1
 
-bundle exec rails identifiers:voided_invoices_report >>/apps/dryad/apps/ui/shared/cron/logs/voided_invoices_report.log 2>&1
+bundle exec rails identifiers:voided_invoices_report >> /home/ec2-user/deploy/shared/log/voided_invoices_report.log 2>&1
 
 # putting this in background since I don't want to delay the counter processor starting
-bundle exec rails counter:populate_citations >> /apps/dryad/apps/ui/shared/cron/logs/citation_populator.log 2>&1 &!
+bundle exec rails counter:populate_citations >> /home/ec2-user/deploy/shared/log/citation_populator.log 2>&1 &!
 
 # the MDC/counter processor only runs in the production && stage environments
 if [ "$RAILS_ENV" == "production" ] || [ "$RAILS_ENV" == "stage" ]
 then
     # the counter.sh script used to do more log procesing, but now only does a couple of things
-    cd /apps/dryad/apps/ui/current/cron
-    ./counter.sh >> /apps/dryad/apps/ui/shared/cron/logs/counter.log 2>&1
+    cd /home/ec2-user/deploy/current/cron
+    ./counter.sh >> /home/ec2-user/deploy/shared/log/counter.log 2>&1
 fi


### PR DESCRIPTION
- reflects the current directory structure
- removed PATH=$PATH:/apps/dryad/local/bin -- seems to no longer be used
- using `shared/log` as the log path
- requiring a new `shared/cron` dir