### PR TITLE
fix: treat v3_production and v3_stage as privileged environments

### DIFF
--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -836,7 +836,7 @@ module StashEngine
     # development environments on either different servers or against different databases (local or not local)
     def s3_dir_name(type: 'data')
       raise 'Error, incorrect upload type' if ALLOWED_UPLOAD_TYPES[type].nil?
-      return "#{id}#{ALLOWED_UPLOAD_TYPES[type]}" if %w[production stage].include?(Rails.env)
+      return "#{id}#{ALLOWED_UPLOAD_TYPES[type]}" if Rails.env.include?('production') || Rails.env.include?('stage')
 
       db_host = Rails.configuration.database_configuration[Rails.env]['host']
       if db_host.include?('localhost') || db_host.include?('127.0.0.1')


### PR DESCRIPTION
Curators complained about being unable to download some files. The cause was a difference in Dryad's representation of the Resource's  root directory for file storage.

When files are stored in S3, the directory name includes a hash for non-privileged environments. The hash allows multiple machines to use the same S3 bucket without creating the same directory names.

In our privileged environments, the hash is omitted for easier tracking. This PR allows 'v3_production' and 'v3_stage' to be treated as priviledged environments, so they operate in the same manner as the old 'production' and 'stage'.