### PR TITLE
chore: remove duplicate backup statement

### DIFF
--- a/cron/every_30.sh
+++ b/cron/every_30.sh
@@ -4,5 +4,4 @@
 
 cd /home/ec2-user/deploy/current/
 
-# Opting not to record output in logs since it would display the command in clear text
-nice -n 19 ionice -c 3 bundle exec rails dev_ops:backup RAILS_ENV=$1
+


### PR DESCRIPTION
The every_30 file does not need to perform database backups, since they are performed by every_hour. (I think we had removed the every_30 from crontab at some point, but we forgot to remove this duplicate statement.)