### PR TITLE
feat: throttle downloads

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -194,9 +194,10 @@ defaults: &DEFAULTS
     size_limit: 10_000_000
     missing_values: ",NA,na,N/A,n/a,N.A.,n.a.,-,.,empty,blank"
   rate_limit:
-    # number of requests allowed per minute
+    file_downloads_per_hour: 100
+    zip_downloads_per_hour: 20
+    # all other rates are number of requests allowed per minute
     all_requests: 120
-    zip_downloads: 10
     api_requests_anon: 30
     api_requests_auth: 120
     api_requests_v1: 30

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -58,7 +58,7 @@ end
 
 # File download throttling
 # We don't want a user to simply download everything in Dryad. That costs us too much in bandwidth charges!
-Rack::Attack.throttle('file_downloads', limit:  APP_CONFIG[:rate_limit][:file_downloads_per_hour], period: 1.hour) do |req|
+Rack::Attack.throttle('file_downloads', limit: APP_CONFIG[:rate_limit][:file_downloads_per_hour], period: 1.hour) do |req|
   "file_download_#{req.ip}" if req.path.start_with?('/stash/downloads/file_stream') ||
                                req.path.match(/api.*files.*download/)
 end

--- a/dryad-config-example/app_config.yml
+++ b/dryad-config-example/app_config.yml
@@ -168,8 +168,9 @@ defaults: &DEFAULTS
     # number of requests allowed per minute
     # these rates are low to facilitate quick testing of the rate limiter,
     # but the rate limiter is disabled for most rspec classes
+    file_downloads_per_hour: 2
+    zip_downloads_per_hour: 2
     all_requests: 10
-    zip_downloads: 2
     api_requests_anon: 5
     api_requests_auth: 10
     api_requests_v1: 5

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Disallow: /search
+Disallow: /stash/downloads
 Crawl-delay: 5
 Sitemap: https://datadryad.org/sitemap.xml

--- a/script/server-utils/heavy_downloaders.sh
+++ b/script/server-utils/heavy_downloaders.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Lists the IP addresses that have downloaded the most in the most recent log file, and their frequency
+
+echo "=== Heavy downloads of individual files ==="
+grep "downloads/file" /var/log/httpd/datadryad.org-access_log | awk '{ print $1 } ' | sort | uniq -c |sort -r | head
+
+echo "=== Heavy downloads of ZIP files ==="
+grep "downloads/zip" /var/log/httpd/datadryad.org-access_log | awk '{ print $1 } ' | sort | uniq -c |sort -r | head
+

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Rack::Attack', type: :request do
     it 'throttles download of zip files' do
       target_url = '/stash/downloads/download_resource/BOGUS'
       freeze_time do
-        APP_CONFIG[:rate_limit][:zip_downloads].times do
+        APP_CONFIG[:rate_limit][:zip_downloads_per_hour].times do
           get target_url, headers: headers
           expect(response).to have_http_status(:not_found)
         end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'Rack::Attack', type: :request do
         expect(response).to have_http_status(:too_many_requests)
       end
 
-      travel_to(2.minutes.from_now) do
+      travel_to(2.hours.from_now) do
         get target_url, headers: headers
         expect(response).to have_http_status(:not_found)
       end


### PR DESCRIPTION
Bots were downloading far too much content -- terabytes of files in a day.

This adds a new RackAttack setting to throttle the number of files an individual IP can download in an hour, and changes the ZIP throttle from per-minute to per-hour, with a lower overall limit.

There is also a new script that identifies the heaviest users of our download access points.