### PR TITLE
chore: increase size of production logs

### DIFF
--- a/config/environments/v3_production.rb
+++ b/config/environments/v3_production.rb
@@ -90,7 +90,7 @@ Rails.application.configure do
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
   else
-    logger = ActiveSupport::Logger.new(Rails.root.join("log", "v3_production.log"), 5, 10.megabytes)
+    logger = ActiveSupport::Logger.new(Rails.root.join("log", "v3_production.log"), 5, 100.megabytes)
   end
 
   config.logger    = ActiveSupport::TaggedLogging.new(logger)


### PR DESCRIPTION
Allow the production logs to be larger, so we retain a couple days of history.